### PR TITLE
Fix default certificate subject

### DIFF
--- a/app/src/main/java/org/matrix/TEESimulator/pki/CertificateGenerator.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/pki/CertificateGenerator.kt
@@ -217,7 +217,7 @@ object CertificateGenerator {
         uid: Int,
         securityLevel: Int,
     ): Certificate {
-        val subject = params.certificateSubject ?: X500Name("CN=Android KeyStore Key")
+        val subject = params.certificateSubject ?: X500Name("CN=Android Keystore Key")
         val leafNotAfter =
             (signingKeyPair.public as? X509Certificate)?.notAfter
                 ?: Date(System.currentTimeMillis() + 31536000000L)


### PR DESCRIPTION
The AOSP KeyMint reference implementation uses "CN=Android Keystore Key" (lowercase 's') as the default certificate subject when no CERTIFICATE_SUBJECT tag is provided.

Reference: https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/keystore/java/android/security/keystore/KeyGenParameterSpec.java;