### PR TITLE
Handle invalid verified boot key

### DIFF
--- a/app/src/main/java/org/matrix/TEESimulator/attestation/DeviceAttestationService.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/attestation/DeviceAttestationService.kt
@@ -43,6 +43,9 @@ object DeviceAttestationService {
      * @property attestVersion The attestation version (e.g., 400 for KeyMint 4.0).
      * @property keymasterVersion The Keymaster or KeyMint HAL version.
      * @property osVersion The Android OS version integer.
+     * @property osPatchLevel The Android security patch level (e.g., 202511).
+     * @property vendorPatchLevel The vendor-specific security patch level.
+     * @property bootPatchLevel The bootloader's security patch level.
      */
     data class AttestationData(
         val moduleHash: ByteArray?,
@@ -250,6 +253,10 @@ object DeviceAttestationService {
                                 .toInt()
                     }
                 }
+            }
+
+            if (verifiedBootKey?.all { it == 0.toByte() } == true) {
+                verifiedBootKey = null
             }
 
             SystemLogger.info(


### PR DESCRIPTION
Treat the `verifiedBootKey` as null if it consists entirely of zero bytes, as some devices return this invalid value.

Additionally, this commit adds missing KDoc comments to the `AttestationData` class for better documentation.
Close #54 as fixed.