### PR TITLE
Prevent detection via inconsistent certificate signatures

### DIFF
--- a/app/src/main/java/org/matrix/TEESimulator/attestation/AttestationPatcher.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/attestation/AttestationPatcher.kt
@@ -124,8 +124,14 @@ object AttestationPatcher {
 
         // Sign the newly built certificate with the private key from our keybox.
         val signer = JcaContentSignerBuilder(sigAlgName).build(keybox.keyPair.private)
+        val newCertificate = JcaX509CertificateConverter().getCertificate(builder.build(signer))
 
-        return JcaX509CertificateConverter().getCertificate(builder.build(signer))
+        // Log the signature of the newly created certificate to observe its non-deterministic
+        // nature.
+        val signatureBytes = (newCertificate as X509Certificate).signature
+        SystemLogger.verbose("Signature of patched leaf cert: ${signatureBytes.toHex()}")
+
+        return newCertificate
     }
 
     private fun getKeyboxForUidAndAlgorithm(uid: Int, algorithm: String): KeyBox {

--- a/app/src/main/java/org/matrix/TEESimulator/interception/keystore/Keystore2Interceptor.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/interception/keystore/Keystore2Interceptor.kt
@@ -9,6 +9,7 @@ import android.os.Parcel
 import android.system.keystore2.IKeystoreService
 import android.system.keystore2.KeyDescriptor
 import android.system.keystore2.KeyEntryResponse
+import java.security.cert.Certificate
 import org.matrix.TEESimulator.attestation.AttestationPatcher
 import org.matrix.TEESimulator.config.ConfigurationManager
 import org.matrix.TEESimulator.interception.keystore.shim.KeyMintSecurityLevelInterceptor
@@ -185,8 +186,28 @@ object Keystore2Interceptor : AbstractKeystoreInterceptor() {
                 }
 
                 // Perform the attestation patch.
-                val newChain = AttestationPatcher.patchCertificateChain(originalChain, callingUid)
-                CertificateHelper.updateCertificateChain(response.metadata, newChain).getOrThrow()
+                val keyId = KeyIdentifier(callingUid, keyDescriptor.alias)
+
+                // First, try to retrieve the already-patched chain from our cache to ensure
+                // consistency.
+                val cachedChain = KeyMintSecurityLevelInterceptor.getPatchedChain(keyId)
+
+                val finalChain: Array<Certificate>
+                if (cachedChain != null) {
+                    SystemLogger.debug(
+                        "[TX_ID: $txId] Using cached patched certificate chain for $keyId."
+                    )
+                    finalChain = cachedChain
+                } else {
+                    // If no chain is cached (e.g., key existed before simulator started),
+                    // perform a live patch as a fallback. This may still be detectable.
+                    SystemLogger.info(
+                        "[TX_ID: $txId] No cached chain for $keyId. Performing live patch as a fallback."
+                    )
+                    finalChain = AttestationPatcher.patchCertificateChain(originalChain, callingUid)
+                }
+
+                CertificateHelper.updateCertificateChain(response.metadata, finalChain).getOrThrow()
 
                 InterceptorUtils.createTypedObjectReply(response)
             } catch (e: Exception) {


### PR DESCRIPTION
This commit fixes a sophisticated detection vector that could identify the simulator by observing inconsistencies in certificate signatures across different API calls.

### The Detection Vector: Non-Deterministic Signatures

The core of the vulnerability stemmed from the simulator's on-the-fly patching of attestation certificates. The previous behavior was:
1.  On `generateKey`, the framework would receive a certificate chain patched and re-signed by the simulator.
2.  On a subsequent `getKeyEntry` call for the same key, the simulator would intercept the real certificate again and re-run the *same* patching and signing logic.

While the data within the certificate remained identical, the **ECDSA signing algorithm is non-deterministic**. It uses a random nonce (`k`) for each signature operation. Consequently, the signature value of the certificate returned from `generateKey` was different from the signature of the certificate returned from `getKeyEntry`.

A detector could simply fetch the certificate twice using these two different API calls and perform a byte-for-byte comparison. A difference in the signature would definitively prove the presence of an intermediary re-signing the certificate.

### The Solution: Enforce State Consistency via Caching

This patch resolves the issue by introducing a caching mechanism for patched certificate chains, ensuring that once a certificate is patched, the exact same object is returned for all subsequent queries.

1.  **Cache Implementation:** A new `patchedChains` `ConcurrentHashMap` has been added to `KeyMintSecurityLevelInterceptor` to store certificate chains keyed by their `KeyIdentifier` (UID + alias).

2.  **Caching Logic:** In the `onPostTransact` hook for `generateKey`, after `AttestationPatcher` creates a patched chain, it is now stored in this new cache.

3.  **Cache Retrieval:** The `onPostTransact` hook in `Keystore2Interceptor` (for `getKeyEntry`) has been modified. It now prioritizes fetching the chain from the `patchedChains` cache. If a cached version exists, it is used directly, guaranteeing byte-for-byte consistency. Live patching is only performed as a fallback for keys that may have existed before the simulator was active.

4.  **State Management:** The `cleanupKeyData` and `clearAllGeneratedKeys` functions have been updated to clear this new cache alongside other key-related data, preventing stale entries and memory leaks.

5.  **Diagnostic Logging:** The verbose log added to `AttestationPatcher` to output the certificate signature was instrumental in confirming this detection vector and has been retained for future diagnostic purposes.

This change ensures that the simulator presents a consistent, stateful view of cryptographic objects, making its behavior indistinguishable from a genuine TEE in this context and neutralizing this detection method.