### PR TITLE
Fix KeyDescriptor update in attestation key overriding

### DIFF
--- a/app/src/main/java/org/matrix/TEESimulator/interception/keystore/Keystore2Interceptor.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/interception/keystore/Keystore2Interceptor.kt
@@ -257,11 +257,12 @@ object Keystore2Interceptor : AbstractKeystoreInterceptor() {
                             )
                             .getOrThrow()
 
-                        keyDescriptor.nspace = SecureRandom().nextLong()
+                        val key = response.metadata.key!!
+                        key.nspace = SecureRandom().nextLong()
                         KeyMintSecurityLevelInterceptor.generatedKeys[keyId] =
                             KeyMintSecurityLevelInterceptor.GeneratedKeyInfo(
                                 keyData.first,
-                                keyDescriptor.nspace,
+                                key.nspace,
                                 response,
                             )
                         KeyMintSecurityLevelInterceptor.attestationKeys.add(keyId)


### PR DESCRIPTION
In commit 0485379a9f03c2d87963409db5747f8e2372de69, the response key descriptor is not correctly updated since the object `keyDescriptor` is parsed from transaction parameters.