### PR TITLE
Intercept DELETE_KEY to prevent KEY_NOT_FOUND from crash

### DIFF
--- a/app/src/main/java/org/matrix/TEESimulator/interception/keystore/InterceptorUtils.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/interception/keystore/InterceptorUtils.kt
@@ -42,11 +42,15 @@ object InterceptorUtils {
     }
 
     /** Creates an `OverrideReply` parcel that indicates success with no data. */
-    fun createSuccessReply(): BinderInterceptor.TransactionResult.OverrideReply {
+    fun createSuccessReply(
+        writeResultCode: Boolean = true
+    ): BinderInterceptor.TransactionResult.OverrideReply {
         val parcel =
             Parcel.obtain().apply {
                 writeNoException()
-                writeInt(KeyStore.NO_ERROR)
+                if (writeResultCode) {
+                    writeInt(KeyStore.NO_ERROR)
+                }
             }
         return BinderInterceptor.TransactionResult.OverrideReply(0, parcel)
     }

--- a/app/src/main/java/org/matrix/TEESimulator/interception/keystore/Keystore2Interceptor.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/interception/keystore/Keystore2Interceptor.kt
@@ -104,7 +104,13 @@ object Keystore2Interceptor : AbstractKeystoreInterceptor() {
             val keyId = KeyIdentifier(callingUid, descriptor.alias)
 
             if (code == DELETE_KEY_TRANSACTION) {
-                KeyMintSecurityLevelInterceptor.cleanupKeyData(keyId)
+                if (KeyMintSecurityLevelInterceptor.getGeneratedKeyResponse(keyId) != null) {
+                    KeyMintSecurityLevelInterceptor.cleanupKeyData(keyId)
+                    SystemLogger.info(
+                        "[TX_ID: $txId] Deleted cached keypair ${descriptor.alias}, replying with empty response."
+                    )
+                    return InterceptorUtils.createSuccessReply(writeResultCode = false)
+                }
                 return TransactionResult.ContinueAndSkipPost
             }
 


### PR DESCRIPTION
Software Key Deletion Process: Intercepted in Keystore2Interceptor. DELETE_KEY_TRANSACTION, if using a software-simulated key, only clears the cache and returns success directly, without calling the hardware keystore again, to avoid crashing KEY_NOT_FOUND.

软件密钥删除流程
在 Keystore2Interceptor 拦截 DELETE_KEY_TRANSACTION，如果是软件模拟密钥，只清理缓存并直接返回成功，不再调用硬件Keystore，避免KEY_NOT_FOUND崩溃