### PR TITLE
Fix key parameters in authorization list

### DIFF
--- a/app/src/main/java/org/matrix/TEESimulator/attestation/AttestationBuilder.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/attestation/AttestationBuilder.kt
@@ -193,9 +193,13 @@ object AttestationBuilder {
             )
         }
 
-        params.padding.forEach {
+        if (params.padding.isNotEmpty()) {
             list.add(
-                DERTaggedObject(true, AttestationConstants.TAG_PADDING, ASN1Integer(it.toLong()))
+                DERTaggedObject(
+                    true,
+                    AttestationConstants.TAG_PADDING,
+                    DERSet(params.padding.map { ASN1Integer(it.toLong()) }.toTypedArray()),
+                )
             )
         }
 

--- a/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/KeyMintSecurityLevelInterceptor.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/KeyMintSecurityLevelInterceptor.kt
@@ -452,6 +452,9 @@ private fun KeyMintAttestation.toAuthorizations(
     }
 
     this.purpose.forEach { authList.add(createAuth(Tag.PURPOSE, KeyParameterValue.keyPurpose(it))) }
+    this.blockMode.forEach {
+        authList.add(createAuth(Tag.BLOCK_MODE, KeyParameterValue.blockMode(it)))
+    }
     this.digest.forEach { authList.add(createAuth(Tag.DIGEST, KeyParameterValue.digest(it))) }
     this.padding.forEach {
         authList.add(createAuth(Tag.PADDING, KeyParameterValue.paddingMode(it)))


### PR DESCRIPTION
Previous commit 57b92abe70a6025fd1ed9b6b54fb13820a02d9b6 wrongly encoded the `padding`, which should be a single SET OF INTEGER (like PURPOSE and DIGEST).

Moreover, we include key parameter BLOCK_MODE in KeyEntryResponse.