### PR TITLE
Fix keybox.xml hot reload by invalidating cache on file change

### DIFF
--- a/app/src/main/java/io/github/beakthoven/TrickyStoreOSS/XmlParser.kt
+++ b/app/src/main/java/io/github/beakthoven/TrickyStoreOSS/XmlParser.kt
@@ -224,6 +224,11 @@ object KeyBoxUtils {
     fun hasKeyboxes(): Boolean =
         loadedKeyboxFiles.isNotEmpty() && loadedKeyboxFiles.values.any { it.isNotEmpty() }
 
+    fun clearCache(fileName: String) {
+        loadedKeyboxFiles.remove(fileName)
+        Logger.i("Cleared cache for keybox file: $fileName")
+    }
+
     // This function is now deprecated and should be removed. We keep it for now to show the
     // transition.
     // Its logic is now inside readFromFile.

--- a/app/src/main/java/io/github/beakthoven/TrickyStoreOSS/config/Config.kt
+++ b/app/src/main/java/io/github/beakthoven/TrickyStoreOSS/config/Config.kt
@@ -166,6 +166,7 @@ object PkgConfig {
                     // a reload where needed.
                     // The main logic for loading is now handled dynamically in KeyBoxUtils.
                     Logger.i("Keybox file $path changed. It will be re-read on next use.")
+                    KeyBoxUtils.clearCache(path)
                 }
                 path == PATCHLEVEL_FILE -> updatePatchLevel(f)
             }


### PR DESCRIPTION
When we replace keybox.xml, the file on the disk changes, but the app process still has the old file content in its memory cache. The getOrPut function sees the file is already in loadedKeyboxFiles and returns the old cached version instead of reading the new file. 

This ensures that replacing `keybox.xml` takes effect immediately on the next usage.