### PR TITLE
Update keybox.xml

### DIFF
--- a/module/keybox.xml
+++ b/module/keybox.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <AndroidAttestation>
-    <NumberOfKeyboxes>2</NumberOfKeyboxes>
+    <NumberOfKeyboxes>1</NumberOfKeyboxes>
     <Keybox DeviceID="dev1">
         <Key algorithm="ecdsa">
             <PrivateKey format="pem">
@@ -50,8 +50,6 @@
                 </Certificate>
             </CertificateChain>
         </Key>
-    </Keybox>
-    <Keybox DeviceID="dev1">
         <Key algorithm="rsa">
             <PrivateKey format="pem">
                 -----BEGIN RSA PRIVATE KEY-----


### PR DESCRIPTION
This fix this:

https://xdaforums.com/t/tricky-store-bootloader-keybox-spoofing.4683446/post-90474295

https://xdaforums.com/t/tricky-store-bootloader-keybox-spoofing.4683446/post-90474473


Just for proper clarification, i open this, not that it's useful, as the AOSP is expired, but most not users confused if check it in PixelFlasher.