### PR TITLE
fix(module): keep restart loop alive regardless of daemon exit code

### DIFF
--- a/module/service.sh
+++ b/module/service.sh
@@ -5,7 +5,7 @@ MODDIR=${0%/*}
 cd $MODDIR
 
 while true; do
-  ./daemon "$MODDIR" || exit 1
+  ./daemon "$MODDIR"
   # ensure keystore initialized
   sleep 2
 done &


### PR DESCRIPTION
`exec` replaces the shell with `app_process`. When the process is killed, it returns non-zero, which triggers the `|| exit 1` clause and permanently kills the restart loop.

The daemon never comes back until the next reboot.

## Fix

Removed `|| exit 1` so the `while true` loop always restarts the daemon after the configured delay.

---

**Scope:** 1 file, 1 line changed