### PR TITLE
Set boot digest via resetprop

### DIFF
--- a/app/src/main/java/org/matrix/TEESimulator/util/AndroidDeviceUtils.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/util/AndroidDeviceUtils.kt
@@ -70,7 +70,7 @@ object AndroidDeviceUtils {
     }
 
     /**
-     * Sets the `ro.boot.vbmeta.digest` system property.
+     * Sets the `ro.boot.vbmeta.digest` system property using the `resetprop` command.
      *
      * @param bytes The 32-byte digest to set.
      */
@@ -78,9 +78,24 @@ object AndroidDeviceUtils {
         val hex = bytes.toHex()
         try {
             SystemLogger.debug("Setting system property 'ro.boot.vbmeta.digest' to: $hex")
-            SystemProperties.set("ro.boot.vbmeta.digest", hex)
+
+            // Construct the command to be executed
+            val command = arrayOf("resetprop", "ro.boot.vbmeta.digest", hex)
+
+            // Execute the command
+            val process = Runtime.getRuntime().exec(command)
+
+            // Wait for the process to complete and check the exit code for errors
+            val exitCode = process.waitFor()
+
+            if (exitCode != 0) {
+                val errorOutput = process.errorStream.bufferedReader().readText()
+                SystemLogger.error(
+                    "resetprop command failed with exit code $exitCode: $errorOutput"
+                )
+            }
         } catch (e: Exception) {
-            SystemLogger.error("Failed to set vbmeta digest property.", e)
+            SystemLogger.error("Failed to set vbmeta digest property by executing resetprop.", e)
         }
     }
 

--- a/stub/src/main/java/android/os/SystemProperties.java
+++ b/stub/src/main/java/android/os/SystemProperties.java
@@ -4,8 +4,4 @@ public class SystemProperties {
     public static String get(String key, String def) {
         throw new UnsupportedOperationException("STUB!");
     }
-
-    public static String set(String key, String val) {
-        throw new UnsupportedOperationException("STUB!");
-    }
 }


### PR DESCRIPTION
The stub method `SystemProperties.set` has wrong signature and is unable to set read-only system properties.
Close #20  as fixed.