### PR TITLE
Keep KeystoreDb reads working when the settings provider is unreachable

### DIFF
--- a/app/src/main/java/org/matrix/teesim/App.kt
+++ b/app/src/main/java/org/matrix/teesim/App.kt
@@ -168,7 +168,61 @@ object App {
         val field = ActivityThread::class.java.getDeclaredField("mInitialApplication")
         field.isAccessible = true
         field.set(activityThread, app)
+
+        neutralizeSqliteSettingsReads()
         return app
+    }
+
+    /**
+     * Stop SQLiteDatabase from reading device settings on its first open in this process. Planting
+     * mInitialApplication above (so KeyStore/PackageManager see a context) makes
+     * ActivityThread.currentApplication() non-null, and SQLiteDatabase's constructor then reaches into
+     * settings the way a normal app would. Our process is not an AMS-registered app, so on some ROMs
+     * resolving a provider throws ("Unable to find app for caller"), and every openDatabase() — hence
+     * every KeystoreDb read — fails, leaving the WebUI key list empty. We pre-seed the framework's
+     * cached settings so those lookups never run. Two independent reads have to be defused:
+     *
+     * - OnePlus builds have SQLiteGlobal consult a package list (getPkgs/BenchAppList) to pick a sync
+     *   mode. Seeding sDefaultSyncMode to NORMAL short-circuits that before it touches PackageManager.
+     * - Stock SQLiteCompatibilityWalFlags.initIfNeeded() reads Settings.Global.getString() under only a
+     *   try/finally. Marking the class initialised returns early before it touches settings; its
+     *   defaults (no compat-WAL overrides) are exactly what our read-only snapshot reads want.
+     *
+     * Each step is best effort: a framework that lays the class out differently just keeps the old
+     * behaviour.
+     */
+    private fun neutralizeSqliteSettingsReads() {
+        // OnePlus compares the current package against a BenchAppList to decide the sync mode; seeding
+        // sDefaultSyncMode keeps SQLiteGlobal from calling getPkgs() through PackageManager.
+        try {
+            val syncMode =
+                Class.forName("android.database.sqlite.SQLiteGlobal")
+                    .getDeclaredField("sDefaultSyncMode")
+                    .apply { isAccessible = true }
+            if (syncMode.get(null) == null) {
+                syncMode.set(null, "NORMAL")
+                SystemLogger.info("SQLiteGlobal.sDefaultSyncMode seeded NORMAL (skip getPkgs on DB open)")
+            }
+        } catch (e: Throwable) {
+            SystemLogger.verbose("SQLiteGlobal sync-mode guard not applied: ${e.message}")
+        }
+
+        // Stock AOSP settings dependency: present since API 28, absent on some newer builds.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            try {
+                val walFlags = Class.forName("android.database.sqlite.SQLiteCompatibilityWalFlags")
+                // Mark initialised so initIfNeeded() returns before reading Settings.Global.
+                walFlags.getDeclaredField("sInitialized").apply { isAccessible = true }.setBoolean(null, true)
+                // Secondary recursion guard, in case a build reorders the initIfNeeded() short-circuit.
+                walFlags
+                    .getDeclaredField("sCallingGlobalSettings")
+                    .apply { isAccessible = true }
+                    .setBoolean(null, true)
+                SystemLogger.info("SQLiteCompatibilityWalFlags neutralised (skip Settings.Global on DB open)")
+            } catch (e: Throwable) {
+                SystemLogger.warning("Could not neutralise SQLiteCompatibilityWalFlags", e)
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
The daemon plants an `Application` into `ActivityThread.mInitialApplication` so AndroidKeyStore and PackageManager find a context in this bare `app_process`. The side effect is that [`ActivityThread.currentApplication()`](https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/core/java/android/app/ActivityThread.java) stops returning null, so on its first `openDatabase()` `SQLiteDatabase` reaches into device settings the way a normal app would. Our process was never registered with ActivityManager, so on a ROM that refuses a provider to an unknown caller the lookup throws `SecurityException` and it propagates straight out of `openDatabase()`, leaving every KeystoreDb read empty — the WebUI key list, the DB-backed re-attest, and the attest-key purge all see nothing:

```
W KeystoreDb.listKeys failed
W java.lang.SecurityException: Unable to find app for caller ...(pid=3883) when getting content provider settings
W     at android.provider.Settings$Global.getString(Settings.java:18100)
W     at android.database.sqlite.SQLiteCompatibilityWalFlags.initIfNeeded(SQLiteCompatibilityWalFlags.java:105)
W     at android.database.sqlite.SQLiteDatabase.<init>(SQLiteDatabase.java:490)
```

So the list isn't empty because there are no keys — the read never runs.

The fix pre-seeds the framework's cached settings right after `mInitialApplication` is set, so those first-open reads never fire. Two independent reads are defused:

- **OnePlus** builds have [`SQLiteGlobal`](https://cs.android.com/android/platform/superproject/main/+/main:frameworks/base/core/java/android/database/sqlite/SQLiteGlobal.java) consult a package list (`getPkgs`/`BenchAppList`) to pick a sync mode. Seeding `sDefaultSyncMode` to `NORMAL` short-circuits that before it touches PackageManager.
- **Stock** [`SQLiteCompatibilityWalFlags.initIfNeeded()`](https://android.googlesource.com/platform/frameworks/base/+/refs/heads/android15-release/core/java/android/database/sqlite/SQLiteCompatibilityWalFlags.java) reads `Settings.Global.getString()` under only a `try/finally`. Marking the class initialised (and setting the `sCallingGlobalSettings` recursion guard) returns early before it touches settings. Leaving its defaults untouched means no compat-WAL overrides, which is what the read-only snapshot reads assume anyway.

Both steps are best effort and logged: a framework that lays the classes out differently just keeps the old behaviour. Adapted from the proven `applySqliteHelperWorkaround` in LSPatch/core.