### PR TITLE
Support key generation with attestation keys

### DIFF
--- a/app/src/main/java/org/matrix/TEESimulator/config/ConfigurationManager.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/config/ConfigurationManager.kt
@@ -81,6 +81,9 @@ object ConfigurationManager {
     /** Determines if a new certificate needs to be generated for a given UID. */
     fun shouldGenerate(uid: Int): Boolean = getPackageModeForUid(uid) == Mode.GENERATE
 
+    /** Determines if no operation is needed for a given UID. */
+    fun shouldSkipUid(uid: Int): Boolean = getPackageModeForUid(uid) == null
+
     /** Resolves the operating mode for a given UID based on its packages and the TEE status. */
     private fun getPackageModeForUid(uid: Int): Mode? {
         val packages = getPackagesForUid(uid)

--- a/app/src/main/java/org/matrix/TEESimulator/logging/KeyMintParameterLogger.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/logging/KeyMintParameterLogger.kt
@@ -97,7 +97,7 @@ object KeyMintParameterLogger {
                 else -> "<raw>"
             } ?: "Unknown Value"
 
-        SystemLogger.debug("Key Parameter -> %-25s | Value: %s".format(tagName, formattedValue))
+        SystemLogger.debug("KeyParam: %-25s | Value: %s".format(tagName, formattedValue))
     }
 
     private fun ByteArray.toReadableString(): String {


### PR DESCRIPTION
This commit enhances the interception logic to correctly handle key generation requests that specify an `attestationKey` (via [setAttestKeyAlias](https://developer.android.com/reference/android/security/keystore/KeyGenParameterSpec.Builder#setAttestKeyAlias(java.lang.String))).

When an attestation key is used, the system signs the newly generated key with it. A simple leaf certificate patch after the fact is insufficient, as it breaks this cryptographic chain. To create a valid, verifiable chain, we must now intercept these `generateKey` operations and perform a full software-based key and certificate generation, even when in patch mode.

This ensures that keys attested by other simulated keys are correctly signed and chained together, bypassing more sophisticated detection methods.

Fixes:
- Correctly use the `android.hardware.security.keymint.Tag` constants for building authorization lists, resolving a bug where internal ASN.1 sequence indices were being used improperly.