### PR TITLE
Implement multi-keybox support for per-app identities

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,22 +40,38 @@ This file provides the master cryptographic identity for the simulator. It conta
 </AndroidAttestation>
 ```
 
-### Mode Configuration (`target.txt`)
+### Mode and Keybox Configuration (`target.txt`)
 
-TEESimulator currently operates in two primary modes as it transitions towards full emulation. You can control this behavior on a per-package basis.
+TEESimulator currently operates in two primary modes as it transitions towards full emulation.
+You can control the simulation mode and the specific keybox.xml file used on a per-package basis.
+
+#### Mode Suffixes
 
 *   **`!` → Force Generation Mode:** Creates a complete, software-based virtual key. This is the foundation of the full TEE simulation.
 *   **`?` → Force Leaf Hacking Mode:** A legacy mode where a real TEE key is generated, but its attestation certificate is intercepted and modified.
 *   **No symbol → Automatic Mode:** The module selects the most appropriate mode for the device.
 
+#### Multi-Keybox Configuration
+
+You can specify different keybox files for different groups of applications. This is done by adding a line with the filename in square brackets (e.g., [demo_keybox.xml]).
+
+All applications listed after this line will use the specified keybox file, until a new keybox is declared. Applications listed before any custom keybox declaration will use the default `keybox.xml`.
+
 For example:
 ```
-# target.txt
-# Use full generation/simulation for this app
+# These two apps will use the default /data/adb/tricky_store/keybox.xml
 com.google.android.gms!
-
-# Use the legacy leaf hacking mode
 io.github.vvb2060.keyattestation?
+
+# Switch to a different keybox for the following apps.
+# The file must be located at /data/adb/tricky_store/aosp_keybox.xml
+[aosp_keybox.xml]
+com.google.android.gsf
+
+# Switch again to another keybox.
+# The file must be located at /data/adb/tricky_store/demo_keybox.xml
+[demo_keybox.xml]
+org.matrix.demo
 ```
 
 ### Security Patch Level (`security_patch.txt`)

--- a/app/src/main/java/io/github/beakthoven/TrickyStoreOSS/CertificateGen.kt
+++ b/app/src/main/java/io/github/beakthoven/TrickyStoreOSS/CertificateGen.kt
@@ -176,7 +176,7 @@ object CertificateGen {
     }
     
     fun generateChain(uid: Int, params: KeyGenParameters, keyPair: KeyPair, securityLevel: Int = 1): List<ByteArray>? = runCatching {
-        val keybox = getKeyboxForAlgorithm(params.algorithm) ?: return null
+        val keybox = getKeyboxForAlgorithm(uid, params.algorithm) ?: return null
 
         val issuer = X509CertificateHolder(keybox.certificates[0].encoded).subject
         val leaf = buildCertificate(keyPair, keybox, params, issuer, uid, securityLevel)
@@ -234,7 +234,7 @@ object CertificateGen {
         }
         
         val keyPair = generateKeyPair(params) ?: return null
-        val keybox = getKeyboxForAlgorithm(params.algorithm) ?: return null
+        val keybox = getKeyboxForAlgorithm(uid, params.algorithm) ?: return null
         
         val (signingKeyPair, issuer) = if (hasAttestKey) {
             getAttestationKeyInfo(uid, attestKeyDescriptor!!)?.let { 
@@ -267,9 +267,10 @@ object CertificateGen {
         }
     }
 
-    private fun getKeyboxForAlgorithm(algorithm: Int): KeyBox? {
+    private fun getKeyboxForAlgorithm(uid: Int, algorithm: Int): KeyBox? {
         val algorithmName = mapAlgorithmToName(algorithm) ?: return null
-        return KeyBoxUtils.keyboxes[algorithmName]
+        val keyboxFileName = PkgConfig.getKeyboxFileForUid(uid)
+        return KeyBoxUtils.getKeybox(keyboxFileName, algorithmName)
     }
 
     private fun getAttestationKeyInfo(uid: Int, attestKeyDescriptor: KeyDescriptor): Pair<KeyPair, X500Name>? {

--- a/app/src/main/java/io/github/beakthoven/TrickyStoreOSS/interceptors/Keystore2Interceptor.kt
+++ b/app/src/main/java/io/github/beakthoven/TrickyStoreOSS/interceptors/Keystore2Interceptor.kt
@@ -150,7 +150,7 @@ object Keystore2Interceptor : BaseKeystoreInterceptor() {
                 if (response != null) {
                     val chain = CertificateUtils.run { response.getCertificateChain() }
                 if (chain != null) {
-                        val newChain = CertificateHack.hackCertificateChain(chain)
+                        val newChain = CertificateHack.hackCertificateChain(chain, callingUid)
                         response.putCertificateChain(newChain).getOrThrow()
                         Logger.i("Hacked certificate for uid=$callingUid")
                         return createTypedObjectReply(response)


### PR DESCRIPTION

This commit introduces a significant enhancement to the configuration system, allowing users to specify different `keybox.xml` files for different groups of applications. This enables the use of distinct cryptographic identities (e.g., from different device models) for targeted apps, increasing flexibility and resilience.

### User-Facing Changes (`target.txt`)

The `target.txt` file now supports a new syntax. A line containing a filename in square brackets, such as `[my_other_keybox.xml]`, sets the active keybox for all subsequent package names in the file.

Example:
```
# Apps in this section use the default keybox.xml
com.google.android.gms!

# Switch to a different keybox for the following app
[aosp_keybox.xml]
com.google.android.gsf
```

### Architectural Refactoring

To support this feature, the configuration and keybox handling logic has been refactored:

1.  **`PkgConfig`:**
    *   The `target.txt` parser is now stateful, tracking the `currentKeyboxFile` as it iterates through the configuration.
    *   A new map, `packageKeyboxes`, is introduced to store the association between a package and its designated keybox file.
    *   A new public function, `getKeyboxFileForUid(uid)`, provides a centralized way to resolve which keybox file to use for a given application UID.

2.  **`KeyBoxUtils`:**
    *   The utility has been transformed from a static, global state manager into a dynamic loader and cacher.
    *   A new cache, `loadedKeyboxFiles`, stores the parsed contents of multiple keybox files, indexed by filename.
    *   The new primary API, `getKeybox(fileName, algorithm)`, loads and parses keybox files on demand, caching the results to avoid redundant I/O.

3.  **`CertificateGen` & `CertificateHack`:**
    *   All key generation and certificate hacking functions have been updated to accept a `uid` parameter.
    *   They now use `PkgConfig.getKeyboxFileForUid(uid)` and `KeyBoxUtils.getKeybox(...)` to dynamically fetch the correct cryptographic identity for each operation, replacing the previous reliance on a single global keybox.