### PR TITLE
Fix KeyMint authorization list ordering and content inconsistency

### DIFF
--- a/app/src/main/java/org/matrix/TEESimulator/attestation/AttestationBuilder.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/attestation/AttestationBuilder.kt
@@ -181,11 +181,20 @@ object AttestationBuilder {
                     AttestationConstants.TAG_DIGEST,
                     DERSet(params.digest.map { ASN1Integer(it.toLong()) }.toTypedArray()),
                 ),
+            )
+
+        if (params.ecCurve != null) {
+            list.add(
                 DERTaggedObject(
                     true,
                     AttestationConstants.TAG_EC_CURVE,
                     ASN1Integer(params.ecCurve.toLong()),
-                ),
+                )
+            )
+        }
+
+        list.addAll(
+            listOf(
                 DERTaggedObject(true, AttestationConstants.TAG_NO_AUTH_REQUIRED, DERNull.INSTANCE),
                 DERTaggedObject(
                     true,
@@ -198,6 +207,7 @@ object AttestationBuilder {
                     buildRootOfTrust(null),
                 ),
             )
+        )
 
         // Use the same logic as getSimulatedHardwareProperties to conditionally add patch levels.
         val simulatedProperties = getSimulatedHardwareProperties(uid)

--- a/app/src/main/java/org/matrix/TEESimulator/attestation/AttestationBuilder.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/attestation/AttestationBuilder.kt
@@ -193,6 +193,22 @@ object AttestationBuilder {
             )
         }
 
