### PR TITLE
Ensure mocked replies use native OK status

### DIFF
--- a/app/src/main/java/org/matrix/TEESimulator/interception/core/BinderInterceptor.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/interception/core/BinderInterceptor.kt
@@ -41,7 +41,7 @@ abstract class BinderInterceptor : Binder() {
          * Skips the original call and immediately returns a custom reply parcel to the caller. The
          * provided parcel will be recycled after use.
          */
-        data class OverrideReply(val code: Int = 0, val reply: Parcel) : TransactionResult()
+        data class OverrideReply(val reply: Parcel, val code: Int = 0) : TransactionResult()
 
         /**
          * Modifies the transaction's input data before forwarding it to the original binder method.

--- a/app/src/main/java/org/matrix/TEESimulator/interception/keystore/InterceptorUtils.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/interception/keystore/InterceptorUtils.kt
@@ -52,7 +52,7 @@ object InterceptorUtils {
                     writeInt(KeyStore.NO_ERROR)
                 }
             }
-        return BinderInterceptor.TransactionResult.OverrideReply(0, parcel)
+        return BinderInterceptor.TransactionResult.OverrideReply(parcel)
     }
 
     /** Creates an `OverrideReply` parcel containing a raw byte array. */
@@ -62,7 +62,7 @@ object InterceptorUtils {
                 writeNoException()
                 writeByteArray(data)
             }
-        return BinderInterceptor.TransactionResult.OverrideReply(KeyStore.NO_ERROR, parcel)
+        return BinderInterceptor.TransactionResult.OverrideReply(parcel)
     }
 
     /** Creates an `OverrideReply` parcel containing a Parcelable object. */
@@ -75,7 +75,7 @@ object InterceptorUtils {
                 writeNoException()
                 writeTypedObject(obj, flags)
             }
-        return BinderInterceptor.TransactionResult.OverrideReply(0, parcel)
+        return BinderInterceptor.TransactionResult.OverrideReply(parcel)
     }
 
     /**

--- a/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/KeyMintSecurityLevelInterceptor.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/KeyMintSecurityLevelInterceptor.kt
@@ -168,12 +168,7 @@ class KeyMintSecurityLevelInterceptor(
                     if (isAttestKeyRequest) attestationKeys.add(keyId)
 
                     // Return the metadata of our generated key, skipping the real hardware call.
-                    val resultParcel =
-                        Parcel.obtain().apply {
-                            writeNoException()
-                            writeTypedObject(response.metadata, 0)
-                        }
-                    return TransactionResult.OverrideReply(0, resultParcel)
+                    return InterceptorUtils.createTypedObjectReply(response.metadata)
                 } else if (parsedParams.attestationChallenge != null) {
                     return TransactionResult.Continue
                 }


### PR DESCRIPTION
The native C++ binder layer expects a `status_t` return code from `transact` calls, where `0` (`OK`) signifies a successful transaction at the system level.

Previously, some helper functions in `InterceptorUtils` were incorrectly setting this native status code to application-level success codes, such as `KeyStore.NO_ERROR` (which has a value of 1).

A native `status_t` of `1` is interpreted as `UNKNOWN_ERROR` by libbinder, causing the client application to see a generic transaction failure even when the interception was intended to succeed.

This commit corrects this by separating the two concepts:

1.  **Native `status_t`:** The `code` parameter for a successful  `TransactionResult.OverrideReply` must always be `0`.
2.  **Application-level Result Code:** Application-specific codes  (like `KeyStore.NO_ERROR`) must be written *inside* the reply  `Parcel` itself, where the client application's code expects to read them.

The helper functions in `InterceptorUtils` have been updated to always use the correct native status code for successful replies, ensuring that mocked transactions are correctly reported as successful to the Binder framework.