### PR TITLE
Cache patched chains for pre-existing keys

### DIFF
--- a/app/src/main/java/org/matrix/TEESimulator/interception/keystore/Keystore2Interceptor.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/interception/keystore/Keystore2Interceptor.kt
@@ -295,6 +295,9 @@ object Keystore2Interceptor : AbstractKeystoreInterceptor() {
                         )
                         finalChain =
                             AttestationPatcher.patchCertificateChain(originalChain, callingUid)
+
+                        KeyMintSecurityLevelInterceptor.patchedChains[keyId] = finalChain
+                        SystemLogger.debug("Cached patched certificate chain for $keyId.")
                     }
 
                     CertificateHelper.updateCertificateChain(response.metadata, finalChain)

--- a/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/KeyMintSecurityLevelInterceptor.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/KeyMintSecurityLevelInterceptor.kt
@@ -334,7 +334,7 @@ class KeyMintSecurityLevelInterceptor(
         // A set to quickly identify keys that were generated for attestation purposes.
         val attestationKeys = ConcurrentHashMap.newKeySet<KeyIdentifier>()
         // Caches patched certificate chains to prevent re-generation and signature inconsistencies.
-        private val patchedChains = ConcurrentHashMap<KeyIdentifier, Array<Certificate>>()
+        val patchedChains = ConcurrentHashMap<KeyIdentifier, Array<Certificate>>()
         // Stores interceptors for active cryptographic operations.
         private val interceptedOperations = ConcurrentHashMap<IBinder, OperationInterceptor>()
 


### PR DESCRIPTION
In commit 0485379a9f03c2d87963409db5747f8e2372de69, we forgot to cache the patched certificate chains.