### PR TITLE
fix(native): block attestation leak when interceptor is dead

### DIFF
--- a/app/src/main/cpp/binder_interceptor.cpp
+++ b/app/src/main/cpp/binder_interceptor.cpp
@@ -587,9 +587,16 @@ bool BinderInterceptor::processInterceptedTransaction(uint64_t tx_id, sp<BBinder
     Parcel pre_req, pre_resp;
     writeTransactionData(pre_req, tx_id, target, code, flags, request);
 
-    if (callback->transact(intercept::kPreTransact, pre_req, &pre_resp) != OK) {
-        LOGW("[TX_ID: %" PRIu64 "] Pre-transaction callback failed. Forwarding original call.", tx_id);
-        return false; // Callback failed, proceed as if not intercepted
+    status_t pre_status = callback->transact(intercept::kPreTransact, pre_req, &pre_resp);
+    if (pre_status != OK) {
+        // Block when interceptor is dead to prevent privacy leak to third-party apps
+        if (callback->pingBinder() != OK) {
+            LOGE("[TX_ID: %" PRIu64 "] Interceptor DEAD. Blocking to prevent attestation leak.", tx_id);
+            result = DEAD_OBJECT;
+            return true;
+        }
+        LOGW("[TX_ID: %" PRIu64 "] Pre-transaction callback failed (not dead). Forwarding.", tx_id);
+        return false;
     }
 
     int32_t action = pre_resp.readInt32();
@@ -642,7 +649,8 @@ bool BinderInterceptor::processInterceptedTransaction(uint64_t tx_id, sp<BBinder
         VALIDATE_STATUS(tx_id, post_req.appendFrom(reply, 0, reply_size));
     }
 
-    if (callback->transact(intercept::kPostTransact, post_req, &post_resp) == OK) {
+    status_t post_status = callback->transact(intercept::kPostTransact, post_req, &post_resp);
+    if (post_status == OK) {
         int32_t post_action = post_resp.readInt32();
         if (post_action == intercept::kActionOverrideReply && reply) {
             result = post_resp.readInt32(); // Read new status


### PR DESCRIPTION
When the Java interceptor process dies, `callback->transact()` returns `DEAD_OBJECT` but execution falls through to the real keystore, exposing genuine TEE attestation state to requesting apps.

This is a security-critical path — any app polling attestation during the window between interceptor death and restart receives authentic device state.

## Fix

Added `pingBinder()` liveness check before forwarding. If the interceptor is confirmed dead, return `DEAD_OBJECT` to the caller instead of forwarding to real hardware. Apps see a transient service error rather than actual device attestation.

---

**Scope:** 1 file, 12 insertions, 4 deletions