### PR TITLE
Hardening: process reliability, key persistence, and anti-detection defenses

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -116,7 +116,7 @@ androidComponents {
                     )
                 ) {
                     into("lib") // Place them in the 'lib' subfolder of the staging directory.
-                    include("**/libinject.so", "**/libTEESimulator.so")
+                    include("**/libinject.so", "**/libTEESimulator.so", "**/libsupervisor.so")
                 }
 
                 // Now, copy and process the files from 'module' directory.

--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -22,6 +22,9 @@ add_executable(libinject.so inject/main.cpp inject/utils.cpp)
 target_include_directories(libinject.so PUBLIC include)
 target_link_libraries(libinject.so PRIVATE lsplt_static)
 
+add_executable(libsupervisor.so supervisor.cpp)
+target_link_libraries(libsupervisor.so PRIVATE log)
+
 add_library(${CMAKE_PROJECT_NAME} SHARED binder_interceptor.cpp)
 target_include_directories(${CMAKE_PROJECT_NAME} PUBLIC external/linux-kernel/include include)
 target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE binder lsplt_static utils)

--- a/app/src/main/cpp/supervisor.cpp
+++ b/app/src/main/cpp/supervisor.cpp
@@ -1,0 +1,57 @@
+// Fork-based supervisor for instant daemon restart
+#include <unistd.h>
+#include <sys/wait.h>
+#include <sys/prctl.h>
+#include <signal.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+
+static volatile sig_atomic_t should_exit = 0;
+
+static void signal_handler(int sig) {
+    should_exit = 1;
+}
+
+int main(int argc, char *argv[]) {
+    if (argc < 2) {
+        fprintf(stderr, "Usage: %s <daemon> [args...]\n", argv[0]);
+        return 1;
+    }
+
+    // Forward termination signals to exit cleanly
+    signal(SIGTERM, signal_handler);
+    signal(SIGINT, signal_handler);
+
+    const char *daemon_path = argv[1];
+    char **daemon_argv = &argv[1];
+
+    while (!should_exit) {
+        pid_t pid = fork();
+
+        if (pid < 0) {
+            perror("fork failed");
+            usleep(100000); // 100ms backoff on fork failure
+            continue;
+        }
+
+        if (pid == 0) {
+            // Child: become the daemon
+            prctl(PR_SET_PDEATHSIG, SIGKILL); // Die if parent dies
+            execv(daemon_path, daemon_argv);
+            perror("execv failed");
+            _exit(127);
+        }
+
+        // Parent: wait for child to exit
+        int status;
+        waitpid(pid, &status, 0);
+
+        if (should_exit) break;
+
+        // Instant restart - no delay
+    }
+
+    return 0;
+}

--- a/app/src/main/java/org/matrix/TEESimulator/attestation/AttestationBuilder.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/attestation/AttestationBuilder.kt
@@ -112,6 +112,7 @@ object AttestationBuilder {
             }
 
         val bootPatch = AndroidDeviceUtils.getBootPatchLevelLong(uid)
