### PR TITLE
Add TrickyStoreOSS Attribution - GPLv3 Compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,3 +88,14 @@ vendor=20251101 # Report a specific vendor patch level
 
 ## 🤝 Contributions
 PRs are welcome as we work towards the goal of a complete TEE simulation. Thank you for supporting true open-source development.
+
+## ❤️ Acknowledgement
+
+- [TrickyStoreOSS](https://github.com/beakthoven/TrickyStoreOSS)
+- [BootloaderSpoofer](https://github.com/chiteroman/BootloaderSpoofer)
+- [FrameworkPatch](https://github.com/chiteroman/FrameworkPatch)
+- [KeyAttestation](https://github.com/vvb2060/KeyAttestation)
+- [KeystoreInjection](https://github.com/aviraxp/Zygisk-KeystoreInjection)
+- [LSPlt-JingMatrix](https://github.com/JingMatrix/LSPlt)
+- [LSPosed](https://github.com/LSPosed/LSPosed)
+- [PlayIntegrityFork](https://github.com/osm0sis/PlayIntegrityFork)


### PR DESCRIPTION
Hi there!

I see you're working on a fork of [TrickyStoreOSS](https://github.com/beakthoven/TrickyStoreOSS) and looking to expand it into a new project. The per-package spoofing is an interesting feature.

It's important in the open source software community that we clearly attribute and document the history of everyone's code, and I notice there isn't a proper attribution for TrickyStoreOSS.

You have mentioned the foundation of the project [here](https://github.com/JingMatrix/TEESimulator/releases/tag/v1.0) and [here](https://github.com/JingMatrix/TEESimulator/blob/27af8309d3b6b828476b13ba5d0ca0ae22bbd7c9/module/changelog.md) but this isn't enough to comply with the [GNU GPLv3 license](https://spdx.org/licenses/GPL-3.0-or-later.html) that TrickyStoreOSS is released under. In particular, sections (5)(a) to (c) require that if making changes to copied software, the changes and attributions need to be *prominent*.

In your first commit renaming the project, you [removed the attribution list](https://github.com/JingMatrix/TEESimulator/commit/5526627e1c0a270c15c4d633e637cb8ea502d6b5#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L118-L126) and this needs to be put back with TrickyStoreOSS in addition in order to comply with GPLv3.

Best of luck with with project!