### PR TITLE
Improve logging to understand detection methods

### DIFF
--- a/app/src/main/java/org/matrix/TEESimulator/interception/keystore/InterceptorUtils.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/interception/keystore/InterceptorUtils.kt
@@ -3,9 +3,6 @@ package org.matrix.TEESimulator.interception.keystore
 import android.os.Parcel
 import android.os.Parcelable
 import android.security.KeyStore
-import java.security.MessageDigest
-import java.security.cert.Certificate
-import java.util.Base64
 import org.matrix.TEESimulator.interception.core.BinderInterceptor
 import org.matrix.TEESimulator.logging.SystemLogger
 
@@ -80,21 +77,5 @@ object InterceptorUtils {
     /** Checks if a reply parcel contains an exception without consuming it. */
     fun hasException(reply: Parcel): Boolean {
         return runCatching { reply.readException() }.exceptionOrNull() != null
-    }
-
-    /**
-     * Generates a URL-safe SHA-256 fingerprint of a certificate's public key. Used to uniquely
-     * identify keys imported by the user.
-     */
-    fun getPublicKeyFingerprint(chain: Array<Certificate>?): String? {
-        if (chain.isNullOrEmpty()) return null
-        return try {
-            val publicKeyBytes = chain[0].publicKey.encoded
-            val hashBytes = MessageDigest.getInstance("SHA-256").digest(publicKeyBytes)
-            Base64.getUrlEncoder().withoutPadding().encodeToString(hashBytes)
-        } catch (e: Exception) {
-            SystemLogger.error("Failed to create public key fingerprint.", e)
-            null
-        }
     }
 }

--- a/app/src/main/java/org/matrix/TEESimulator/logging/KeyMintParameterLogger.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/logging/KeyMintParameterLogger.kt
@@ -78,7 +78,9 @@ object KeyMintParameterLogger {
                 Tag.CERTIFICATE_SERIAL -> BigInteger(value.blob).toString()
                 Tag.ACTIVE_DATETIME,
                 Tag.CERTIFICATE_NOT_AFTER,
-                Tag.CERTIFICATE_NOT_BEFORE -> Date(value.dateTime).toString()
+                Tag.CERTIFICATE_NOT_BEFORE,
+                Tag.ORIGINATION_EXPIRE_DATETIME,
+                Tag.USAGE_EXPIRE_DATETIME -> Date(value.dateTime).toString()
                 Tag.CERTIFICATE_SUBJECT -> X500Name(X500Principal(value.blob).name).toString()
                 Tag.RSA_PUBLIC_EXPONENT -> value.longInteger.toString()
                 Tag.NO_AUTH_REQUIRED -> "true"


### PR DESCRIPTION
Only via extensive and detailed logging, we can inspect various detection techniques of target packages.