### PR TITLE
Always load all key boxes in keybox.xml

### DIFF
--- a/app/src/main/java/io/github/beakthoven/TrickyStoreOSS/XmlParser.kt
+++ b/app/src/main/java/io/github/beakthoven/TrickyStoreOSS/XmlParser.kt
@@ -196,21 +196,21 @@ object KeyBoxUtils {
             val xmlData = filePath.readText()
             val xmlParser = XmlParser(xmlData.sanitizeXml())
 
-            val numberOfKeyboxesResult = xmlParser.obtainPath("AndroidAttestation.NumberOfKeyboxes")
-            val numberOfKeyboxes =
-                when (numberOfKeyboxesResult) {
-                    is XmlParser.ParseResult.Success ->
-                        numberOfKeyboxesResult.attributes["text"]?.toIntOrNull() ?: 1
-                    is XmlParser.ParseResult.Error ->
-                        throw Exception(
-                            numberOfKeyboxesResult.message,
-                            numberOfKeyboxesResult.cause,
-                        )
+            var keyIndex = 0
+            while (true) {
+                try {
+                    val (algorithmName, keyBox) = processKeybox(xmlParser, keyIndex)
+                    keyboxes[algorithmName] = keyBox
+                    Logger.i("Successfully processed keybox index $keyIndex with algorithm $algorithmName")
+                    keyIndex++
+                } catch (e: Exception) {
+                    if (e.message?.contains("Path not found") == true) {
+                        Logger.i("Finished processing all keyboxes. Found $keyIndex keys.")
+                    } else {
+                        Logger.e("Error processing keybox at index ${keyIndex-1}", e)
+                    }
+                    break
                 }
-
-            repeat(numberOfKeyboxes) { i ->
-                val (algorithmName, keyBox) = processKeybox(xmlParser, i)
-                keyboxes[algorithmName] = keyBox
             }
 
             Logger.i("Successfully loaded ${keyboxes.size} keyboxes from $fileName")


### PR DESCRIPTION
改进keybox.xml的解析以加载所有可用密钥，旧的keybox.xml解析逻辑依赖`<NumberOfKeyboxes>`标签来决定循环次数。如果标签值不对（比如写了1,但实际有2个key），就会漏掉一些key,比如ecdsa密钥
当应用（比如说Revolut）请求这些被漏掉的密钥时，程序会因为找不到keybox
`java.lang.SecurityException: Caused by: java.lang.SecurityException: Certificate is not available`而崩溃    

The following is from Google Translate: Improved keybox.xml parsing to load all available keys. The old keybox.xml parsing logic relied on the `<NumberOfKeyboxes>` tag to determine the number of loops. If the tag value was incorrect (e.g., 1 was written, but there are actually 2 keys), some keys would be missed, such as ECDSA keys. When an application (such as Revolut) requests these missed keys, the program will crash because it cannot find the keybox: `java.lang.SecurityException: Caused by: java.lang.SecurityException: Certificate is not available`.