### PR TITLE
Honour auth-bound keys and mirror device state to the TA

### DIFF
--- a/keymint/keymint_router.cpp
+++ b/keymint/keymint_router.cpp
@@ -122,6 +122,17 @@ TaPtr DefaultTa() {
   return g_default_ta;
 }
 
+// A snapshot of every configured profile's TA, for device-state transitions (earlyBootEnded /
+// setAdditionalAttestationInfo) that must reach all our keys, not just the default profile. The list
+// is copied under the config lock so the calls themselves run unlocked.
+std::vector<TaPtr> AllProfileTas() {
+  std::lock_guard<std::mutex> lk(g_cfg_mu);
+  std::vector<TaPtr> tas;
+  tas.reserve(g_profiles.size());
+  for (const auto& p : g_profiles) tas.push_back(p.ta);
+  return tas;
+}
+
 // --- AIDL KeyParameter <-> flat KmParam --------------------------------------
 
 KmParam ToKm(const KeyParameter& kp) {
@@ -295,6 +306,34 @@ bool IsAttestKeyRequest(const std::vector<KeyParameter>& params) {
   return false;
 }
 
+// --- auth / timestamp token marshalling --------------------------------------
+
+// Flatten an optional AIDL HardwareAuthToken into the flat C ABI struct. Returns a pointer to
+// `storage` (filled in) when the token is present, or nullptr when absent — exactly the nullability
+// the TA expects. The mac pointer borrows the token's vector, which outlives the FFI call.
+const TsAuthToken* FlattenAuth(const std::optional<HardwareAuthToken>& tok, TsAuthToken* storage) {
+  if (!tok) return nullptr;
+  storage->challenge = tok->challenge;
+  storage->user_id = tok->userId;
+  storage->authenticator_id = tok->authenticatorId;
+  storage->authenticator_type = static_cast<int32_t>(tok->authenticatorType);
+  storage->timestamp_ms = tok->timestamp.milliSeconds;
+  storage->mac = tok->mac.empty() ? nullptr : tok->mac.data();
+  storage->mac_len = tok->mac.size();
+  return storage;
+}
+
+// Flatten an optional secureclock TimeStampToken into the flat C ABI struct (nullptr when absent).
+const TsTimestampToken* FlattenTimestamp(const std::optional<secureclock::TimeStampToken>& tok,
+                                         TsTimestampToken* storage) {
+  if (!tok) return nullptr;
+  storage->challenge = tok->challenge;
+  storage->timestamp_ms = tok->timestamp.milliSeconds;
+  storage->mac = tok->mac.empty() ? nullptr : tok->mac.data();
+  storage->mac_len = tok->mac.size();
+  return storage;
+}
+
 // --- IKeyMintOperation -------------------------------------------------------
 
 class TeesimKeyMintOperation : public BnKeyMintOperation {
@@ -306,18 +345,24 @@ class TeesimKeyMintOperation : public BnKeyMintOperation {
   }
 
   ndk::ScopedAStatus updateAad(const std::vector<uint8_t>& input,
-                               const std::optional<HardwareAuthToken>&,
-                               const std::optional<secureclock::TimeStampToken>&) override {
-    return Status(teesim_km_update_aad(ta_.get(), op_handle_, input.data(), input.size()));
+                               const std::optional<HardwareAuthToken>& authToken,
+                               const std::optional<secureclock::TimeStampToken>& tst) override {
+    TsAuthToken at;
+    TsTimestampToken tt;
+    return Status(teesim_km_update_aad(ta_.get(), op_handle_, input.data(), input.size(),
+                                       FlattenAuth(authToken, &at), FlattenTimestamp(tst, &tt)));
   }
 
   ndk::ScopedAStatus update(const std::vector<uint8_t>& input,
-                            const std::optional<HardwareAuthToken>&,
-                            const std::optional<secureclock::TimeStampToken>&,
+                            const std::optional<HardwareAuthToken>& authToken,
+                            const std::optional<secureclock::TimeStampToken>& tst,
                             std::vector<uint8_t>* out) override {
+    TsAuthToken at;
+    TsTimestampToken tt;
     uint8_t* buf = nullptr;
     size_t len = 0;
-    int32_t rc = teesim_km_update(ta_.get(), op_handle_, input.data(), input.size(), &buf, &len);
+    int32_t rc = teesim_km_update(ta_.get(), op_handle_, input.data(), input.size(),
+                                  FlattenAuth(authToken, &at), FlattenTimestamp(tst, &tt), &buf, &len);
     if (rc != 0) return Status(rc);
     out->assign(buf, buf + len);
     teesim_km_free_buf(buf, len);
@@ -326,18 +371,23 @@ class TeesimKeyMintOperation : public BnKeyMintOperation {
 
   ndk::ScopedAStatus finish(const std::optional<std::vector<uint8_t>>& input,
                             const std::optional<std::vector<uint8_t>>& signature,
-                            const std::optional<HardwareAuthToken>&,
-                            const std::optional<secureclock::TimeStampToken>&,
-                            const std::optional<std::vector<uint8_t>>&,
+                            const std::optional<HardwareAuthToken>& authToken,
+                            const std::optional<secureclock::TimeStampToken>& tst,
+                            const std::optional<std::vector<uint8_t>>& confirmationToken,
                             std::vector<uint8_t>* out) override {
     const uint8_t* in_ptr = input ? input->data() : nullptr;
     size_t in_len = input ? input->size() : 0;
     const uint8_t* sig_ptr = signature ? signature->data() : nullptr;
     size_t sig_len = signature ? signature->size() : 0;
+    const uint8_t* conf_ptr = confirmationToken ? confirmationToken->data() : nullptr;
+    size_t conf_len = confirmationToken ? confirmationToken->size() : 0;
+    TsAuthToken at;
+    TsTimestampToken tt;
     uint8_t* buf = nullptr;
     size_t len = 0;
-    int32_t rc =
-        teesim_km_finish(ta_.get(), op_handle_, in_ptr, in_len, sig_ptr, sig_len, &buf, &len);
+    int32_t rc = teesim_km_finish(ta_.get(), op_handle_, in_ptr, in_len, sig_ptr, sig_len,
+                                  FlattenAuth(authToken, &at), FlattenTimestamp(tst, &tt), conf_ptr,
+                                  conf_len, &buf, &len);
     finished_ = true;
     if (rc != 0) return Status(rc);
     out->assign(buf, buf + len);
@@ -491,9 +541,11 @@ class TeesimKeyMintDevice : public BnKeyMintDevice {
     TaPtr ta = DefaultTa();
     if (!ta) return Status(-100);
     auto km = ToKmVec(params);
+    TsAuthToken at;
     TsBeginResult* res = nullptr;
     int32_t rc = teesim_km_begin(ta.get(), static_cast<int32_t>(purpose), keyBlob.data(),
-                                 keyBlob.size(), km.data(), km.size(), &res);
+                                 keyBlob.size(), km.data(), km.size(), FlattenAuth(authToken, &at),
+                                 &res);
     if (rc != 0) return Status(rc);
     out->challenge = teesim_km_begin_challenge(res);
     size_t n = teesim_km_begin_num_params(res);
@@ -594,6 +646,10 @@ class TeesimKeyMintDevice : public BnKeyMintDevice {
     ForwardGuard g;
     return real_ ? real_->addRngEntropy(data) : ndk::ScopedAStatus::ok();
   }
+  // Wrapped-key import is always forwarded to the real HAL, even for a target app: the result is a
+  // real, unmarked blob whose later operations forward to real hardware, so it is never re-rooted
+  // under the keybox. Simulating it would mean unwrapping with the wrapping key inside our TA, which
+  // we only hold if that wrapping key was itself minted by us — a rare case not worth the surface.
   ndk::ScopedAStatus importWrappedKey(const std::vector<uint8_t>& wrappedKeyData,
                                       const std::vector<uint8_t>& wrappingKeyBlob,
                                       const std::vector<uint8_t>& maskingKey,
@@ -613,6 +669,11 @@ class TeesimKeyMintDevice : public BnKeyMintDevice {
     ForwardGuard g;
     return real_ ? real_->destroyAttestationIds() : ndk::ScopedAStatus::ok();
   }
+  // deviceLocked notifies the HAL that the screen locked, so AUTH_TIMEOUT keys require fresh auth
+  // before the timeout would otherwise expire. Our TA (an Android-14 kmr-ta) models device lock only
+  // at boot (SetBootInfo), not at runtime, so there is nothing to route here: our auth-timeout keys
+  // instead expire on the auth token's own timestamp, checked at begin. We relay to the real HAL for
+  // its own (real hardware) keys.
   ndk::ScopedAStatus deviceLocked(bool passwordOnly,
                                   const std::optional<secureclock::TimeStampToken>& tst) override {
     ForwardGuard g;
@@ -624,6 +685,12 @@ class TeesimKeyMintDevice : public BnKeyMintDevice {
 #pragma clang diagnostic pop
   }
   ndk::ScopedAStatus earlyBootEnded() override {
+    // Latch end-of-early-boot on our keys too, so an EARLY_BOOT_ONLY key we minted stops working at
+    // the same point keystore2 signals the real HAL. Best-effort: a TA that rejects is only logged.
+    for (const auto& ta : AllProfileTas()) {
+      int32_t rc = teesim_km_early_boot_ended(ta.get());
+      if (rc != 0) LOGW("earlyBootEnded: TA rejected (%d)", rc);
+    }
     ForwardGuard g;
     return real_ ? real_->earlyBootEnded() : ndk::ScopedAStatus::ok();
   }
@@ -640,7 +707,15 @@ class TeesimKeyMintDevice : public BnKeyMintDevice {
     ForwardGuard g;
     return real_ ? real_->sendRootOfTrust(rootOfTrust) : ndk::ScopedAStatus::ok();
   }
+  // Record the additional attestation info (e.g. MODULE_HASH on Android 16) on our TAs as well, so a
+  // key we attest carries the same value keystore2 pushes to the real HAL and a verifier that checks
+  // it still validates. Applied to every profile since the info is device-wide; best-effort per TA.
   ndk::ScopedAStatus setAdditionalAttestationInfo(const std::vector<KeyParameter>& info) override {
+    auto km = ToKmVec(info);
+    for (const auto& ta : AllProfileTas()) {
+      int32_t rc = teesim_km_set_additional_attestation_info(ta.get(), km.data(), km.size());
+      if (rc != 0) LOGW("setAdditionalAttestationInfo: TA rejected (%d)", rc);
+    }
     ForwardGuard g;
     return real_ ? real_->setAdditionalAttestationInfo(info) : ndk::ScopedAStatus::ok();
   }

--- a/keystore/keystore_router.cpp
+++ b/keystore/keystore_router.cpp
@@ -662,8 +662,11 @@ bool HandleBegin(int uid, Parcel& in, Parcel* reply) {
   if (!ta) ta = DefaultTa();
   if (!ta) return false;
   TsBeginResult* res = nullptr;
+  // The legacy keystore1 HAL carries auth tokens through its own mechanism, not the flat token structs
+  // the keystore2 path uses, so no auth token is forwarded here yet (unchanged behavior). Auth-bound
+  // keys on Android 10/11 are a separate follow-up; pass nullptr to mean "no token".
   int32_t rc = teesim_km_begin(ta.get(), purpose, blob.data(), blob.size(), op_params.data(),
-                               op_params.size(), &res);
+                               op_params.size(), /*auth_token=*/nullptr, &res);
   if (rc != 0 || !res) {
     LOGE("keystore: TA begin failed rc=%d", rc);
     return false;
@@ -718,7 +721,8 @@ bool HandleUpdate(int /*uid*/, Parcel& in, Parcel* reply) {
 
   uint8_t* out = nullptr;
   size_t out_len = 0;
-  int32_t rc = teesim_km_update(ta.get(), op_handle, input.data(), input.size(), &out, &out_len);
+  int32_t rc = teesim_km_update(ta.get(), op_handle, input.data(), input.size(),
+                                /*auth_token=*/nullptr, /*timestamp_token=*/nullptr, &out, &out_len);
   std::vector<uint8_t> output;
   if (rc == 0 && out) {
     output.assign(out, out + out_len);
@@ -746,7 +750,8 @@ bool HandleFinish(int /*uid*/, Parcel& in, Parcel* reply) {
   uint8_t* out = nullptr;
   size_t out_len = 0;
   int32_t rc = teesim_km_finish(ta.get(), op_handle, nullptr, 0, signature.data(), signature.size(),
-                                &out, &out_len);
+                                /*auth_token=*/nullptr, /*timestamp_token=*/nullptr,
+                                /*confirmation_token=*/nullptr, 0, &out, &out_len);
   std::vector<uint8_t> output;
   if (rc == 0 && out) {
     output.assign(out, out + out_len);

--- a/rust/patches/kmr-ta-authtoken.patch
+++ b/rust/patches/kmr-ta-authtoken.patch
@@ -1,0 +1,39 @@
+diff --git a/ta/src/operation.rs b/ta/src/operation.rs
+index 4975798..37f94ca 100644
+--- a/ta/src/operation.rs
++++ b/ta/src/operation.rs
+@@ -23,7 +23,7 @@ use kmr_wire::{
+     keymint::{HardwareAuthToken, KeyParam},
+     secureclock::{TimeStampToken, Timestamp},
+ };
+-use log::{error, warn};
++use log::{error, info, warn};
+ 
+ mod begin;
+ 
+@@ -392,9 +392,22 @@ impl crate::KeyMintTa {
+         challenge: Option<i64>,
+     ) -> Result<(), Error> {
+         // Common check: confirm the HMAC tag in the token is valid.
+-        let mac_input = crate::hardware_auth_token_mac_input(&auth_token)?;
+-        if !self.verify_device_hmac(&mac_input, &auth_token.mac)? {
+-            return Err(km_err!(KeyUserNotAuthenticated, "failed to authenticate auth_token"));
++        //
++        // TEESimulator: the token is MAC'd by the real Gatekeeper/biometric under the device's
++        // ISharedSecret key. This in-process TA never joins that negotiation (ISharedSecret is not
++        // intercepted), so it holds no device HMAC key and cannot recompute the tag. keystore2 only
++        // attaches a token after the caller has authenticated against the real Gatekeeper, so when we
++        // have no key to verify with, trust the token's presence rather than reject it. Every other
++        // binding below — auth type, secure id, timeout, challenge — is still enforced against the real
++        // token, and an unauthenticated caller carries no token at all. If a device HMAC key is ever
++        // negotiated, verification happens as normal.
++        if self.get_hmac_key().is_some() {
++            let mac_input = crate::hardware_auth_token_mac_input(&auth_token)?;
++            if !self.verify_device_hmac(&mac_input, &auth_token.mac)? {
++                return Err(km_err!(KeyUserNotAuthenticated, "failed to authenticate auth_token"));
++            }
++        } else {
++            info!("no device HMAC key; accepting auth_token on presence (real bindings still checked)");
+         }
+         // Common check: token's auth type should match key's USER_AUTH_TYPE.
+         if (auth_token.authenticator_type as u32 & auth_info.auth_type) == 0 {

--- a/rust/teesim-km/include/teesim_km.h
+++ b/rust/teesim-km/include/teesim_km.h
@@ -45,6 +45,28 @@ typedef struct {
   const uint8_t *model;        size_t model_len;
 } TsDeviceIds;
 
+// A KeyMint HardwareAuthToken flattened for the C ABI, passed (nullable) to begin/update/finish so the
+// TA can honour auth-bound keys. `mac` is the Gatekeeper/biometric HMAC tag (NULL/0 when absent).
+typedef struct {
+  int64_t challenge;
+  int64_t user_id;
+  int64_t authenticator_id;
+  int32_t authenticator_type;  // HardwareAuthenticatorType: 0 None, 1 Password, 2 Fingerprint, -1 Any
+  int64_t timestamp_ms;        // milliseconds since epoch
+  const uint8_t *mac;
+  size_t mac_len;
+} TsAuthToken;
+
+// A secureclock TimeStampToken flattened for the C ABI (nullable), carried alongside update/finish for
+// auth-timeout keys checked on a clockless TA. Our TA has its own clock, but the token is forwarded
+// verbatim so the reference TA behaves exactly as it would on real hardware.
+typedef struct {
+  int64_t challenge;
+  int64_t timestamp_ms;
+  const uint8_t *mac;
+  size_t mac_len;
+} TsTimestampToken;
+
 // --- lifecycle ---------------------------------------------------------------
 
 // Build a TA with the historical default identity (used before any daemon push).
@@ -112,21 +134,32 @@ void teesim_km_free_result(TsCreationResult *res);
 
 // --- begin / operation -------------------------------------------------------
 
+// `auth_token` is nullable: keystore2 attaches it when the key is auth-bound (fingerprint/PIN). The TA
+// checks it at begin for AUTH_TIMEOUT keys and defers to update/finish for auth-per-operation keys.
 int32_t teesim_km_begin(Ta *ta, int32_t purpose, const uint8_t *key_blob,
                         size_t key_blob_len, const KmParam *params,
-                        size_t n_params, TsBeginResult **out);
+                        size_t n_params, const TsAuthToken *auth_token,
+                        TsBeginResult **out);
 int64_t teesim_km_begin_challenge(const TsBeginResult *res);
 int64_t teesim_km_begin_op_handle(const TsBeginResult *res);
 size_t teesim_km_begin_num_params(const TsBeginResult *res);
 void teesim_km_begin_param(const TsBeginResult *res, size_t i, KmParam *out);
 void teesim_km_free_begin(TsBeginResult *res);
 
+// update / updateAad / finish take the same nullable auth + timestamp tokens keystore2 passes, so an
+// auth-per-operation key is re-checked on every invocation. finish also carries the (nullable)
+// confirmation token for TRUSTED_CONFIRMATION_REQUIRED keys.
 int32_t teesim_km_update(Ta *ta, int64_t op_handle, const uint8_t *input,
-                        size_t input_len, uint8_t **out, size_t *out_len);
-int32_t teesim_km_update_aad(Ta *ta, int64_t op_handle, const uint8_t *input, size_t input_len);
+                        size_t input_len, const TsAuthToken *auth_token,
+                        const TsTimestampToken *timestamp_token, uint8_t **out, size_t *out_len);
+int32_t teesim_km_update_aad(Ta *ta, int64_t op_handle, const uint8_t *input, size_t input_len,
+                            const TsAuthToken *auth_token, const TsTimestampToken *timestamp_token);
 int32_t teesim_km_finish(Ta *ta, int64_t op_handle, const uint8_t *input,
                         size_t input_len, const uint8_t *signature,
-                        size_t signature_len, uint8_t **out, size_t *out_len);
+                        size_t signature_len, const TsAuthToken *auth_token,
+                        const TsTimestampToken *timestamp_token,
+                        const uint8_t *confirmation_token, size_t confirmation_token_len,
+                        uint8_t **out, size_t *out_len);
 int32_t teesim_km_abort(Ta *ta, int64_t op_handle);
 
 // --- deleteKey / upgradeKey / getKeyCharacteristics --------------------------
@@ -144,6 +177,16 @@ size_t teesim_km_chars_num(const TsCharacteristics *res);
 size_t teesim_km_chars_entry(const TsCharacteristics *res, size_t ci, int32_t *security_level);
 void teesim_km_chars_param(const TsCharacteristics *res, size_t ci, size_t pi, KmParam *out);
 void teesim_km_free_chars(TsCharacteristics *res);
+
+// --- device state (routed to our TA for our keys) ----------------------------
+
+// Mark early boot as ended: EARLY_BOOT_ONLY keys become unusable afterwards. Applied to each profile
+// TA so our keys observe the same transition keystore2 signals to the real HAL.
+int32_t teesim_km_early_boot_ended(Ta *ta);
+
+// Record additional attestation info (e.g. MODULE_HASH on Android 16) so keys attested by this TA
+// carry it, matching what keystore2 pushes to the real HAL. `info` is a KeyParameter array.
+int32_t teesim_km_set_additional_attestation_info(Ta *ta, const KmParam *info, size_t n_info);
 
 #ifdef __cplusplus
 }

--- a/rust/teesim-km/src/capi.rs
+++ b/rust/teesim-km/src/capi.rs
@@ -13,8 +13,10 @@
 use crate::{Ta, OpError};
 use kmr_wire::cbor::value::{Integer, Value};
 use kmr_wire::keymint::{
-    AttestationKey, KeyCharacteristics, KeyCreationResult, KeyFormat, KeyParam, KeyPurpose,
+    AttestationKey, HardwareAuthToken, HardwareAuthenticatorType, KeyCharacteristics,
+    KeyCreationResult, KeyFormat, KeyParam, KeyPurpose,
 };
+use kmr_wire::secureclock::{TimeStampToken, Timestamp};
 use kmr_wire::AsCborValue;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::slice;
@@ -30,6 +32,59 @@ pub struct KmParam {
     pub int_value: i64,
     pub blob: *const u8,
     pub blob_len: usize,
+}
+
+/// A flattened KeyMint `HardwareAuthToken` (see teesim_km.h). Layout mirrors the C struct.
+#[repr(C)]
+pub struct TsAuthToken {
+    pub challenge: i64,
+    pub user_id: i64,
+    pub authenticator_id: i64,
+    pub authenticator_type: i32,
+    pub timestamp_ms: i64,
+    pub mac: *const u8,
+    pub mac_len: usize,
+}
+
+/// A flattened secureclock `TimeStampToken` (see teesim_km.h). Layout mirrors the C struct.
+#[repr(C)]
+pub struct TsTimestampToken {
+    pub challenge: i64,
+    pub timestamp_ms: i64,
+    pub mac: *const u8,
+    pub mac_len: usize,
+}
+
+/// Rebuild a kmr_wire `HardwareAuthToken` from the flat struct, or `None` when the pointer is null
+/// (keystore2 omits the token for keys that need no user authentication).
+///
+/// # Safety
+/// `tok` is null or points to a valid `TsAuthToken` whose `mac`/`mac_len` describe a readable span.
+unsafe fn auth_token(tok: *const TsAuthToken) -> Option<HardwareAuthToken> {
+    let t = tok.as_ref()?;
+    Some(HardwareAuthToken {
+        challenge: t.challenge,
+        user_id: t.user_id,
+        authenticator_id: t.authenticator_id,
+        // Any unexpected value maps to `Any` rather than failing the whole operation.
+        authenticator_type: HardwareAuthenticatorType::try_from(t.authenticator_type)
+            .unwrap_or(HardwareAuthenticatorType::Any),
+        timestamp: Timestamp { milliseconds: t.timestamp_ms },
+        mac: opt_bytes(t.mac, t.mac_len).unwrap_or_default(),
+    })
+}
+
+/// Rebuild a kmr_wire `TimeStampToken` from the flat struct, or `None` when the pointer is null.
+///
+/// # Safety
+/// `tok` is null or points to a valid `TsTimestampToken` whose `mac`/`mac_len` describe a readable span.
+unsafe fn timestamp_token(tok: *const TsTimestampToken) -> Option<TimeStampToken> {
+    let t = tok.as_ref()?;
+    Some(TimeStampToken {
+        challenge: t.challenge,
+        timestamp: Timestamp { milliseconds: t.timestamp_ms },
+        mac: opt_bytes(t.mac, t.mac_len).unwrap_or_default(),
+    })
 }
 
 // KeyMint TagType bits (top nibble of a tag).
@@ -349,6 +404,7 @@ pub unsafe extern "C" fn teesim_km_begin(
     key_blob_len: usize,
     params: *const KmParam,
     n_params: usize,
+    auth_token_ptr: *const TsAuthToken,
     out: *mut *mut TsBeginResult,
 ) -> i32 {
     match call(|| {
@@ -357,8 +413,9 @@ pub unsafe extern "C" fn teesim_km_begin(
             .ok_or(OpError { code: ERR_UNKNOWN, msg: format!("bad purpose {purpose}") })?;
         let blob = if key_blob.is_null() { &[][..] } else { slice::from_raw_parts(key_blob, key_blob_len) };
         let key_params = to_keyparams(params, n_params)?;
-        // Auth-bound keys are not supported until ISharedSecret is handled.
-        let r = ta.begin(purpose, blob, key_params, None)?;
+        // Forward the auth token keystore2 attached; the TA checks it here for AUTH_TIMEOUT keys and
+        // defers to update/finish for auth-per-operation keys.
+        let r = ta.begin(purpose, blob, key_params, auth_token(auth_token_ptr))?;
         Ok(TsBeginResult {
             challenge: r.challenge,
             op_handle: r.op_handle,
@@ -438,13 +495,15 @@ pub unsafe extern "C" fn teesim_km_update(
     op_handle: i64,
     input: *const u8,
     input_len: usize,
+    auth_token_ptr: *const TsAuthToken,
+    timestamp_token_ptr: *const TsTimestampToken,
     out: *mut *mut u8,
     out_len: *mut usize,
 ) -> i32 {
     match call(|| {
         let ta = &mut *ta;
         let data = if input.is_null() { Vec::new() } else { slice::from_raw_parts(input, input_len).to_vec() };
-        ta.update(op_handle, data, None, None)
+        ta.update(op_handle, data, auth_token(auth_token_ptr), timestamp_token(timestamp_token_ptr))
     }) {
         Ok(bytes) => {
             emit(bytes, out, out_len);
@@ -462,11 +521,13 @@ pub unsafe extern "C" fn teesim_km_update_aad(
     op_handle: i64,
     input: *const u8,
     input_len: usize,
+    auth_token_ptr: *const TsAuthToken,
+    timestamp_token_ptr: *const TsTimestampToken,
 ) -> i32 {
     match call(|| {
         let ta = &mut *ta;
         let data = if input.is_null() { Vec::new() } else { slice::from_raw_parts(input, input_len).to_vec() };
-        ta.update_aad(op_handle, data, None, None)
+        ta.update_aad(op_handle, data, auth_token(auth_token_ptr), timestamp_token(timestamp_token_ptr))
     }) {
         Ok(()) => 0,
         Err(code) => code,
@@ -483,12 +544,23 @@ pub unsafe extern "C" fn teesim_km_finish(
     input_len: usize,
     signature: *const u8,
     signature_len: usize,
+    auth_token_ptr: *const TsAuthToken,
+    timestamp_token_ptr: *const TsTimestampToken,
+    confirmation_token: *const u8,
+    confirmation_token_len: usize,
     out: *mut *mut u8,
     out_len: *mut usize,
 ) -> i32 {
     match call(|| {
         let ta = &mut *ta;
-        ta.finish(op_handle, opt_bytes(input, input_len), opt_bytes(signature, signature_len), None, None, None)
+        ta.finish(
+            op_handle,
+            opt_bytes(input, input_len),
+            opt_bytes(signature, signature_len),
+            auth_token(auth_token_ptr),
+            timestamp_token(timestamp_token_ptr),
+            opt_bytes(confirmation_token, confirmation_token_len),
+        )
     }) {
         Ok(bytes) => {
             emit(bytes, out, out_len);
@@ -503,6 +575,36 @@ pub unsafe extern "C" fn teesim_km_finish(
 #[no_mangle]
 pub unsafe extern "C" fn teesim_km_abort(ta: *mut Ta, op_handle: i64) -> i32 {
     match call(|| (&mut *ta).abort(op_handle)) {
+        Ok(()) => 0,
+        Err(code) => code,
+    }
+}
+
+// --- device state ------------------------------------------------------------
+
+/// # Safety
+/// `ta` is a valid TA handle.
+#[no_mangle]
+pub unsafe extern "C" fn teesim_km_early_boot_ended(ta: *mut Ta) -> i32 {
+    match call(|| (&mut *ta).early_boot_ended()) {
+        Ok(()) => 0,
+        Err(code) => code,
+    }
+}
+
+/// # Safety
+/// `info`/`n_info` describe a readable `KmParam` array (or null/0 for none).
+#[no_mangle]
+pub unsafe extern "C" fn teesim_km_set_additional_attestation_info(
+    ta: *mut Ta,
+    info: *const KmParam,
+    n_info: usize,
+) -> i32 {
+    match call(|| {
+        let ta = &mut *ta;
+        let params = to_keyparams(info, n_info)?;
+        ta.set_additional_attestation_info(params)
+    }) {
         Ok(()) => 0,
         Err(code) => code,
     }

--- a/rust/teesim-km/src/ops.rs
+++ b/rust/teesim-km/src/ops.rs
@@ -13,10 +13,11 @@ use kmr_wire::keymint::{
 use kmr_wire::secureclock::TimeStampToken;
 use kmr_wire::{
     cbor, read_to_value, AbortRequest, AbortResponse, AsCborValue, BeginRequest, BeginResponse,
-    Code, DeleteKeyRequest, DeleteKeyResponse, FinishRequest, FinishResponse, GenerateKeyRequest,
-    GenerateKeyResponse,
+    Code, DeleteKeyRequest, DeleteKeyResponse, EarlyBootEndedRequest, EarlyBootEndedResponse,
+    FinishRequest, FinishResponse, GenerateKeyRequest, GenerateKeyResponse,
     GetKeyCharacteristicsRequest, GetKeyCharacteristicsResponse, ImportKeyRequest, ImportKeyResponse,
-    InternalBeginResult, KeyMintOperation, UpdateAadRequest, UpdateAadResponse, UpdateRequest,
+    InternalBeginResult, KeyMintOperation, SetAdditionalAttestationInfoRequest,
+    SetAdditionalAttestationInfoResponse, UpdateAadRequest, UpdateAadResponse, UpdateRequest,
     UpdateResponse, UpgradeKeyRequest, UpgradeKeyResponse,
 };
 
@@ -225,6 +226,26 @@ impl Ta {
     /// abort an operation.
     pub fn abort(&mut self, op_handle: i64) -> Result<(), OpError> {
         let _: AbortResponse = self.perform(AbortRequest { op_handle })?;
+        Ok(())
+    }
+
+    /// earlyBootEnded: latch the end of early boot so our EARLY_BOOT_ONLY keys stop working, matching
+    /// the transition keystore2 signals to the real HAL.
+    pub fn early_boot_ended(&mut self) -> Result<(), OpError> {
+        log::info!("teesim_km: early_boot_ended");
+        let _: EarlyBootEndedResponse = self.perform(EarlyBootEndedRequest {})?;
+        Ok(())
+    }
+
+    /// setAdditionalAttestationInfo: record info (e.g. MODULE_HASH) that keys attested by this TA must
+    /// carry, so our attestations match what keystore2 pushes to the real HAL.
+    pub fn set_additional_attestation_info(
+        &mut self,
+        info: Vec<KeyParam>,
+    ) -> Result<(), OpError> {
+        log::info!("teesim_km: set_additional_attestation_info: {} param(s)", info.len());
+        let _: SetAdditionalAttestationInfoResponse =
+            self.perform(SetAdditionalAttestationInfoRequest { info })?;
         Ok(())
     }
 


### PR DESCRIPTION
Keys that require user authentication — a fingerprint- or PIN-gated signing or decryption key — failed every operation under a target profile, even in the moment right after the user authenticated. keystore2 hands KeyMint a [HardwareAuthToken](https://cs.android.com/android/platform/superproject/main/+/main:hardware/interfaces/security/keymint/aidl/android/hardware/security/keymint/HardwareAuthToken.aidl) alongside `begin`, `update`, `updateAad` and `finish` for any key carrying `USER_SECURE_ID`, but the interceptor threw it away at both layers: the [IKeyMintOperation](https://cs.android.com/android/platform/superproject/main/+/main:hardware/interfaces/security/keymint/aidl/android/hardware/security/keymint/IKeyMintOperation.aidl) overrides in [keymint_router.cpp](https://github.com/JingMatrix/TEESimulator/blob/fix/auth-token-and-state-plumbing/keymint/keymint_router.cpp) ignored the optional token arguments, and the flat C ABI in [capi.rs](https://github.com/JingMatrix/TEESimulator/blob/fix/auth-token-and-state-plumbing/rust/teesim-km/src/capi.rs) passed `None` in their place. A key minted for a target app in generation mode then failed with `KEY_USER_NOT_AUTHENTICATED`, as seen on an Android 16 device where the user had authenticated by fingerprint (`add_auth_token(..., authType=0x2)`) and keystore2 had attached the token to `finish`, yet the reference TA still rejected the operation with `no auth token on subsequent op`. That check lives in the vendored KeyMint TA's [operation.rs](https://cs.android.com/android/platform/superproject/main/+/main:system/keymint/ta/src/operation.rs), which validates the token at `begin` for `AUTH_TIMEOUT` keys and again on every `update` and `finish` for auth-per-operation keys, so nothing bound to user authentication could complete.

This change threads the token through instead of dropping it. [teesim_km.h](https://github.com/JingMatrix/TEESimulator/blob/fix/auth-token-and-state-plumbing/rust/teesim-km/include/teesim_km.h) gains flat `TsAuthToken` and `TsTimestampToken` structs; the router flattens the AIDL token — and the accompanying [TimeStampToken](https://cs.android.com/android/platform/superproject/main/+/main:hardware/interfaces/security/secureclock/aidl/android/hardware/security/secureclock/TimeStampToken.aidl) — into them, and [capi.rs](https://github.com/JingMatrix/TEESimulator/blob/fix/auth-token-and-state-plumbing/rust/teesim-km/src/capi.rs) rebuilds the `kmr_wire` types that [ops.rs](https://github.com/JingMatrix/TEESimulator/blob/fix/auth-token-and-state-plumbing/rust/teesim-km/src/ops.rs) already accepted. `finish` also carries the confirmation token now, so keys marked `TRUSTED_CONFIRMATION_REQUIRED` work as well.

Forwarding the token is necessary but not sufficient, because the token is MAC'd by the real Gatekeeper under the device's [ISharedSecret](https://cs.android.com/android/platform/superproject/main/+/main:hardware/interfaces/security/sharedsecret/aidl/android/hardware/security/sharedsecret/ISharedSecret.aidl) key, which this in-process TA never negotiated and so cannot recompute. The accompanying [kmr-ta-authtoken.patch](https://github.com/JingMatrix/TEESimulator/blob/fix/auth-token-and-state-plumbing/rust/patches/kmr-ta-authtoken.patch) makes `check_auth_token` skip only the HMAC comparison when no device HMAC key is present, while leaving every other binding intact — authenticator type, secure id, timeout, and challenge are all still checked against the real token. Since keystore2 attaches a token only after genuine authentication, and an unauthenticated caller arrives with no token at all, this trusts the token's presence without weakening what it means. While at the boundary, the change also routes `earlyBootEnded` and `setAdditionalAttestationInfo` to every profile TA, so an `EARLY_BOOT_ONLY` key minted here stops working at the same point keystore2 signals the real HAL, and our attestations carry the `MODULE_HASH` that keystore2 pushes on Android 16.

The behaviour keystore2 relies on is documented in its own [operation.rs](https://cs.android.com/android/platform/superproject/main/+/main:system/security/keystore2/src/operation.rs) and [security_level.rs](https://cs.android.com/android/platform/superproject/main/+/main:system/security/keystore2/src/security_level.rs).
