### PR TITLE
Support symmetric (AES/HMAC/3DES) key generation

### DIFF
--- a/app/src/main/java/org/matrix/TEESimulator/attestation/KeyMintAttestation.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/attestation/KeyMintAttestation.kt
@@ -41,6 +41,9 @@ data class KeyMintAttestation(
     val manufacturer: ByteArray?,
     val model: ByteArray?,
     val secondImei: ByteArray?,
+    // Operation params (present on createOperation for symmetric ciphers), absent at generateKey.
+    val nonce: ByteArray? = null,
+    val macLength: Int = 0,
 ) {
     /** Secondary constructor that populates the fields by parsing an array of `KeyParameter`. */
     constructor(
@@ -104,6 +107,10 @@ data class KeyMintAttestation(
         manufacturer = params.findBlob(Tag.ATTESTATION_ID_MANUFACTURER),
         model = params.findBlob(Tag.ATTESTATION_ID_MODEL),
         secondImei = params.findBlob(Tag.ATTESTATION_ID_SECOND_IMEI),
+
+        // AOSP: [key_param(tag = NONCE, field = Blob)] / [key_param(tag = MAC_LENGTH, field = Integer)]
+        nonce = params.findBlob(Tag.NONCE),
+        macLength = params.findInteger(Tag.MAC_LENGTH) ?: 0,
     ) {
         // Log all parsed parameters for debugging purposes.
         params.forEach { KeyMintParameterLogger.logParameter(it) }

--- a/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/KeyMintSecurityLevelInterceptor.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/KeyMintSecurityLevelInterceptor.kt
@@ -12,6 +12,7 @@ import java.security.KeyPair
 import java.security.SecureRandom
 import java.security.cert.Certificate
 import java.util.concurrent.ConcurrentHashMap
+import javax.crypto.SecretKey
 import org.matrix.TEESimulator.attestation.AttestationPatcher
 import org.matrix.TEESimulator.attestation.KeyMintAttestation
 import org.matrix.TEESimulator.config.ConfigurationManager
@@ -33,10 +34,12 @@ class KeyMintSecurityLevelInterceptor(
 ) : BinderInterceptor() {
 
     // --- Data Structures for State Management ---
+    // Exactly one of [keyPair] (asymmetric) or [secretKey] (symmetric AES/HMAC/3DES) is set.
     data class GeneratedKeyInfo(
-        val keyPair: KeyPair,
+        val keyPair: KeyPair?,
         val nspace: Long,
         val response: KeyEntryResponse,
+        val secretKey: SecretKey? = null,
     )
 
     override fun onPreTransact(
@@ -211,7 +214,12 @@ class KeyMintSecurityLevelInterceptor(
         val params = data.createTypedArray(KeyParameter.CREATOR)!!
         val parsedParams = KeyMintAttestation(params)
 
-        val softwareOperation = SoftwareOperation(txId, generatedKeyInfo.keyPair, parsedParams)
+        val softwareOperation =
+            if (generatedKeyInfo.secretKey != null) {
+                SoftwareOperation(txId, generatedKeyInfo.secretKey, parsedParams)
+            } else {
+                SoftwareOperation(txId, generatedKeyInfo.keyPair!!, parsedParams)
+            }
         val operationBinder = SoftwareOperationBinder(softwareOperation)
 
         val response =
@@ -246,6 +254,33 @@ class KeyMintSecurityLevelInterceptor(
                         (ConfigurationManager.shouldPatch(callingUid) && isAttestKeyRequest) ||
                         (attestationKey != null &&
                             isAttestationKey(KeyIdentifier(callingUid, attestationKey.alias)))
+
+                if (needsSoftwareGeneration && CertificateGenerator.isSymmetric(parsedParams.algorithm)) {
+                    // Symmetric keys (AES/HMAC/3DES) have no attestation certificate chain.
+                    // e.g. Google Wallet's `google_pay_keyguard_fuse_key` (AES-128, keyguard-bound).
+                    keyDescriptor.nspace = secureRandom.nextLong()
+                    SystemLogger.info(
+                        "Generating software secret key for ${keyDescriptor.alias}[${keyDescriptor.nspace}]."
+                    )
+
+                    val secretKey =
+                        CertificateGenerator.generateSecretKey(parsedParams)
+                            ?: throw Exception("Failed to generate underlying secret key.")
+
+                    val keyId = KeyIdentifier(callingUid, keyDescriptor.alias)
+                    cleanupKeyData(keyId)
+                    val response =
+                        buildSymmetricKeyEntryResponse(callingUid, parsedParams, keyDescriptor)
+                    generatedKeys[keyId] =
+                        GeneratedKeyInfo(
+                            keyPair = null,
+                            nspace = keyDescriptor.nspace,
+                            response = response,
+                            secretKey = secretKey,
+                        )
+
+                    return@runCatching InterceptorUtils.createTypedObjectReply(response.metadata)
+                }
 
                 if (needsSoftwareGeneration) {
                     keyDescriptor.nspace = secureRandom.nextLong()
@@ -317,6 +352,38 @@ class KeyMintSecurityLevelInterceptor(
             }
         CertificateHelper.updateCertificateChain(callingUid, metadata, chain.toTypedArray())
             .getOrThrow()
+        return KeyEntryResponse().apply {
+            this.metadata = metadata
+            iSecurityLevel = original
+        }
+    }
+
+    /**
+     * Constructs a `KeyEntryResponse` for a symmetric key. Unlike asymmetric keys, symmetric keys
+     * carry no attestation certificate chain, so the metadata's certificate/certificateChain are
+     * left null.
+     */
+    private fun buildSymmetricKeyEntryResponse(
+        callingUid: Int,
+        params: KeyMintAttestation,
+        descriptor: KeyDescriptor,
+    ): KeyEntryResponse {
+        val normalizedKeyDescriptor =
+            KeyDescriptor().apply {
+                domain = Domain.KEY_ID
+                nspace = descriptor.nspace
+                alias = null
+                blob = null
+            }
+        val metadata =
+            KeyMetadata().apply {
+                keySecurityLevel = securityLevel
+                key = normalizedKeyDescriptor
+                authorizations = params.toAuthorizations(callingUid, securityLevel)
+                certificate = null
+                certificateChain = null
+                modificationTimeMs = System.currentTimeMillis()
+            }
         return KeyEntryResponse().apply {
             this.metadata = metadata
             iSecurityLevel = original

--- a/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/SoftwareOperation.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/interception/keystore/shim/SoftwareOperation.kt
@@ -8,9 +8,14 @@ import android.hardware.security.keymint.PaddingMode
 import android.os.RemoteException
 import android.system.keystore2.IKeystoreOperation
 import java.security.KeyPair
+import java.security.SecureRandom
 import java.security.Signature
 import java.security.SignatureException
 import javax.crypto.Cipher
+import javax.crypto.Mac
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.IvParameterSpec
 import org.matrix.TEESimulator.attestation.KeyMintAttestation
 import org.matrix.TEESimulator.logging.KeyMintParameterLogger
 import org.matrix.TEESimulator.logging.SystemLogger
@@ -142,31 +147,114 @@ private class CipherPrimitive(
     override fun abort() {}
 }
 
+// Concrete implementation for symmetric Encryption/Decryption (AES / 3DES).
+// Handles the IV/nonce for CBC and GCM block modes. On ENCRYPT the caller does not supply an IV,
+// so one is generated and prepended to the first output chunk (matching KeyMint's behaviour of
+// returning the IV to the client). On DECRYPT the IV/nonce is taken from the operation params.
+private class SecretCipherPrimitive(
+    private val secretKey: SecretKey,
+    private val params: KeyMintAttestation,
+    private val opMode: Int,
+) : CryptoPrimitive {
+    private val blockMode = params.blockMode.firstOrNull()
+    private val transformation = JcaAlgorithmMapper.mapCipherAlgorithm(params)
+    private val cipher: Cipher = Cipher.getInstance(transformation)
+    private var ivEmitted = false
+    private var generatedIv: ByteArray? = null
+
+    init {
+        val needsIv = blockMode == BlockMode.CBC || blockMode == BlockMode.GCM
+        if (opMode == Cipher.ENCRYPT_MODE) {
+            if (needsIv) {
+                val ivLen = if (blockMode == BlockMode.GCM) 12 else 16
+                val iv = ByteArray(ivLen).also { SecureRandom().nextBytes(it) }
+                generatedIv = iv
+                cipher.init(opMode, secretKey, buildSpec(iv))
+            } else {
+                cipher.init(opMode, secretKey)
+            }
+        } else {
+            if (needsIv) {
+                val iv =
+                    params.nonce
+                        ?: throw IllegalArgumentException("Missing IV/nonce for decrypt operation")
+                cipher.init(opMode, secretKey, buildSpec(iv))
+            } else {
+                cipher.init(opMode, secretKey)
+            }
+        }
+    }
+
+    private fun buildSpec(iv: ByteArray) =
+        if (blockMode == BlockMode.GCM) {
+            val macBits = if (params.macLength > 0) params.macLength else 128
+            GCMParameterSpec(macBits, iv)
+        } else {
+            IvParameterSpec(iv)
+        }
+
+    // Prepend the generated IV to the first output produced during an encrypt operation.
+    private fun maybePrependIv(out: ByteArray?): ByteArray? {
+        if (opMode != Cipher.ENCRYPT_MODE || ivEmitted) return out
+        val iv = generatedIv ?: return out
+        ivEmitted = true
+        return iv + (out ?: ByteArray(0))
+    }
+
+    override fun update(data: ByteArray?): ByteArray? =
+        maybePrependIv(if (data != null) cipher.update(data) else null)
+
+    override fun finish(data: ByteArray?, signature: ByteArray?): ByteArray? =
+        maybePrependIv(if (data != null) cipher.doFinal(data) else cipher.doFinal())
+
+    override fun abort() {}
+}
+
+// Concrete implementation for HMAC signing/verification with a symmetric key.
+private class MacPrimitive(secretKey: SecretKey, params: KeyMintAttestation) : CryptoPrimitive {
+    private val mac: Mac =
+        Mac.getInstance(secretKey.algorithm).apply { init(secretKey) }
+
+    override fun update(data: ByteArray?): ByteArray? {
+        if (data != null) mac.update(data)
+        return null
+    }
+
+    override fun finish(data: ByteArray?, signature: ByteArray?): ByteArray? {
+        if (data != null) mac.update(data)
+        val computed = mac.doFinal()
+        // VERIFY passes the expected MAC as `signature`; SIGN returns the computed MAC.
+        if (signature != null) {
+            if (!computed.contentEquals(signature))
+                throw SignatureException("HMAC verification failed")
+            return null
+        }
+        return computed
+    }
+
+    override fun abort() {}
+}
+
 /**
  * A software-only implementation of a cryptographic operation. This class acts as a controller,
  * delegating to a specific cryptographic primitive based on the operation's purpose.
  */
-class SoftwareOperation(private val txId: Long, keyPair: KeyPair, params: KeyMintAttestation) {
-    // This now holds the specific strategy object (Signer, Verifier, etc.)
-    private val primitive: CryptoPrimitive
+class SoftwareOperation
+private constructor(private val txId: Long, private val primitive: CryptoPrimitive) {
 
-    init {
-        // The "Strategy" pattern: choose the implementation based on the purpose.
-        // For simplicity, we only consider the first purpose listed.
-        val purpose = params.purpose.firstOrNull()
-        val purposeName = KeyMintParameterLogger.purposeNames[purpose] ?: "UNKNOWN"
-        SystemLogger.debug("[SoftwareOp TX_ID: $txId] Initializing for purpose: $purposeName.")
+    // Asymmetric (KeyPair-backed) operations: SIGN / VERIFY / ENCRYPT / DECRYPT.
+    constructor(
+        txId: Long,
+        keyPair: KeyPair,
+        params: KeyMintAttestation,
+    ) : this(txId, selectAsymmetricPrimitive(txId, keyPair, params))
 
-        primitive =
-            when (purpose) {
-                KeyPurpose.SIGN -> Signer(keyPair, params)
-                KeyPurpose.VERIFY -> Verifier(keyPair, params)
-                KeyPurpose.ENCRYPT -> CipherPrimitive(keyPair, params, Cipher.ENCRYPT_MODE)
-                KeyPurpose.DECRYPT -> CipherPrimitive(keyPair, params, Cipher.DECRYPT_MODE)
-                else ->
-                    throw UnsupportedOperationException("Unsupported operation purpose: $purpose")
-            }
-    }
+    // Symmetric (SecretKey-backed) operations: AES/3DES cipher + HMAC.
+    constructor(
+        txId: Long,
+        secretKey: SecretKey,
+        params: KeyMintAttestation,
+    ) : this(txId, selectSymmetricPrimitive(txId, secretKey, params))
 
     fun update(data: ByteArray?): ByteArray? {
         try {
@@ -192,6 +280,50 @@ class SoftwareOperation(private val txId: Long, keyPair: KeyPair, params: KeyMin
     fun abort() {
         primitive.abort()
         SystemLogger.debug("[SoftwareOp TX_ID: $txId] Operation aborted.")
+    }
+
+    companion object {
+        private fun logPurpose(txId: Long, params: KeyMintAttestation) {
+            val purpose = params.purpose.firstOrNull()
+            val purposeName = KeyMintParameterLogger.purposeNames[purpose] ?: "UNKNOWN"
+            SystemLogger.debug("[SoftwareOp TX_ID: $txId] Initializing for purpose: $purposeName.")
+        }
+
+        private fun selectAsymmetricPrimitive(
+            txId: Long,
+            keyPair: KeyPair,
+            params: KeyMintAttestation,
+        ): CryptoPrimitive {
+            logPurpose(txId, params)
+            return when (params.purpose.firstOrNull()) {
+                KeyPurpose.SIGN -> Signer(keyPair, params)
+                KeyPurpose.VERIFY -> Verifier(keyPair, params)
+                KeyPurpose.ENCRYPT -> CipherPrimitive(keyPair, params, Cipher.ENCRYPT_MODE)
+                KeyPurpose.DECRYPT -> CipherPrimitive(keyPair, params, Cipher.DECRYPT_MODE)
+                else ->
+                    throw UnsupportedOperationException(
+                        "Unsupported operation purpose: ${params.purpose.firstOrNull()}"
+                    )
+            }
+        }
+
+        private fun selectSymmetricPrimitive(
+            txId: Long,
+            secretKey: SecretKey,
+            params: KeyMintAttestation,
+        ): CryptoPrimitive {
+            logPurpose(txId, params)
+            return when (params.purpose.firstOrNull()) {
+                KeyPurpose.ENCRYPT -> SecretCipherPrimitive(secretKey, params, Cipher.ENCRYPT_MODE)
+                KeyPurpose.DECRYPT -> SecretCipherPrimitive(secretKey, params, Cipher.DECRYPT_MODE)
+                KeyPurpose.SIGN,
+                KeyPurpose.VERIFY -> MacPrimitive(secretKey, params)
+                else ->
+                    throw UnsupportedOperationException(
+                        "Unsupported symmetric operation purpose: ${params.purpose.firstOrNull()}"
+                    )
+            }
+        }
     }
 }
 

--- a/app/src/main/java/org/matrix/TEESimulator/pki/CertificateGenerator.kt
+++ b/app/src/main/java/org/matrix/TEESimulator/pki/CertificateGenerator.kt
@@ -14,6 +14,8 @@ import java.security.interfaces.RSAKey
 import java.security.spec.ECGenParameterSpec
 import java.security.spec.RSAKeyGenParameterSpec
 import java.util.Date
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
 import org.bouncycastle.asn1.x500.X500Name
 import org.bouncycastle.asn1.x509.Extension
 import org.bouncycastle.asn1.x509.KeyUsage
@@ -70,6 +72,44 @@ object CertificateGenerator {
                     .generateKeyPair()
             }
             .onFailure { SystemLogger.error("Failed to generate software key pair.", it) }
+            .getOrNull()
+    }
+
+    /** True for algorithms that produce a symmetric secret key rather than a key pair. */
+    fun isSymmetric(algorithm: Int): Boolean =
+        algorithm == Algorithm.AES ||
+            algorithm == Algorithm.HMAC ||
+            algorithm == Algorithm.TRIPLE_DES
+
+    /**
+     * Generates a software-based symmetric secret key (AES / HMAC / 3DES).
+     *
+     * Symmetric keys have no attestation certificate chain, so callers should return a
+     * [KeyMetadata] with an empty certificate list. Returns `null` on failure.
+     */
+    fun generateSecretKey(params: KeyMintAttestation): SecretKey? {
+        return runCatching {
+                val algorithm =
+                    when (params.algorithm) {
+                        Algorithm.AES -> "AES"
+                        Algorithm.HMAC ->
+                            when (params.digest.firstOrNull()) {
+                                android.hardware.security.keymint.Digest.SHA_2_224 -> "HmacSHA224"
+                                android.hardware.security.keymint.Digest.SHA_2_384 -> "HmacSHA384"
+                                android.hardware.security.keymint.Digest.SHA_2_512 -> "HmacSHA512"
+                                android.hardware.security.keymint.Digest.SHA1 -> "HmacSHA1"
+                                else -> "HmacSHA256"
+                            }
+                        Algorithm.TRIPLE_DES -> "DESede"
+                        else ->
+                            throw IllegalArgumentException(
+                                "Not a symmetric algorithm: ${params.algorithm}"
+                            )
+                    }
+                SystemLogger.debug("Generating $algorithm secret key with size ${params.keySize}")
+                KeyGenerator.getInstance(algorithm).apply { init(params.keySize) }.generateKey()
+            }
+            .onFailure { SystemLogger.error("Failed to generate software secret key.", it) }
             .getOrNull()
     }
 


### PR DESCRIPTION
Fixes #189.

`handleGenerateKey` only handled asymmetric EC/RSA keypairs and threw `IllegalArgumentException` for symmetric algorithms (e.g. AES=32). This broke apps that generate a keyguard-bound symmetric key on a broken TEE — for example Google Wallet's `google_pay_keyguard_fuse_key` (AES-128), which aborted card tokenization with an attestation error.

This adds software generation and operations for symmetric keys: `CertificateGenerator.generateSecretKey()` (AES/HMAC/3DES), a symmetric branch in `handleGenerateKey`/`handleCreateOperation` returning a response with no cert chain, and `SecretCipherPrimitive` (AES CBC/GCM) + `MacPrimitive` (HMAC) in `SoftwareOperation`. Tested on a Moto X4 (payton, Keymaster 3.0): the keyguard key now generates and the tokenization storage-key step passes.