### PR TITLE
Bump androidx.annotation:annotation from 1.9.1 to 1.10.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "8.13.2"
-annotation = "1.9.1"
+annotation = "1.10.0"
 jdk18on = "1.83"
 kotlin = "2.3.0"
 ktfmt = "0.25.0"


### PR DESCRIPTION
Bumps androidx.annotation:annotation from 1.9.1 to 1.10.0.

---
updated-dependencies:
- dependency-name: androidx.annotation:annotation dependency-version: 1.10.0 dependency-type: direct:production update-type: version-update:semver-minor ...