+        SystemLogger.info("Attestation patch levels for uid=$uid: os=$osPatch, vendor=$vendorPatch, boot=$bootPatch")
         properties[AttestationConstants.TAG_BOOT_PATCHLEVEL] =
             if (bootPatch != DO_NOT_REPORT) {
                 DERTaggedObject(

--- a/app/src/main/java/org/matrix/TEESimulator/config/ConfigurationManager.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/config/ConfigurationManager.kt
@@ -307,8 +307,10 @@ object ConfigurationManager {
 
             val file = if (event != DELETE) File(configRoot, path) else null
             when (path) {
-                TARGET_PACKAGES_FILE -> loadTargetPackages(file!!)
-                PATCH_LEVEL_FILE -> loadPatchLevelConfig(file!!)
+                TARGET_PACKAGES_FILE -> file?.let { loadTargetPackages(it) }
+                    ?: SystemLogger.warning("$TARGET_PACKAGES_FILE was deleted.")
+                PATCH_LEVEL_FILE -> file?.let { loadPatchLevelConfig(it) }
+                    ?: SystemLogger.warning("$PATCH_LEVEL_FILE was deleted.")
                 // Any change to an XML file is assumed to be a keybox.
                 // The cache in KeyBoxManager will handle reloading it on its next use.
                 else ->

--- a/app/src/main/java/org/matrix/TEESimulator/config/ConfigurationManager.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/config/ConfigurationManager.kt
@@ -253,7 +253,14 @@ object ConfigurationManager {
             }
 
             // Parse global and per-package configurations.
-            val newGlobalLevel = parseLines(contextLines[""])
+            var newGlobalLevel = parseLines(contextLines[""])
+            // TrickyAddon writes Pixel bulletin dates for boot/vendor but system=prop
+            // resolves to the real device prop — force boot/vendor through the same path
+            // to prevent cross-component date mismatches on non-Pixel devices.
+            if (newGlobalLevel?.system.equals("prop", ignoreCase = true)) {
+                SystemLogger.info("system=prop: forcing boot/vendor to derive from device props (were: boot=${newGlobalLevel?.boot}, vendor=${newGlobalLevel?.vendor})")
+                newGlobalLevel = newGlobalLevel?.copy(boot = "prop", vendor = "prop")
+            }
             contextLines.remove("") // Remove global context to iterate over packages next
 
             for ((pkg, lines) in contextLines) {

--- a/app/src/main/java/org/matrix/TEESimulator/interception/keystore/Keystore2Interceptor.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/interception/keystore/Keystore2Interceptor.kt
@@ -235,8 +235,15 @@ object Keystore2Interceptor : AbstractKeystoreInterceptor() {
                         ?.let { it.keyParameter.value.origin }
 
                 if (origin == KeyOrigin.IMPORTED || origin == KeyOrigin.SECURELY_IMPORTED) {
-                    SystemLogger.info("[TX_ID: $txId] Skip patching for imported keys.")
-                    return TransactionResult.SkipTransaction
+                    val keyId = KeyIdentifier(callingUid, keyDescriptor.alias)
+                    val retainedChain = KeyMintSecurityLevelInterceptor.getPatchedChain(keyId)
+                    if (retainedChain == null) {
+                        SystemLogger.info("[TX_ID: $txId] Skip patching for imported key (no prior attestation).")
+                        return TransactionResult.SkipTransaction
+                    }
+                    SystemLogger.info("[TX_ID: $txId] Imported key overwrote attested alias, serving retained chain for $keyId")
+                    CertificateHelper.updateCertificateChain(response.metadata, retainedChain).getOrThrow()
+                    return InterceptorUtils.createTypedObjectReply(response)
                 }
 
                 if (originalChain == null || originalChain.size < 2) {

--- a/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/GeneratedKeyPersistence.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/GeneratedKeyPersistence.kt
@@ -1,0 +1,352 @@
+package org.matrix.TEESimulator.interception.keystore.shim
+
+import java.io.BufferedInputStream
+import java.io.BufferedOutputStream
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.security.KeyPair
+import java.security.MessageDigest
+import java.security.cert.Certificate
+import org.matrix.TEESimulator.config.ConfigurationManager.CONFIG_PATH
+import org.matrix.TEESimulator.interception.keystore.KeyIdentifier
+import org.matrix.TEESimulator.logging.SystemLogger
+import org.matrix.TEESimulator.pki.CertificateHelper
+
+data class PersistedKeyData(
+    val uid: Int,
+    val alias: String,
+    val nspace: Long,
+    val securityLevel: Int,
+    val isAttestationKey: Boolean,
+    val algorithm: Int,
+    val keySize: Int,
+    val ecCurve: Int,
+    val purposes: List<Int>,
+    val digests: List<Int>,
+    val privateKeyBytes: ByteArray,
+    val certChainBytes: List<ByteArray>,
+)
+
+object GeneratedKeyPersistence {
+
+    private const val FORMAT_VERSION = 1
+    private val PERSISTENCE_DIR = File(CONFIG_PATH, "persistent_keys")
+
+    fun save(
+        keyId: KeyIdentifier,
+        keyPair: KeyPair,
+        nspace: Long,
+        securityLevel: Int,
+        certChain: List<Certificate>,
+        algorithm: Int,
+        keySize: Int,
+        ecCurve: Int,
+        purposes: List<Int>,
+        digests: List<Int>,
+        isAttestationKey: Boolean,
+    ) {
+        runCatching {
+            PERSISTENCE_DIR.mkdirs()
+            val filename = keyFileName(keyId.uid, keyId.alias)
+            val finalFile = File(PERSISTENCE_DIR, filename)
+            val tmpFile = File(PERSISTENCE_DIR, "$filename.tmp")
+
+            try {
+                DataOutputStream(BufferedOutputStream(FileOutputStream(tmpFile))).use { out ->
+                    out.writeInt(FORMAT_VERSION)
+                    out.writeInt(securityLevel)
+                    out.writeInt(keyId.uid)
+                    out.writeUTF(keyId.alias)
+                    out.writeLong(nspace)
+                    out.writeBoolean(isAttestationKey)
+                    out.writeInt(algorithm)
+                    out.writeInt(keySize)
+                    out.writeInt(ecCurve)
+
+                    out.writeInt(purposes.size)
+                    purposes.forEach { out.writeInt(it) }
+
+                    out.writeInt(digests.size)
+                    digests.forEach { out.writeInt(it) }
+
+                    val pkBytes = keyPair.private.encoded
+                    out.writeInt(pkBytes.size)
+                    out.write(pkBytes)
+
+                    out.writeInt(certChain.size)
+                    certChain.forEach { cert ->
+                        val encoded = cert.encoded
+                        out.writeInt(encoded.size)
+                        out.write(encoded)
+                    }
+                }
+            } catch (e: Exception) {
+                tmpFile.delete()
+                throw e
+            }
+
+            // Atomic rename — if this fails the tmp is left behind and cleaned on next deleteAll
+            if (!tmpFile.renameTo(finalFile)) {
+                tmpFile.delete()
+                throw IllegalStateException("Failed to atomically rename $tmpFile -> $finalFile")
+            }
+
+            SystemLogger.debug("Persisted key: $keyId")
+        }.onFailure { e ->
+            SystemLogger.error("Failed to persist key $keyId", e)
+        }
+    }
+
+    fun delete(keyId: KeyIdentifier) {
+        runCatching {
+            val file = File(PERSISTENCE_DIR, keyFileName(keyId.uid, keyId.alias))
+            if (file.exists()) {
+                if (file.delete()) {
+                    SystemLogger.debug("Deleted persisted key: $keyId")
+                } else {
+                    SystemLogger.warning("Failed to delete persisted key file: ${file.name}")
+                }
+            } else {
+                SystemLogger.debug("No persisted file to delete for: $keyId")
+            }
+        }.onFailure { e ->
+            SystemLogger.error("Failed to delete persisted key $keyId", e)
+        }
+    }
+
+    fun deleteAll() {
+        runCatching {
+            if (!PERSISTENCE_DIR.exists()) {
+                SystemLogger.debug("No persistent_keys directory, nothing to delete")
+                return
+            }
+            val files = PERSISTENCE_DIR.listFiles()
+            if (files == null) {
+                SystemLogger.warning("Cannot list persistent_keys directory")
+                return
+            }
+            var count = 0
+            files.forEach { file ->
+                if (file.name.endsWith(".bin") || file.name.endsWith(".tmp")) {
+                    if (file.delete()) count++
+                }
+            }
+            SystemLogger.info("Deleted $count persisted key files")
+        }.onFailure { e ->
+            SystemLogger.error("Failed to delete all persisted keys", e)
+        }
+    }
+
+    fun loadAll(securityLevel: Int): List<PersistedKeyData> {
+        if (!PERSISTENCE_DIR.exists()) {
+            SystemLogger.debug("No persistent_keys directory, nothing to load")
+            return emptyList()
+        }
+        val files = PERSISTENCE_DIR.listFiles { _, name -> name.endsWith(".bin") }
+        if (files == null) {
+            SystemLogger.warning("Cannot read persistent_keys directory")
+            return emptyList()
+        }
+        if (files.isEmpty()) {
+            SystemLogger.debug("No persisted key files found")
+            return emptyList()
+        }
+        SystemLogger.info("Found ${files.size} persisted key files to process")
+
+        val result = mutableListOf<PersistedKeyData>()
+
+        for (file in files) {
+            runCatching {
+                DataInputStream(BufferedInputStream(FileInputStream(file))).use { input ->
+                    val version = input.readInt()
+                    if (version != FORMAT_VERSION) {
+                        SystemLogger.warning(
+                            "Skipping ${file.name}: unknown format version $version"
+                        )
+                        return@runCatching
+                    }
+
+                    val storedSecLevel = input.readInt()
+                    val uid = input.readInt()
+                    val alias = input.readUTF()
+                    val nspace = input.readLong()
+                    val isAttestKey = input.readBoolean()
+                    val algo = input.readInt()
+                    val kSize = input.readInt()
+                    val curve = input.readInt()
+
+                    val purposeCount = requireBounds(input.readInt(), 64, "purposeCount")
+                    val purposes = (0 until purposeCount).map { input.readInt() }
+
+                    val digestCount = requireBounds(input.readInt(), 64, "digestCount")
+                    val digests = (0 until digestCount).map { input.readInt() }
+
+                    val pkLen = requireBounds(input.readInt(), 8192, "pkLen")
+                    val pkBytes = ByteArray(pkLen)
+                    input.readFully(pkBytes)
+
+                    val certCount = requireBounds(input.readInt(), 10, "certCount")
+                    val certChainBytes = (0 until certCount).map {
+                        val certLen = requireBounds(input.readInt(), 65536, "certLen")
+                        val certBytes = ByteArray(certLen)
+                        input.readFully(certBytes)
+                        certBytes
+                    }
+
+                    if (storedSecLevel == securityLevel) {
+                        result.add(
+                            PersistedKeyData(
+                                uid = uid,
+                                alias = alias,
+                                nspace = nspace,
+                                securityLevel = storedSecLevel,
+                                isAttestationKey = isAttestKey,
+                                algorithm = algo,
+                                keySize = kSize,
+                                ecCurve = curve,
+                                purposes = purposes,
+                                digests = digests,
+                                privateKeyBytes = pkBytes,
+                                certChainBytes = certChainBytes,
+                            )
+                        )
+                    }
+                }
+            }.onFailure { e ->
+                SystemLogger.warning("Skipping corrupted persisted key file: ${file.name}", e)
+            }
+        }
+
+        SystemLogger.info("Loaded ${result.size} persisted keys for security level $securityLevel")
+        return result
+    }
+
+    // Re-persist updates the cert chain for an already-persisted key without
+    // reconstructing authorization parameters from the response. This avoids
+    // pulling keymint Tag dependencies into this file and is correct because
+    // the only field that changes post-generation is the patched cert chain.
+    fun rePersistIfNeeded(
+        callingUid: Int,
+        generatedKeyInfo: KeyMintSecurityLevelInterceptor.GeneratedKeyInfo,
+    ) {
+        val metadata = generatedKeyInfo.response.metadata
+        if (metadata == null) {
+            SystemLogger.debug("rePersist: no metadata, skipping")
+            return
+        }
+        val secLevel = metadata.keySecurityLevel
+
+        val entry = KeyMintSecurityLevelInterceptor.generatedKeys.entries.find { (id, info) ->
+            id.uid == callingUid && info.nspace == generatedKeyInfo.nspace
+        }
+        if (entry == null) {
+            SystemLogger.debug("rePersist: key not found in map for uid=$callingUid nspace=${generatedKeyInfo.nspace}")
+            return
+        }
+
+        val keyId = entry.key
+        val filename = keyFileName(keyId.uid, keyId.alias)
+        val existing = File(PERSISTENCE_DIR, filename)
+
+        if (!existing.exists()) {
+            SystemLogger.debug("rePersist: no existing file for $keyId, skipping")
+            return
+        }
+
+        val newChain = CertificateHelper.getCertificateChain(metadata)
+        if (newChain == null) {
+            SystemLogger.warning("rePersist: could not extract cert chain for $keyId")
+            return
+        }
+
+        val persisted = runCatching {
+            DataInputStream(BufferedInputStream(FileInputStream(existing))).use { input ->
+                val version = input.readInt()
+                if (version != FORMAT_VERSION) {
+                    SystemLogger.warning("rePersist: unknown format version $version for $keyId")
+                    return
+                }
+                readPersistedKeyData(input)
+            }
+        }.getOrNull()
+        if (persisted == null) {
+            SystemLogger.warning("rePersist: failed to read existing data for $keyId")
+            return
+        }
+
+        save(
+            keyId = keyId,
+            keyPair = generatedKeyInfo.keyPair,
+            nspace = generatedKeyInfo.nspace,
+            securityLevel = secLevel,
+            certChain = newChain.toList(),
+            algorithm = persisted.algorithm,
+            keySize = persisted.keySize,
+            ecCurve = persisted.ecCurve,
+            purposes = persisted.purposes,
+            digests = persisted.digests,
+            isAttestationKey = persisted.isAttestationKey,
+        )
+        SystemLogger.debug("Re-persisted key $keyId with updated cert chain")
+    }
+
+    // Corrupted binary files can have arbitrary length fields — cap allocations
+    private fun requireBounds(value: Int, max: Int, name: String): Int {
+        require(value in 0..max) { "$name out of bounds: $value (max $max)" }
+        return value
+    }
+
+    private fun keyFileName(uid: Int, alias: String): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+            .digest("$uid:$alias".toByteArray(Charsets.UTF_8))
+        return digest.joinToString("") { "%02x".format(it) } + ".bin"
+    }
+
+    // Reads all fields after version has already been consumed
+    private fun readPersistedKeyData(input: DataInputStream): PersistedKeyData {
+        val secLevel = input.readInt()
+        val uid = input.readInt()
+        val alias = input.readUTF()
+        val nspace = input.readLong()
+        val isAttestKey = input.readBoolean()
+        val algo = input.readInt()
+        val kSize = input.readInt()
+        val curve = input.readInt()
+
+        val purposeCount = requireBounds(input.readInt(), 64, "purposeCount")
+        val purposes = (0 until purposeCount).map { input.readInt() }
+
+        val digestCount = requireBounds(input.readInt(), 64, "digestCount")
+        val digests = (0 until digestCount).map { input.readInt() }
+
+        val pkLen = requireBounds(input.readInt(), 8192, "pkLen")
+        val pkBytes = ByteArray(pkLen)
+        input.readFully(pkBytes)
+
+        val certCount = requireBounds(input.readInt(), 10, "certCount")
+        val certChainBytes = (0 until certCount).map {
+            val certLen = requireBounds(input.readInt(), 65536, "certLen")
+            val certBytes = ByteArray(certLen)
+            input.readFully(certBytes)
+            certBytes
+        }
+
+        return PersistedKeyData(
+            uid = uid,
+            alias = alias,
+            nspace = nspace,
+            securityLevel = secLevel,
+            isAttestationKey = isAttestKey,
+            algorithm = algo,
+            keySize = kSize,
+            ecCurve = curve,
+            purposes = purposes,
+            digests = digests,
+            privateKeyBytes = pkBytes,
+            certChainBytes = certChainBytes,
+        )
+    }
+}

--- a/app/src/main/java/org/matrix/TEESimulator/util/AndroidDeviceUtils.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/util/AndroidDeviceUtils.kt
@@ -239,11 +239,12 @@ object AndroidDeviceUtils {
         val resolvedValue = resolveDateKeywords(value)
 
         return when {
-            // "device_default" indicates falling back to the system property.
             resolvedValue.equals("device_default", ignoreCase = true) -> null
-            // "no" indicates this value should not be reported.
+            // Resolve from live system prop — matches what detectors see via getprop,
+            // even when PIF has spoofed ro.build.version.security_patch via resetprop
+            resolvedValue.equals("prop", ignoreCase = true) ->
+                parsePatchLevelValue(SystemProperties.get("ro.build.version.security_patch", ""), isLong)
             resolvedValue.equals("no", ignoreCase = true) -> DO_NOT_REPORT
-            // Otherwise, parse the resolved date string.
             else -> parsePatchLevelValue(resolvedValue, isLong)
         }
     }

--- a/app/src/main/java/org/matrix/TEESimulator/util/Extensions.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/util/Extensions.kt
@@ -6,7 +6,11 @@ package org.matrix.TEESimulator.util
  *
  * @return A new string with each line individually trimmed.
  */
-fun String.trimLines(): String = this.trim().lines().joinToString("\n") { it.trim() }
+fun String.trimLines(): String =
+    this.trim()
+        .lines()
+        .filter { !it.trim().startsWith("<!--") }
+        .joinToString("\n") { it.trim() }
 
 /**
  * Converts a ByteArray to its hexadecimal string representation.

--- a/module/action.sh
+++ b/module/action.sh
@@ -1,0 +1,11 @@
+#!/system/bin/sh
+MODDIR=${0%/*}
+CONFIG_DIR=/data/adb/tricky_store
+
+if [ -d "$CONFIG_DIR/persistent_keys" ]; then
+    rm -rf "$CONFIG_DIR/persistent_keys"
+    mkdir -p "$CONFIG_DIR/persistent_keys"
+    echo "Persistent key storage cleared"
+else
+    echo "No persistent key storage found"
+fi

--- a/module/customize.sh
+++ b/module/customize.sh
@@ -67,10 +67,13 @@ ui_print ""
 ui_print "- Extracting $ARCH libraries"
 install_file "lib/$ABI_DIR/libTEESimulator.so" "$MODPATH"
 install_file "lib/$ABI_DIR/libinject.so" "$MODPATH"
+install_file "lib/$ABI_DIR/libsupervisor.so" "$MODPATH"
 ui_print ""
 
 mv "$MODPATH/libinject.so" "$MODPATH/inject"
+mv "$MODPATH/libsupervisor.so" "$MODPATH/supervisor"
 chmod 755 "$MODPATH/inject"
+chmod 755 "$MODPATH/supervisor"
 
 # --- Configuration Files ---
 if [ ! -d "$CONFIG_DIR" ]; then

--- a/module/service.sh
+++ b/module/service.sh
@@ -1,11 +1,5 @@
-DEBUG=false
-
 MODDIR=${0%/*}
-
 cd $MODDIR
 
-while true; do
-  ./daemon "$MODDIR" || exit 1
-  # ensure keystore initialized
-  sleep 2
-done &
+# Fork-based supervisor for instant restart
+./supervisor ./daemon "$MODDIR" &

--- a/module/uninstall.sh
+++ b/module/uninstall.sh
@@ -1,0 +1,11 @@
+#!/system/bin/sh
+MODDIR=${0%/*}
+CONFIG_DIR=/data/adb/tricky_store
+
+# Kill daemon and supervisor
+for pid in $(pidof TEESimulator) $(pidof supervisor) $(pidof daemon); do
+    kill -9 "$pid" 2>/dev/null
+done
+
+rm -rf "$CONFIG_DIR/persistent_keys"
+rm -f "$CONFIG_DIR/tee_status.txt"


### PR DESCRIPTION
## Problem

TEESimulator v3.1 has several gaps that real-world detector apps exploit to either crash the interceptor, starve its resources, or extract genuine TEE attestation state. This PR addresses the ones I've been able to reproduce and fix on a physical Beanpod device.

### Attack vectors observed

**Binder flooding (DuckDetector, #71, #109):** Rapid-fire `generateKey` requests with oversized aliases or high concurrency saturate the interceptor's thread pool. Legitimate GMS attestation requests queue behind the flood, time out, and Play Integrity fails.

**Generate-then-import eviction (Luna/GarfieldHan):** `generateKey` creates an attested alias with a patched chain. Immediately calling `importKey` on the same alias triggers `cleanupKeyData()`, which wipes the patched chain. A subsequent `getKeyEntry` returns the real unpatched chain from Keystore2. Detection.

**Interceptor death → TEE state leak:** When the Java interceptor dies, `callback->transact()` returns `DEAD_OBJECT` but the native layer falls through to the real Keystore2 service, exposing genuine device attestation to the requesting app.

**Security patch cross-component mismatch:** When `security_patch.txt` sets `system=prop` but boot/vendor use explicit dates from Pixel bulletins, non-Pixel devices show mismatched patch levels across ASN.1 tags 706/718/719 in the attestation certificate.

**Keybox PEM parsing failure:** Some keybox sources contain HTML comments (`<!-- -->`) inside PEM certificate blocks. BouncyCastle's PEMParser silently fails on non-base64 lines, resulting in a broken keybox with no clear error.

**FileObserver crash on config deletion:** Deleting a config file fires an event with `file=null`, which gets force-unwrapped (`file!!`) in the `when` block, killing the FileObserver thread. All subsequent config change notifications are silently lost.

---

## Changes

### Process reliability

- **Fork-based supervisor daemon** — `service.sh` launches a supervisor that forks the interceptor process. If the interceptor dies, the supervisor restarts it immediately.
- **Attestation leak blocker** — Native `pingBinder()` liveness check before forwarding. If the interceptor is confirmed dead, return `DEAD_OBJECT` to callers instead of falling through to real hardware.
- **Lifecycle scripts** — `action.sh` clears persistent key storage via KSU Action button (soft reset, daemon stays alive). `uninstall.sh` kills processes and removes module artifacts while preserving `target.txt` and keybox config.

### Key persistence

- **Generated key persistence layer** — Serialize software-generated attestation chains to `/data/adb/tricky_store/persistent_keys/*.bin` with version header and atomic write (tmp + rename). Daemon restarts and reboots no longer require fresh keygen for every app.
- **Interceptor integration** — Save on `generateKey`, restore on startup, delete on cleanup, re-persist on `updateSubcomponents`.
- **File-level locking** — Per-key `ReentrantLock` prevents concurrent writes to the same key file when multiple software fallback requests hit simultaneously.

### Anti-detection hardening

- **Per-UID hardware keygen rate limiter** — Sliding window: max 2 hardware `generateKey` calls per 30s per UID, max 2 concurrent. Overflow falls back to software cert generation. Prevents DuckDetector-style resource starvation without blocking legitimate attestation. (Addresses #71)
- **importKey eviction hardening** — `importKey` post-hook retains patched chains instead of calling `cleanupKeyData()`. `getKeyEntry` in `Keystore2Interceptor` serves retained chains for imported keys that overwrote attested aliases. Closes the Luna/GarfieldHan generate-then-import detection vector.
- **Native payload size guard** — `binder_interceptor.cpp` bypasses interception for payloads > 256KB, preventing thread starvation from oversized binder transactions. (Addresses #109)
- **Alias length validation** — Java-side rejection of aliases exceeding 256KB (4x safety margin against 1MB binder buffer). (Addresses #109)

### Bug fixes

- **Security patch consistency** — When `system=prop`, force boot and vendor patch levels through the same `SystemProperties.get()` resolution path. All three ASN.1 tags match what detectors see via `getprop`.
- **PEM HTML comment stripping** — Filter `<!--` lines in `trimLines()` before content reaches the PEM parser.
- **FileObserver null safety** — Replace force-unwrap with safe call on config file deletion events.

---

## Testing

Tested on Xiaomi Redmi 14C (Android 14, KernelSU Next, Beanpod KeyMaster, `isTeeBroken=false`).

- **15+ detector apps** — zero detection (includes Play Integrity, DuckDetector, Luna/GarfieldHan, wu.keyChain.test, Risk Detector)
- Daemon survives process kills and restarts within ~1s
- Persistent keys survive reboots; no keygen storm on boot
- Security patch levels consistent across system/boot/vendor under `system=prop` configuration
- Rate limiter correctly throttles flood attacks while allowing legitimate GMS attestation through

---

## Commit overview

Prefer **rebase merge** to preserve commit structure — each commit is a self-contained logical change.

1. `feat(module)` — supervisor daemon + leak blocker + lifecycle scripts
2. `feat` — generated key persistence layer
3. `feat` — integrate persistence with interceptors
4. `fix(config)` — FileObserver NPE on config deletion
5. `fix(pki)` — strip HTML comments from PEM blocks
6. `fix` — reject oversized aliases (#109)
7. `feat` — file-level locking for key persistence
8. `fix(native)` — cap binder payload at 256KB (#109)
9. `feat` — per-UID rate limiter + importKey eviction hardening (#71)
10. `fix` — derive boot/vendor patch from system prop when `system=prop`