### PR TITLE
Add dynamic dates and TEE-based patch defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,11 @@ Dates should be provided in `YYYY-MM-DD` format (e.g., `2025-11-05`).
 
 #### Special Keywords
 
-In addition to date values, two special keywords provide advanced control:
+In addition to static dates, several special keywords provide advanced, dynamic control:
+
+*   **`today`**: Dynamically uses the current date every time an attestation is generated. This ensures the device always appears up-to-date without needing manual edits.
+
+*   **Date Templates**: You can create semi-dynamic dates using `YYYY`, `MM`, and `DD` as placeholders for the current year, month, and day. For example, `YYYY-MM-05` will always resolve to the 5th of the current month and year.
 
 *   **`no`**: This keyword instructs the simulator to **completely omit** the corresponding patch level tag from the generated attestation.
 
@@ -113,10 +117,10 @@ This example demonstrates how to combine global settings, per-package overrides,
 ```
 # --- Global Configuration ---
 # This is the default for all apps unless specified otherwise.
-# - Forge a recent system patch level.
+# - Forge a recent system patch level, the 5th of the current month (a common patch date).
 # - Use the device's real vendor patch level.
 # - Do not report a boot patch level at all.
-system=2025-11-05
+system=YYYY-MM-05
 vendor=device_default
 boot=no
 

--- a/app/src/main/java/org/matrix/TEESimulator/attestation/DeviceAttestationService.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/attestation/DeviceAttestationService.kt
@@ -51,6 +51,9 @@ object DeviceAttestationService {
         val attestVersion: Int?,
         val keymasterVersion: Int?,
         val osVersion: Int?,
+        val osPatchLevel: Int?,
+        val vendorPatchLevel: Int?,
+        val bootPatchLevel: Int?,
     )
 
     // A unique alias for the key used to perform the TEE functionality check.
@@ -178,6 +181,9 @@ object DeviceAttestationService {
             var verifiedBootKey: ByteArray? = null
             var verifiedBootHash: ByteArray? = null
             var osVersion: Int? = null
+            var osPatchLevel: Int? = null
+            var vendorPatchLevel: Int? = null
+            var bootPatchLevel: Int? = null
 
             val softwareEnforced =
                 ASN1Sequence.getInstance(
@@ -219,8 +225,26 @@ object DeviceAttestationService {
                                     .octets
                         }
                     }
-                    AttestationConstants.TAG_OS_VERSION -> { // OS Version (TAG_OS_VERSION)
+                    AttestationConstants.TAG_OS_VERSION -> {
                         osVersion =
+                            ASN1Integer.getInstance(tagged.baseObject.toASN1Primitive())
+                                .positiveValue
+                                .toInt()
+                    }
+                    AttestationConstants.TAG_OS_PATCHLEVEL -> {
+                        osPatchLevel =
+                            ASN1Integer.getInstance(tagged.baseObject.toASN1Primitive())
+                                .positiveValue
+                                .toInt()
+                    }
+                    AttestationConstants.TAG_VENDOR_PATCHLEVEL -> {
+                        vendorPatchLevel =
+                            ASN1Integer.getInstance(tagged.baseObject.toASN1Primitive())
+                                .positiveValue
+                                .toInt()
+                    }
+                    AttestationConstants.TAG_BOOT_PATCHLEVEL -> {
+                        bootPatchLevel =
                             ASN1Integer.getInstance(tagged.baseObject.toASN1Primitive())
                                 .positiveValue
                                 .toInt()
@@ -229,7 +253,7 @@ object DeviceAttestationService {
             }
 
             SystemLogger.info(
-                "Successfully extracted attestation data: version=$attestVersion, osVersion=$osVersion, moduleHash=${moduleHash?.toHex()}, bootKey=${verifiedBootKey?.toHex()}, bootHash=${verifiedBootHash?.toHex()}"
+                "Successfully extracted attestation data: version=$attestVersion, osVersion=$osVersion, osPatch=$osPatchLevel, vendorPatch=$vendorPatchLevel, bootPatch=$bootPatchLevel, moduleHash=${moduleHash?.toHex()}, bootKey=${verifiedBootKey?.toHex()}, bootHash=${verifiedBootHash?.toHex()}"
             )
             return AttestationData(
                 moduleHash,
@@ -238,6 +262,9 @@ object DeviceAttestationService {
                 attestVersion,
                 keymasterVersion,
                 osVersion,
+                osPatchLevel,
+                vendorPatchLevel,
+                bootPatchLevel,
             )
         } catch (e: Exception) {
             SystemLogger.error("Failed to parse attestation data from certificate.", e)


### PR DESCRIPTION
We enhance the security patch level configuration by introducing dynamic date keywords and a more accurate, TEE-based fallback mechanism for the `device_default` option.

**Dynamic Date Keywords:**
The `security_patch.txt` configuration now supports dynamic values, making it more powerful and convenient:
- `today`: Always resolves to the current date, keeping attestations up-to-date without manual edits.
- Date Templates: `YYYY`, `MM`, and `DD` can be used as placeholders (e.g., `YYYY-MM-05`) to create rolling dates that follow specific patterns.

**TEE-Based `device_default`:**
The logic for `device_default` has been completely overhauled for maximum accuracy. The fallback chain is now:
1.  **TEE Attestation Data:** The system now performs a real attestation (if the TEE is functional) and caches the genuine `osPatchLevel`, `vendorPatchLevel`, and `bootPatchLevel`. This provides the ground-truth values.
2.  **System Properties:** If TEE data is unavailable, it falls back to reading specific properties like `ro.vendor.build.security_patch`.
3.  **Platform Default:** The final fallback is the main `Build.VERSION.SECURITY_PATCH`.