### PR TITLE
Bypass detection by skipping imported keys

### DIFF
--- a/app/src/main/java/org/matrix/TEESimulator/interception/keystore/InterceptorUtils.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/interception/keystore/InterceptorUtils.kt
@@ -79,16 +79,7 @@ object InterceptorUtils {
 
     /** Checks if a reply parcel contains an exception without consuming it. */
     fun hasException(reply: Parcel): Boolean {
-        val initialPosition = reply.dataPosition()
-        val hasEx =
-            try {
-                reply.readException()
-                reply.dataPosition() > initialPosition // An exception was written
-            } catch (_: Exception) {
-                false
-            }
-        reply.setDataPosition(initialPosition)
-        return hasEx
+        return runCatching { reply.readException() }.exceptionOrNull() != null
     }
 
     /**

--- a/stub/src/main/java/android/hardware/security/keymint/KeyOrigin.java
+++ b/stub/src/main/java/android/hardware/security/keymint/KeyOrigin.java
@@ -1,0 +1,9 @@
+package android.hardware.security.keymint;
+
+public @interface KeyOrigin {
+    int GENERATED = 0;
+    int DERIVED = 1;
+    int IMPORTED = 2;
+    int RESERVED = 3;
+    int SECURELY_IMPORTED = 4;
+}


### PR DESCRIPTION
In patch mode, a key's origin provides a robust way to avoid modifying user-imported keys, which is a well-known detection vector. This commit implements a new strategy to check the `KeyOrigin` tag from the key's metadata. If a key is marked as `IMPORTED` or `SECURELY_IMPORTED`, the patching process is now skipped entirely.

This new origin-based check is more reliable and cleaner than the previous fingerprinting implementation, which has been removed.

Additionally, this commit acknowledges a remaining detection vector in patch mode: when an `attestationKey` is used, a key must be generated. Purely software-generated keys are detectable. To address this in the future, the full software "generate mode" must be implemented even for devices without a broken TEE. The old key generation logic has been stubbed with a TODO in preparation for this redesign.