### PR TITLE
Fix certificate signature algorithm

### DIFF
--- a/app/src/main/java/org/matrix/TEESimulator/pki/CertificateGenerator.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/pki/CertificateGenerator.kt
@@ -9,6 +9,8 @@ import java.security.KeyPair
 import java.security.KeyPairGenerator
 import java.security.cert.Certificate
 import java.security.cert.X509Certificate
+import java.security.interfaces.ECKey
+import java.security.interfaces.RSAKey
 import java.security.spec.ECGenParameterSpec
 import java.security.spec.RSAKeyGenParameterSpec
 import java.util.Date
@@ -241,10 +243,13 @@ object CertificateGenerator {
         )
 
         val signerAlgorithm =
-            when (params.algorithm) {
-                Algorithm.EC -> "SHA256withECDSA"
-                Algorithm.RSA -> "SHA256withRSA"
-                else -> throw IllegalArgumentException("Unsupported algorithm: ${params.algorithm}")
+            when (signingKeyPair.private) {
+                is ECKey -> "SHA256withECDSA"
+                is RSAKey -> "SHA256withRSA"
+                else ->
+                    throw IllegalArgumentException(
+                        "Unsupported signing key type: ${signingKeyPair.private.javaClass}"
+                    )
             }
         val contentSigner =
             JcaContentSignerBuilder(signerAlgorithm)


### PR DESCRIPTION
The signing algorithm for the leaf certificate must match the signing key's type (from keybox or attestation key), not the subject key's algorithm.

An EC attestation key signing an RSA subject key's certificate would previously select SHA256withRSA (wrong) instead of SHA256withECDSA, producing an invalid or failing certificate.