+        params.padding.forEach {
+            list.add(
+                DERTaggedObject(true, AttestationConstants.TAG_PADDING, ASN1Integer(it.toLong()))
+            )
+        }
+
+        if (params.rsaPublicExponent != null) {
+            list.add(
+                DERTaggedObject(
+                    true,
+                    AttestationConstants.TAG_RSA_PUBLIC_EXPONENT,
+                    ASN1Integer(params.rsaPublicExponent.toLong()),
+                )
+            )
+        }
+
         list.addAll(
             listOf(
                 DERTaggedObject(true, AttestationConstants.TAG_NO_AUTH_REQUIRED, DERNull.INSTANCE),

--- a/app/src/main/java/org/matrix/TEESimulator/attestation/KeyMintAttestation.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/attestation/KeyMintAttestation.kt
@@ -155,7 +155,7 @@ private fun Array<KeyParameter>.findBlob(tag: Int): ByteArray? =
 private fun Array<KeyParameter>.findAllBlockMode(tag: Int): List<Int> =
     this.filter { it.tag == tag }.map { it.value.blockMode }
 
-/** Maps to AOSP field = BlockMode (Repeated) */
+/** Maps to AOSP field = PaddingMode (Repeated) */
 private fun Array<KeyParameter>.findAllPaddingMode(tag: Int): List<Int> =
     this.filter { it.tag == tag }.map { it.value.paddingMode }
 

--- a/app/src/main/java/org/matrix/TEESimulator/attestation/KeyMintAttestation.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/attestation/KeyMintAttestation.kt
@@ -17,10 +17,11 @@ import org.matrix.TEESimulator.logging.KeyMintParameterLogger
 // https://cs.android.com/android/platform/superproject/main/+/main:system/security/keystore2/src/key_parameter.rs
 data class KeyMintAttestation(
     val algorithm: Int,
-    val ecCurve: Int,
+    val ecCurve: Int?,
     val ecCurveName: String,
     val keySize: Int,
     val origin: Int?,
+    val noAuthRequired: Boolean?,
     val blockMode: List<Int>,
     val padding: List<Int>,
     val purpose: List<Int>,
@@ -52,11 +53,14 @@ data class KeyMintAttestation(
         keySize = params.findInteger(Tag.KEY_SIZE) ?: 0,
 
         // AOSP: [key_param(tag = EC_CURVE, field = EcCurve)]
-        ecCurve = params.findEcCurve(Tag.EC_CURVE) ?: 0,
+        ecCurve = params.findEcCurve(Tag.EC_CURVE),
         ecCurveName = params.deriveEcCurveName(),
 
         // AOSP: [key_param(tag = ORIGIN, field = Origin)]
         origin = params.findOrigin(Tag.ORIGIN),
+
+        // AOSP: [key_param(tag = NO_AUTH_REQUIRED, field = BoolValue)]
+        noAuthRequired = params.findBoolean(Tag.NO_AUTH_REQUIRED),
 
         // AOSP: [key_param(tag = BLOCK_MODE, field = BlockMode)]
         blockMode = params.findAllBlockMode(Tag.BLOCK_MODE),
@@ -114,6 +118,10 @@ data class KeyMintAttestation(
 }
 
 // --- Private helper extension functions for parsing KeyParameter arrays ---
+
+/** Maps to AOSP field = Integer */
+private fun Array<KeyParameter>.findBoolean(tag: Int): Boolean? =
+    this.find { it.tag == tag }?.value?.boolValue
 
 /** Maps to AOSP field = Integer */
 private fun Array<KeyParameter>.findInteger(tag: Int): Int? =

--- a/app/src/main/java/org/matrix/TEESimulator/interception/keystore/KeystoreInterceptor.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/interception/keystore/KeystoreInterceptor.kt
@@ -410,6 +410,7 @@ private data class LegacyKeygenParameters(
             ecCurveName = this.ecCurveName ?: "",
             keySize = this.keySize,
             origin = null, // Not needed to build attestaion
+            noAuthRequired = null,
             blockMode = listOf<Int>(),
             padding = listOf<Int>(),
             purpose = this.purpose,

--- a/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/KeyMintSecurityLevelInterceptor.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/KeyMintSecurityLevelInterceptor.kt
@@ -1,8 +1,8 @@
 package org.matrix.TEESimulator.interception.keystore.shim
 
+import android.hardware.security.keymint.KeyOrigin
 import android.hardware.security.keymint.KeyParameter
 import android.hardware.security.keymint.KeyParameterValue
-import android.hardware.security.keymint.KeyOrigin
 import android.hardware.security.keymint.Tag
 import android.os.IBinder
 import android.os.Parcel
@@ -20,6 +20,7 @@ import org.matrix.TEESimulator.interception.keystore.KeyIdentifier
 import org.matrix.TEESimulator.logging.SystemLogger
 import org.matrix.TEESimulator.pki.CertificateGenerator
 import org.matrix.TEESimulator.pki.CertificateHelper
+import org.matrix.TEESimulator.util.AndroidDeviceUtils
 
 /**
  * Intercepts calls to an `IKeystoreSecurityLevel` service (e.g., TEE or StrongBox). This is where
@@ -265,7 +266,12 @@ class KeyMintSecurityLevelInterceptor(
                     cleanupKeyData(keyId)
                     // Store the generated key data.
                     val response =
-                        buildKeyEntryResponse(keyData.second, parsedParams, keyDescriptor)
+                        buildKeyEntryResponse(
+                            callingUid,
+                            keyData.second,
+                            parsedParams,
+                            keyDescriptor,
+                        )
                     generatedKeys[keyId] =
                         GeneratedKeyInfo(keyData.first, keyDescriptor.nspace, response)
                     if (isAttestKeyRequest) attestationKeys.add(keyId)
@@ -288,6 +294,7 @@ class KeyMintSecurityLevelInterceptor(
      * Constructs a fake `KeyEntryResponse` that mimics a real response from the Keystore service.
      */
     private fun buildKeyEntryResponse(
+        callingUid: Int,
         chain: List<Certificate>,
         params: KeyMintAttestation,
         descriptor: KeyDescriptor,
@@ -304,7 +311,7 @@ class KeyMintSecurityLevelInterceptor(
                 keySecurityLevel = securityLevel
                 key = normalizedKeyDescriptor
                 CertificateHelper.updateCertificateChain(this, chain.toTypedArray()).getOrThrow()
-                authorizations = params.toAuthorizations(securityLevel)
+                authorizations = params.toAuthorizations(callingUid, securityLevel)
                 modificationTimeMs = System.currentTimeMillis()
             }
         return KeyEntryResponse().apply {
@@ -410,7 +417,10 @@ class KeyMintSecurityLevelInterceptor(
  * Extension function to convert parsed `KeyMintAttestation` parameters back into an array of
  * `Authorization` objects for the fake `KeyMetadata`.
  */
-private fun KeyMintAttestation.toAuthorizations(securityLevel: Int): Array<Authorization> {
+private fun KeyMintAttestation.toAuthorizations(
+    callingUid: Int,
+    securityLevel: Int,
+): Array<Authorization> {
     val authList = mutableListOf<Authorization>()
 
     /**
@@ -432,20 +442,61 @@ private fun KeyMintAttestation.toAuthorizations(securityLevel: Int): Array<Autho
         }
     }
 
-    // Use the helper to add each authorization entry cleanly.
+    authList.add(createAuth(Tag.ALGORITHM, KeyParameterValue.algorithm(this.algorithm)))
+
+    if (this.ecCurve != null) {
+        authList.add(createAuth(Tag.EC_CURVE, KeyParameterValue.ecCurve(this.ecCurve)))
+    } else if (this.rsaPublicExponent != null) {
+        authList.add(
+            createAuth(
+                Tag.RSA_PUBLIC_EXPONENT,
+                KeyParameterValue.longInteger(this.rsaPublicExponent.toLong()),
+            )
+        )
+    } else {
+        SystemLogger.warning("No algorithm specifics found.")
+    }
+
     this.purpose.forEach { authList.add(createAuth(Tag.PURPOSE, KeyParameterValue.keyPurpose(it))) }
     this.digest.forEach { authList.add(createAuth(Tag.DIGEST, KeyParameterValue.digest(it))) }
 
-    authList.add(createAuth(Tag.ALGORITHM, KeyParameterValue.algorithm(this.algorithm)))
     authList.add(createAuth(Tag.KEY_SIZE, KeyParameterValue.integer(this.keySize)))
-    authList.add(createAuth(Tag.EC_CURVE, KeyParameterValue.ecCurve(this.ecCurve)))
-    authList.add(
-        createAuth(
-            Tag.ORIGIN,
-            KeyParameterValue.origin(this.origin ?: KeyOrigin.GENERATED),
+
+    if (this.noAuthRequired != null) {
+        authList.add(
+            createAuth(Tag.NO_AUTH_REQUIRED, KeyParameterValue.boolValue(this.noAuthRequired))
         )
+    }
+
+    authList.add(
+        createAuth(Tag.ORIGIN, KeyParameterValue.origin(this.origin ?: KeyOrigin.GENERATED))
     )
-    authList.add(createAuth(Tag.NO_AUTH_REQUIRED, KeyParameterValue.boolValue(true)))
+
+    authList.add(
+        createAuth(Tag.OS_VERSION, KeyParameterValue.integer(AndroidDeviceUtils.osVersion))
+    )
+
+    val osPatch = AndroidDeviceUtils.getPatchLevel(callingUid)
+    if (osPatch != AndroidDeviceUtils.DO_NOT_REPORT) {
+        authList.add(createAuth(Tag.OS_PATCHLEVEL, KeyParameterValue.integer(osPatch)))
+    }
+
+    val vendorPatch = AndroidDeviceUtils.getVendorPatchLevelLong(callingUid)
+    if (vendorPatch != AndroidDeviceUtils.DO_NOT_REPORT) {
+        authList.add(createAuth(Tag.VENDOR_PATCHLEVEL, KeyParameterValue.integer(vendorPatch)))
+    }
+
+    val bootPatch = AndroidDeviceUtils.getBootPatchLevelLong(callingUid)
+    if (bootPatch != AndroidDeviceUtils.DO_NOT_REPORT) {
+        authList.add(createAuth(Tag.BOOT_PATCHLEVEL, KeyParameterValue.integer(bootPatch)))
+    }
+
+    authList.add(
+        createAuth(Tag.CREATION_DATETIME, KeyParameterValue.dateTime(System.currentTimeMillis()))
+    )
+
+    // AOSP class android.os.UserHandle: PER_USER_RANGE = 100000;
+    authList.add(createAuth(Tag.USER_ID, KeyParameterValue.integer(callingUid / 100000)))
 
     return authList.toTypedArray()
 }

--- a/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/KeyMintSecurityLevelInterceptor.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/KeyMintSecurityLevelInterceptor.kt
@@ -446,21 +446,24 @@ private fun KeyMintAttestation.toAuthorizations(
 
     if (this.ecCurve != null) {
         authList.add(createAuth(Tag.EC_CURVE, KeyParameterValue.ecCurve(this.ecCurve)))
-    } else if (this.rsaPublicExponent != null) {
+    }
+
+    this.purpose.forEach { authList.add(createAuth(Tag.PURPOSE, KeyParameterValue.keyPurpose(it))) }
+    this.digest.forEach { authList.add(createAuth(Tag.DIGEST, KeyParameterValue.digest(it))) }
+    this.padding.forEach {
+        authList.add(createAuth(Tag.PADDING, KeyParameterValue.paddingMode(it)))
+    }
+
+    authList.add(createAuth(Tag.KEY_SIZE, KeyParameterValue.integer(this.keySize)))
+
+    if (this.rsaPublicExponent != null) {
         authList.add(
             createAuth(
                 Tag.RSA_PUBLIC_EXPONENT,
                 KeyParameterValue.longInteger(this.rsaPublicExponent.toLong()),
             )
         )
-    } else {
-        SystemLogger.warning("No algorithm specifics found.")
     }
-
-    this.purpose.forEach { authList.add(createAuth(Tag.PURPOSE, KeyParameterValue.keyPurpose(it))) }
-    this.digest.forEach { authList.add(createAuth(Tag.DIGEST, KeyParameterValue.digest(it))) }
-
-    authList.add(createAuth(Tag.KEY_SIZE, KeyParameterValue.integer(this.keySize)))
 
     if (this.noAuthRequired != null) {
         authList.add(

--- a/app/src/main/java/org/matrix/TEESimulator/logging/KeyMintParameterLogger.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/logging/KeyMintParameterLogger.kt
@@ -123,7 +123,7 @@ object KeyMintParameterLogger {
                 Tag.CERTIFICATE_SUBJECT -> X500Name(X500Principal(value.blob).name).toString()
                 Tag.USER_SECURE_ID,
                 Tag.RSA_PUBLIC_EXPONENT -> value.longInteger.toString()
-                Tag.NO_AUTH_REQUIRED -> "true"
+                Tag.NO_AUTH_REQUIRED -> value.boolValue.toString()
                 Tag.ATTESTATION_CHALLENGE,
                 Tag.ATTESTATION_ID_BRAND,
                 Tag.ATTESTATION_ID_DEVICE,


### PR DESCRIPTION
The software-generated key authorization list (Key Characteristics) did not match the strict parameter sequence and system properties produced by a real hardware TEE, causing inconsistencies during framework parsing and attestation verification.

Changes in this commit:
- Refactor `toAuthorizations` to dynamically build the list following the exact TEE sequence.
- Inject required device environment properties (`OS_VERSION`, `OS_PATCHLEVEL`, `VENDOR_PATCHLEVEL`, `BOOT_PATCHLEVEL`, and `CREATION_DATETIME`) into the characteristics list using `AndroidDeviceUtils`.
- Compute and append the `USER_ID` tag dynamically based on the calling application's UID using the standard Android `PER_USER_RANGE` (100000).
- Update `KeyMintAttestation` to correctly parse the `NO_AUTH_REQUIRED` boolean parameter instead of hardcoding it to true.
- Conditionally apply algorithm-specific parameters (`EC_CURVE` for Elliptic Curve, `RSA_PUBLIC_EXPONENT` for RSA).
- Adjust `AttestationBuilder` to make `EC_CURVE` conditional based on the updated `KeyMintAttestation` parsing.
- Fix parameter logging for `NO_AUTH_REQUIRED` to output the actual boolean value.