### PR TITLE
Add SELinux rules for libTEESimulator.so loading

### DIFF
--- a/module/sepolicy.rule
+++ b/module/sepolicy.rule
@@ -1,2 +1,2 @@
-allow keystore {adb_data_file, shell_data_file} file *
+allow keystore {adb_data_file shell_data_file} file *
 allow crash_dump keystore process *


### PR DESCRIPTION
Allow `keystore` to access the `file` class for `adb_data_file` and `shell_data_file` contexts.

The target contexts correspond to the following locations:
- `adb_data_file`: The library path `/data/adb/modules/tricky_store/libTEESimulator.so`, used for FD transfer.
- `shell_data_file`: The fallback mechanism for loading the library by staging it in `/data/local/tmp`.

Note: The rule for the `dir` class (directory search) has been removed because the supporting audit logs were lost. The remaining file access logs were observed on a MEIZU 21 Note.