### PR TITLE
Ignore invalid bootHash

### DIFF
--- a/app/src/main/java/org/matrix/TEESimulator/attestation/DeviceAttestationService.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/attestation/DeviceAttestationService.kt
@@ -249,6 +249,10 @@ object DeviceAttestationService {
                 verifiedBootKey = null
             }
 
+            if (verifiedBootHash?.all { it == 0.toByte() } == true) {
+                verifiedBootHash = null
+            }
+
             SystemLogger.info(
                 "Successfully extracted attestation data: version=$attestVersion, osVersion=$osVersion, osPatch=$osPatchLevel, vendorPatch=$vendorPatchLevel, bootPatch=$bootPatchLevel, moduleHash=${moduleHash?.toHex()}, bootKey=${verifiedBootKey?.toHex()}, bootHash=${verifiedBootHash?.toHex()}"
             )


### PR DESCRIPTION
Invalid bootHash filled with 0 is found in device `beyondxxx-user 12 SP1A.210812.016 G977BXXSEHWC1`.