### PR TITLE
Align generated KeyMetadata and Authorizations with AOSP Keystore2 se…

### DIFF
--- a/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/KeyMintSecurityLevelInterceptor.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/KeyMintSecurityLevelInterceptor.kt
@@ -2,6 +2,7 @@ package org.matrix.TEESimulator.interception.keystore.shim
 
 import android.hardware.security.keymint.KeyParameter
 import android.hardware.security.keymint.KeyParameterValue
+import android.hardware.security.keymint.KeyOrigin
 import android.hardware.security.keymint.Tag
 import android.os.IBinder
 import android.os.Parcel
@@ -291,12 +292,20 @@ class KeyMintSecurityLevelInterceptor(
         params: KeyMintAttestation,
         descriptor: KeyDescriptor,
     ): KeyEntryResponse {
+        val normalizedKeyDescriptor =
+            KeyDescriptor().apply {
+                domain = Domain.KEY_ID
+                nspace = descriptor.nspace
+                alias = null
+                blob = null
+            }
         val metadata =
             KeyMetadata().apply {
                 keySecurityLevel = securityLevel
-                key = descriptor
+                key = normalizedKeyDescriptor
                 CertificateHelper.updateCertificateChain(this, chain.toTypedArray()).getOrThrow()
                 authorizations = params.toAuthorizations(securityLevel)
+                modificationTimeMs = System.currentTimeMillis()
             }
         return KeyEntryResponse().apply {
             this.metadata = metadata
@@ -430,6 +439,12 @@ private fun KeyMintAttestation.toAuthorizations(securityLevel: Int): Array<Autho
     authList.add(createAuth(Tag.ALGORITHM, KeyParameterValue.algorithm(this.algorithm)))
     authList.add(createAuth(Tag.KEY_SIZE, KeyParameterValue.integer(this.keySize)))
     authList.add(createAuth(Tag.EC_CURVE, KeyParameterValue.ecCurve(this.ecCurve)))
+    authList.add(
+        createAuth(
+            Tag.ORIGIN,
+            KeyParameterValue.origin(this.origin ?: KeyOrigin.GENERATED),
+        )
+    )
     authList.add(createAuth(Tag.NO_AUTH_REQUIRED, KeyParameterValue.boolValue(true)))
 
     return authList.toTypedArray()


### PR DESCRIPTION
…mantics

This commit rectifies structural deviations in the `KeyEntryResponse` object returned during software key generation, ensuring strict adherence to Keystore2's internal data representation and KeyMint HAL specifications.

Specifically, it addresses the following semantic inconsistencies:

1. KeyDescriptor Normalization (Domain::KEY_ID): Previously, the simulator directly returned the client-provided `KeyDescriptor` (containing `Domain::APP` and the raw alias). However, the AOSP Keystore2 daemon normalizes the descriptor in its response. This commit explicitly constructs a normalized `KeyDescriptor` where `domain` is set to `Domain::KEY_ID`, `nspace` exposes the allocated 64-bit internal ID, and `alias`/`blob` are explicitly nullified, matching the framework's expectation for persistent key references.

2. Modification Timestamp Population: The `modificationTimeMs` field in `KeyMetadata` was previously defaulting to 0. It is now accurately populated with the current epoch timestamp, mirroring the database creation/update time behavior implemented in `service.rs`.

3. Mandatory HAL Tag Injection (Tag::ORIGIN): The KeyMint HAL strictly requires that hardware-backed keys contain `Tag::ORIGIN` in their characteristics. This commit injects `KeyOrigin::GENERATED` into the final `authorizations` array for software-generated keys, preventing parsing inconsistencies in higher-level framework components that rely on this foundational tag.

References:
https://cs.android.com/android/platform/superproject/main/+/main:system/security/keystore2/src/service.rs?q=Domain::KEY_ID https://cs.android.com/android/platform/superproject/main/+/main:hardware/interfaces/security/keymint/aidl/android/hardware/security/keymint/KeyOrigin.aidl