### PR TITLE
Fix `list_past_alias` enumeration filter

### DIFF
--- a/app/src/main/java/org/matrix/TEESimulator/interception/keystore/ListEntriesHandler.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/interception/keystore/ListEntriesHandler.kt
@@ -120,7 +120,7 @@ object ListEntriesHandler {
         startPastAlias: String?,
     ): List<KeyDescriptor> {
         return KeyMintSecurityLevelInterceptor.generatedKeys.keys
-            .filter { it.uid == uid && (startPastAlias == null || it.alias < startPastAlias) }
+            .filter { it.uid == uid && (startPastAlias == null || it.alias > startPastAlias) }
             .map { keyId ->
                 KeyDescriptor().apply {
                     this.domain = Domain.APP


### PR DESCRIPTION
It was an error of using `<` comparison to return a list of KeyDescriptors (in the selected domain/namespace) whose aliases are greater than the specified 'start_past_alias'.