### PR TITLE
Fix date format of vendor patch level

### DIFF
--- a/app/src/main/java/org/matrix/TEESimulator/attestation/AttestationBuilder.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/attestation/AttestationBuilder.kt
@@ -81,7 +81,7 @@ object AttestationBuilder {
             DERTaggedObject(
                 true,
                 AttestationConstants.TAG_VENDOR_PATCHLEVEL,
-                ASN1Integer(AndroidDeviceUtils.vendorPatchLevel.toLong()),
+                ASN1Integer(AndroidDeviceUtils.vendorPatchLevelLong.toLong()),
             )
         )
         vector.add(
@@ -165,7 +165,7 @@ object AttestationBuilder {
                 DERTaggedObject(
                     true,
                     AttestationConstants.TAG_VENDOR_PATCHLEVEL,
-                    ASN1Integer(AndroidDeviceUtils.vendorPatchLevel.toLong()),
+                    ASN1Integer(AndroidDeviceUtils.vendorPatchLevelLong.toLong()),
                 ),
                 DERTaggedObject(
                     true,

--- a/app/src/main/java/org/matrix/TEESimulator/util/AndroidDeviceUtils.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/util/AndroidDeviceUtils.kt
@@ -110,10 +110,10 @@ object AndroidDeviceUtils {
             getCustomPatchLevelFor("system", isLong = false)
                 ?: Build.VERSION.SECURITY_PATCH.toPatchLevelInt(isLong = false)
 
-    val vendorPatchLevel: Int
+    val vendorPatchLevelLong: Int
         get() =
-            getCustomPatchLevelFor("vendor", isLong = false)
-                ?: Build.VERSION.SECURITY_PATCH.toPatchLevelInt(isLong = false)
+            getCustomPatchLevelFor("vendor", isLong = true)
+                ?: Build.VERSION.SECURITY_PATCH.toPatchLevelInt(isLong = true)
 
     val bootPatchLevelLong: Int
         get() =


### PR DESCRIPTION
This was a mistake during the refactoring of TrickyStoreOSS.
After correcting it, we can obtain STRONG integrity (instead of DEVICE) with a valid keybox.

The correct format can be easily found using the `Key Attestation` app.