### PR TITLE
Separate captured harvest state from an editable override layer

### DIFF
--- a/app/src/main/java/org/matrix/teesim/App.kt
+++ b/app/src/main/java/org/matrix/teesim/App.kt
@@ -23,8 +23,14 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider
 object App {
 
     @Volatile private lateinit var appContext: Context
+    // The frozen captured harvest (raw device state + computed default overrides). Never re-merged.
+    @Volatile private lateinit var capturedBase: Harvester.Record
+    // capturedBase with the user's overrides.json layered on — what we present and push. Recomputed on
+    // every resolveAndPush, so an edit to overrides.json (which trips the DATA_DIR watcher) takes effect.
     @Volatile private lateinit var harvest: Harvester.Record
     @Volatile private var lastGoodConfig: ConfigStore.Config? = null
+    // The ro.boot.vbmeta.* values we last pushed to resetprop, so we only re-set them when they change.
+    @Volatile private var lastBootProps: Map<String, String> = emptyMap()
     // Cleared after the first committed push, so the startup-only attest-key purge runs exactly once.
     private val firstCommit = java.util.concurrent.atomic.AtomicBoolean(true)
 
@@ -75,8 +81,10 @@ object App {
 
             Packages.init(appContext)
 
-            // Real-key harvest (frozen verifiedBoot*), persisted to harvested.json.
-            harvest = Harvester.run(appContext)
+            // Real-key harvest (frozen verifiedBoot*), persisted to harvested.json. Then layer the user's
+            // overrides.json over it for the record we actually present.
+            capturedBase = Harvester.run(appContext)
+            harvest = Harvester.applyUserOverrides(capturedBase, OverrideStore.load())
 
             // Key-management endpoint for the WebUI.
             KeyAdmin.start(harvest)
@@ -177,6 +185,12 @@ object App {
      */
     @Synchronized
     private fun resolveAndPush() {
+        // Re-layer the user's overrides.json over the frozen capture — an override edit trips the same
+        // DATA_DIR watcher that calls us, so this is where a changed override becomes live. Refresh the
+        // record the WebUI reads, and reflect any boot key/hash override into ro.boot.vbmeta.*.
+        harvest = Harvester.applyUserOverrides(capturedBase, OverrideStore.load())
+        KeyAdmin.updateHarvest(harvest)
+        applyBootProps(harvest)
         try {
             lastGoodConfig = ConfigStore.load()
         } catch (e: ConfigStore.ConfigException) {
@@ -196,6 +210,24 @@ object App {
         } catch (e: Exception) {
             SystemLogger.error("Failed to resolve/push config", e)
         }
+    }
+
+    /**
+     * When a verifiedBootKey/Hash override is active (only possible when the device reported an all-zero,
+     * unlocked boot value), reflect the spoofed value into the matching ro.boot.vbmeta.* property so that
+     * anything reading those props directly sees what attestation presents. Only re-sets a property when
+     * its value changed, so the package/config watchers don't resetprop on every unrelated event.
+     */
+    private fun applyBootProps(h: Harvester.Record) {
+        val want =
+            Harvester.BOOT_PROP.mapNotNull { (field, prop) ->
+                h.overrides[field]?.value?.takeIf { it.isNotEmpty() }?.let { prop to it }
+            }.toMap()
+        if (want == lastBootProps) return
+        for ((prop, value) in want) {
+            if (lastBootProps[prop] != value) SysProp.set(prop, value)
+        }
+        lastBootProps = want
     }
 
     /** Where the inject binary + native libs live: args[0], else the dex dir, else default. */

--- a/app/src/main/java/org/matrix/teesim/Const.kt
+++ b/app/src/main/java/org/matrix/teesim/Const.kt
@@ -9,6 +9,9 @@ object Const {
 
     val configFile = File(DATA_DIR, "config.json")
     val harvestedFile = File(DATA_DIR, "harvested.json")
+    /** User edits to the harvest override layer (device ids, synthesized levels, an all-zero boot key).
+     *  Written by the WebUI, merged over the frozen captured harvest on every push. */
+    val overridesFile = File(DATA_DIR, "overrides.json")
     val adminTokenFile = File(DATA_DIR, "admin.token")
 
     /** keystore's uid; the control socket only sends the keybox once the peer is it. */

--- a/app/src/main/java/org/matrix/teesim/Harvester.kt
+++ b/app/src/main/java/org/matrix/teesim/Harvester.kt
@@ -81,11 +81,71 @@ object Harvester {
     private const val TAG_ATTESTATION_ID_MODEL = 717
     private const val TAG_ATTESTATION_ID_SECOND_IMEI = 723
 
+    /** Where an override value comes from, which drives its badge and editability in the WebUI. */
+    enum class OverrideSource {
+        /** Structurally forced for attestation to pass (deviceLocked, verifiedBootState, and the boot
+         *  key/hash when the device reported an all-zero one). Locked, except the boot key/hash. */
+        REQUIRED,
+        /** A real device value the attested leaf did not carry (imei/meid/serial), read from the OS. */
+        SUPPLEMENT,
+        /** Synthesized because there is no working hardware (level/version on a software-only device). */
+        SYNTHESIZED,
+    }
+
+    /** One field we present to apps in place of the raw captured value. `value` is the display/wire form
+     *  (hex for the boot key/hash, the plain string otherwise). `editable` is whether the WebUI may change
+     *  it; `userEdited` is whether the live value came from the user's overrides.json rather than the
+     *  daemon's computed default. */
+    data class Override(
+        val value: String,
+        val source: OverrideSource,
+        val editable: Boolean,
+        val userEdited: Boolean = false,
+    )
+
+    /** Device ids the leaf omits but we read from the OS. Shown for transparency but NOT editable here —
+     *  spoofing an id is a per-profile concern (Resolver.resolveProfile lets a profile override each). */
+    private val SUPPLEMENT_IDS = setOf("serial", "imei", "imei2", "meid")
+    /** Level/version values we synthesize on a device with no working hardware — editable. */
+    private val SYNTHESIZED_FIELDS =
+        setOf(
+            "attestationSecurityLevel",
+            "keymasterSecurityLevel",
+            "attestationVersion",
+            "keymasterVersion",
+        )
+    /** The two boot fields the user may edit ONLY when the captured value is all-zero (unlocked device);
+     *  applying an override for either also resetprops the matching ro.boot.vbmeta.* system property. */
+    val BOOT_PROP = mapOf(
+        "verifiedBootKey" to "ro.boot.vbmeta.public_key_digest",
+        "verifiedBootHash" to "ro.boot.vbmeta.digest",
+    )
+
+    private fun sourceFor(field: String): OverrideSource =
+        when {
+            field in SUPPLEMENT_IDS -> OverrideSource.SUPPLEMENT
+            field in SYNTHESIZED_FIELDS -> OverrideSource.SYNTHESIZED
+            else -> OverrideSource.REQUIRED
+        }
+
+    /** Whether a field's override may be edited in the WebUI. Boot key/hash are editable only when the
+     *  device reported an all-zero (unlocked) value; everything required-but-not-boot stays locked. */
+    private fun editableFor(field: String, bootKeyRaw: ByteArray, bootHashRaw: ByteArray): Boolean =
+        when (field) {
+            in SYNTHESIZED_FIELDS -> true
+            "verifiedBootKey" -> !isReal(bootKeyRaw)
+            "verifiedBootHash" -> !isReal(bootHashRaw)
+            else -> false // SUPPLEMENT ids are shown only; per-profile config spoofs them
+        }
+
+    private fun editableFor(field: String, captured: Record): Boolean =
+        editableFor(field, captured.verifiedBootKey, captured.verifiedBootHash)
+
     /** One harvested (or fallback) device-identity record. */
     data class Record(
         val harvestFailed: Boolean,
-        val verifiedBootKey: ByteArray, // 32 bytes, frozen
-        val verifiedBootHash: ByteArray, // 32 bytes, frozen
+        val verifiedBootKey: ByteArray, // 32 bytes, RAW as captured (all-zero on an unlocked device)
+        val verifiedBootHash: ByteArray, // 32 bytes, RAW as captured
         val deviceLocked: Boolean,
         val verifiedBootState: Int, // 0 Verified,1 SelfSigned,2 Unverified,3 Failed
         val attestationSecurityLevel: Int, // 0 SW,1 TEE,2 SB
@@ -104,8 +164,9 @@ object Harvester {
         val vendorPatchLevel: Int?, // YYYYMMDD
         val bootPatchLevel: Int?, // YYYYMMDD
         val moduleHash: ByteArray?,
-        // Device-identity values captured from the attested leaf (empty when the TEE
-        // does not provision that id). Provisioned back so ID attestation can succeed.
+        // Device-identity values captured from the attested leaf, RAW — blank when the leaf did not
+        // carry that id (device-properties attestation omits imei/meid/serial). The value we actually
+        // present for a blank one lives in `overrides` (source SUPPLEMENT), never written back here.
         val brand: String,
         val device: String,
         val product: String,
@@ -115,12 +176,45 @@ object Harvester {
         val imei: String,
         val meid: String,
         val imei2: String,
-        // JSON field names whose value we synthesize (fabricate) for attestation, mapped to
-        // the display value we override them to. The record itself keeps the RAW captured
-        // values; this map lets the WebUI show the overrides separately and honestly.
-        val fabricated: Map<String, String>,
+        // The values we present to apps in place of the raw captured ones, keyed by JSON field name.
+        // The record keeps the RAW capture in the fields above; this map is the honest override layer
+        // the WebUI shows separately (and, for editable fields, lets the user change via overrides.json).
+        val overrides: Map<String, Override>,
         val harvestedAt: Long,
-    )
+    ) {
+        /** The string we actually present for a field: the override when one is active, else the raw
+         *  capture. A blank result (e.g. an unsupplemented, unattested id) means "decline that field". */
+        fun effective(field: String): String =
+            overrides[field]?.value ?: capturedString(field)
+
+        /** The integer we present for a numeric field, or [fallback] when neither override nor capture
+         *  yields a parseable value. */
+        fun effectiveInt(field: String, fallback: Int): Int =
+            overrides[field]?.value?.toIntOrNull() ?: capturedString(field).toIntOrNull() ?: fallback
+
+        /** The 32-byte boot key/hash we actually present: the override (hex) when active — guaranteed
+         *  non-zero — else the raw capture. Used by the config push and ownership check, which must
+         *  never see the all-zero value an unlocked device reports. */
+        fun effectiveBootKey(): ByteArray = effectiveBoot("verifiedBootKey", verifiedBootKey)
+
+        fun effectiveBootHash(): ByteArray = effectiveBoot("verifiedBootHash", verifiedBootHash)
+
+        private fun effectiveBoot(field: String, captured: ByteArray): ByteArray =
+            overrides[field]?.value?.let { hexBytes(it) } ?: captured
+
+        private fun capturedString(field: String): String =
+            when (field) {
+                "serial" -> serial
+                "imei" -> imei
+                "imei2" -> imei2
+                "meid" -> meid
+                "attestationSecurityLevel" -> attestationSecurityLevel.toString()
+                "keymasterSecurityLevel" -> keymasterSecurityLevel.toString()
+                "attestationVersion" -> attestationVersion.toString()
+                "keymasterVersion" -> keymasterVersion.toString()
+                else -> ""
+            }
+    }
 
     // --- Fabricated attestation identity (software-only / TEE-broken devices) --------------------
     // When the device produces no working HARDWARE attestation — a software-only emulator, or a device
@@ -165,20 +259,70 @@ object Harvester {
             else -> attestationVersion
         }
 
-    private fun secLevelName(n: Int): String =
-        (arrayOf("Software", "TrustedEnvironment", "StrongBox").getOrNull(n) ?: "$n") + " ($n)"
+    /** Build the typed default overrides from a raw field->value map, deciding editability against the
+     *  raw captured boot key/hash. `userEdited` is false: these are the daemon's computed defaults. Values
+     *  are the machine form (the level integer, "true", hex) — the WebUI formats them for display. */
+    private fun typedOverrides(
+        values: Map<String, String>,
+        bootKeyRaw: ByteArray,
+        bootHashRaw: ByteArray,
+    ): Map<String, Override> =
+        values.mapValues { (field, value) ->
+            Override(value, sourceFor(field), editableFor(field, bootKeyRaw, bootHashRaw), userEdited = false)
+        }
 
-    /** When there is no working hardware, record the fabricated TrustedEnvironment level + versions in
-     *  the `fabricated` map so the WebUI presents what we hand apps. Raw captured fields stay untouched. */
+    /** Add or replace one computed-default override, keeping the raw captured fields untouched. */
+    private fun Record.withOverride(field: String, value: String): Record =
+        copy(
+            overrides =
+                overrides + (field to Override(value, sourceFor(field), editableFor(field, this))),
+        )
+
+    /**
+     * Layer the user's overrides.json (field -> value) over the daemon's computed defaults, honoring only
+     * editable fields (synthesized levels/versions, and an all-zero boot key/hash) — a hand-edited id or
+     * required field is ignored, since ids are a per-profile concern. A blank value resets a field to its
+     * computed default; an out-of-range value is dropped with a warning. This is what the daemon pushes.
+     */
+    fun applyUserOverrides(base: Record, user: Map<String, String>): Record {
+        if (user.isEmpty()) return base
+        val merged = base.overrides.toMutableMap()
+        for ((field, raw) in user) {
+            if (!editableFor(field, base)) {
+                SystemLogger.info("override: ignoring non-editable field '$field'")
+                continue
+            }
+            val value = raw.trim()
+            when {
+                value.isEmpty() -> Unit // reset: keep the computed default already in `merged`
+                !validOverride(field, value) ->
+                    SystemLogger.warning("override: ignoring invalid $field='$value'")
+                else -> merged[field] = Override(value, sourceFor(field), true, userEdited = true)
+            }
+        }
+        return base.copy(overrides = merged)
+    }
+
+    /** Per-field validation for a user override value (machine form): 64 hex chars for a boot key/hash,
+     *  an in-range level/version. Keeps a bad hand-edit from ever reaching the config push. */
+    private fun validOverride(field: String, value: String): Boolean =
+        when (field) {
+            "verifiedBootKey", "verifiedBootHash" -> hexBytes(value) != null
+            "attestationSecurityLevel", "keymasterSecurityLevel" -> value.toIntOrNull() in 0..2
+            "attestationVersion", "keymasterVersion" -> (value.toIntOrNull() ?: -1) in 1..100_000
+            else -> true
+        }
+
+    /** When there is no working hardware, record the synthesized TrustedEnvironment level + versions as
+     *  overrides so the WebUI presents what we hand apps. Raw captured fields stay untouched. */
     private fun markFabricatedAttestation(r: Record): Record {
         if (!noWorkingHardware(r)) return r
         val (level, version) = effectiveAttestation(r)
-        val fab = r.fabricated.toMutableMap()
-        fab["attestationSecurityLevel"] = secLevelName(level)
-        fab["keymasterSecurityLevel"] = secLevelName(level)
-        fab["attestationVersion"] = version.toString()
-        fab["keymasterVersion"] = keymasterVersionFor(version).toString()
-        return r.copy(fabricated = fab)
+        return r
+            .withOverride("attestationSecurityLevel", level.toString())
+            .withOverride("keymasterSecurityLevel", level.toString())
+            .withOverride("attestationVersion", version.toString())
+            .withOverride("keymasterVersion", keymasterVersionFor(version).toString())
     }
 
     /**
@@ -204,8 +348,10 @@ object Harvester {
                             verifiedBootHash =
                                 if (isReal(existing.verifiedBootHash)) existing.verifiedBootHash
                                 else fresh.verifiedBootHash,
-                            fabricated =
-                                fresh.fabricated.filterKeys { k ->
+                            // When we keep existing's real captured boot value, drop fresh's synthesized
+                            // override for it — the captured value is now honest and needs no override.
+                            overrides =
+                                fresh.overrides.filterKeys { k ->
                                     !(k == "verifiedBootKey" && isReal(existing.verifiedBootKey)) &&
                                         !(k == "verifiedBootHash" && isReal(existing.verifiedBootHash))
                                 },
@@ -264,15 +410,16 @@ object Harvester {
         SystemLogger.info(
             "Harvest telephony IDs: imei='$imei' secondImei='$imei2' meid='$meid' serial='$serial'"
         )
-        // These ids are not carried by device-properties attestation; when the attested leaf had no
-        // value (r.<id> blank) and we supplemented one, it is fabricated rather than captured — record
-        // that so the WebUI shows it honestly. A device that DID attest an id keeps it as captured.
-        val fab = r.fabricated.toMutableMap()
-        if (r.imei.isBlank() && imei.isNotBlank()) fab["imei"] = imei
-        if (r.imei2.isBlank() && imei2.isNotBlank()) fab["imei2"] = imei2
-        if (r.meid.isBlank() && meid.isNotBlank()) fab["meid"] = meid
-        if (r.serial.isBlank() && serial.isNotBlank()) fab["serial"] = serial
-        return r.copy(imei = imei, imei2 = imei2, meid = meid, serial = serial, fabricated = fab)
+        // These ids are not carried by device-properties attestation. When the attested leaf had no value
+        // (r.<id> blank) and we read one from the OS, it is a SUPPLEMENT override — the RAW captured field
+        // stays blank so "Captured" never claims we attested it. A device that DID attest an id keeps it
+        // as a real capture (no override), and the user can still spoof it per-profile.
+        var out = r
+        if (r.imei.isBlank() && imei.isNotBlank()) out = out.withOverride("imei", imei)
+        if (r.imei2.isBlank() && imei2.isNotBlank()) out = out.withOverride("imei2", imei2)
+        if (r.meid.isBlank() && meid.isNotBlank()) out = out.withOverride("meid", meid)
+        if (r.serial.isBlank() && serial.isNotBlank()) out = out.withOverride("serial", serial)
+        return out
     }
 
     /**
@@ -508,17 +655,28 @@ object Harvester {
         }
 
         val fab = mutableMapOf<String, String>()
-        // Always attest a locked, Verified device (an unlocked / unverified state fails
-        // attestation by construction). The record keeps the RAW captured values; these two
-        // are fabricated only when the device's real value differs — a genuinely locked,
-        // Verified device reports them captured, so the map stays empty for them.
+        // Always attest a locked, Verified device (an unlocked / unverified state fails attestation by
+        // construction). The record keeps the RAW captured values; these two get an override only when the
+        // device's real value differs — a genuinely locked, Verified device needs none. Values are the
+        // machine form ("true", "0"); the WebUI formats them for display.
         if (!deviceLocked) fab["deviceLocked"] = "true"
-        if (verifiedBootState != 0) fab["verifiedBootState"] = "Verified (0)"
+        if (verifiedBootState != 0) fab["verifiedBootState"] = "0"
 
-        // When the leaf omits MODULE_HASH (older HAL versions do), deduce it from /apex exactly the
-        // way Android's attestation and keystore2 build it, so a key attested with it still verifies.
-        // A deduced value is not captured from our attestation, so it is marked fabricated.
-        val moduleHash = capturedModuleHash ?: computeModuleHash().also { fab["moduleHash"] = it.toHex() }
+        // The RAW captured boot key/hash, exactly as the leaf reported them (all-zero on an unlocked
+        // device, or absent). We keep the raw bytes in the record and, when they are not usable, add an
+        // editable override carrying the value we actually present (from ro.boot.vbmeta.* or a stable
+        // fallback). The override is editable precisely because the capture was all-zero — see editableFor.
+        val rawBootKey = verifiedBootKey ?: ByteArray(32)
+        val rawBootHash = verifiedBootHash ?: ByteArray(32)
+        defaultBootOverride("ro.boot.vbmeta.public_key_digest", ::fallbackBootKey, rawBootKey)
+            ?.let { fab["verifiedBootKey"] = it }
+        defaultBootOverride("ro.boot.vbmeta.digest", ::fallbackBootHash, rawBootHash)
+            ?.let { fab["verifiedBootHash"] = it }
+
+        // When the leaf omits MODULE_HASH (older HAL versions do), deduce it from /apex exactly the way
+        // Android's attestation and keystore2 build it, so a key attested with it still verifies. The RAW
+        // capture stays null; the deduced value is an override, shown honestly as synthesized.
+        if (capturedModuleHash == null) fab["moduleHash"] = computeModuleHash().toHex()
 
         // Device-identity ids parsed per tag. An empty value means the tag was ABSENT from the leaf —
         // device-properties attestation omits imei/meid/serial — not a parse failure.
@@ -540,10 +698,8 @@ object Harvester {
         )
         return Record(
             harvestFailed = false,
-            verifiedBootKey =
-                resolveBoot(verifiedBootKey, "ro.boot.vbmeta.public_key_digest", ::fallbackBootKey, fab, "verifiedBootKey"),
-            verifiedBootHash =
-                resolveBoot(verifiedBootHash, "ro.boot.vbmeta.digest", ::fallbackBootHash, fab, "verifiedBootHash"),
+            verifiedBootKey = rawBootKey,
+            verifiedBootHash = rawBootHash,
             deviceLocked = deviceLocked,
             verifiedBootState = verifiedBootState,
             attestationSecurityLevel = attestSecLevel,
@@ -556,7 +712,7 @@ object Harvester {
             osPatchLevel = osPatchLevel,
             vendorPatchLevel = vendorPatchLevel,
             bootPatchLevel = bootPatchLevel,
-            moduleHash = moduleHash,
+            moduleHash = capturedModuleHash,
             brand = brand,
             device = device,
             product = product,
@@ -566,7 +722,7 @@ object Harvester {
             imei = imei,
             meid = meid,
             imei2 = imei2,
-            fabricated = fab,
+            overrides = typedOverrides(fab, rawBootKey, rawBootHash),
             harvestedAt = System.currentTimeMillis(),
         )
     }
@@ -768,20 +924,14 @@ object Harvester {
      * stable fallback. Never all-zeros — that is what an unlocked device reports and
      * it fails attestation.
      */
-    private fun resolveBoot(
-        harvested: ByteArray?,
-        prop: String,
-        fallback: () -> ByteArray,
-        fabricated: MutableMap<String, String>,
-        name: String,
-    ): ByteArray {
-        if (isReal(harvested)) return harvested!!
-        hexBytes(DeviceProps.prop(prop, ""))?.let {
-            return it
-        }
-        val synthesized = fallback()
-        fabricated[name] = synthesized.toHex()
-        return synthesized
+    /** The value to present for a boot key/hash when the RAW capture is unusable (all-zero on an unlocked
+     *  device, or absent): the ro.boot.vbmeta.* property if it holds a real 32-byte value, else a stable
+     *  synthesized fallback — returned as hex. Null when the capture is already real, so no override is
+     *  recorded and the honest captured value stands. */
+    private fun defaultBootOverride(prop: String, fallback: () -> ByteArray, raw: ByteArray): String? {
+        if (isReal(raw)) return null
+        hexBytes(DeviceProps.prop(prop, ""))?.let { return it.toHex() }
+        return fallback().toHex()
     }
 
     /** A usable boot value: exactly 32 bytes and not all zero. */
@@ -804,12 +954,16 @@ object Harvester {
         val osPatchLevel = DeviceProps.toYyyymm(DeviceProps.systemSecurityPatch())
         val vendorPatchLevel = DeviceProps.toYyyymmdd(DeviceProps.vendorSecurityPatch())
         val bootPatchLevel = DeviceProps.toYyyymmdd(DeviceProps.vendorSecurityPatch())
+        // Harvest failed: nothing was captured, so every field is raw-empty (all-zero boot bytes, null
+        // moduleHash) and every attestation-critical value we present lives in `overrides`. The WebUI
+        // hides the Captured group entirely when harvestFailed, so only these synthesized values show.
+        val zero = ByteArray(32)
         return Record(
             harvestFailed = true,
-            verifiedBootKey = fallbackBootKey(),
-            verifiedBootHash = fallbackBootHash(),
-            deviceLocked = true,
-            verifiedBootState = 0, // Verified
+            verifiedBootKey = zero,
+            verifiedBootHash = zero,
+            deviceLocked = false,
+            verifiedBootState = 2, // Unverified — nothing was captured
             attestationSecurityLevel = Const.SECLEVEL_TEE,
             keymasterSecurityLevel = Const.SECLEVEL_TEE,
             strongBoxAvailable = false, // no working TEE ⇒ no StrongBox either
@@ -820,7 +974,7 @@ object Harvester {
             osPatchLevel = osPatchLevel,
             vendorPatchLevel = vendorPatchLevel,
             bootPatchLevel = bootPatchLevel,
-            moduleHash = computeModuleHash(),
+            moduleHash = null,
             brand = buildId("ro.product.brand", Build.BRAND),
             device = buildId("ro.product.device", Build.DEVICE),
             product = buildId("ro.product.name", Build.PRODUCT),
@@ -830,18 +984,22 @@ object Harvester {
             imei = "",
             meid = "",
             imei2 = "",
-            // No working TEE: every attestation-critical value is synthesized.
-            fabricated =
-                mapOf(
-                    "deviceLocked" to "true",
-                    "verifiedBootState" to "Verified (0)",
-                    "verifiedBootKey" to fallbackBootKey().toHex(),
-                    "verifiedBootHash" to fallbackBootHash().toHex(),
-                    "osVersion" to osVersion.toString(),
-                    "osPatchLevel" to osPatchLevel.toString(),
-                    "vendorPatchLevel" to vendorPatchLevel.toString(),
-                    "bootPatchLevel" to bootPatchLevel.toString(),
-                    "moduleHash" to computeModuleHash().toHex(),
+            // No working TEE: every attestation-critical value is synthesized (machine form values).
+            overrides =
+                typedOverrides(
+                    mapOf(
+                        "deviceLocked" to "true",
+                        "verifiedBootState" to "0",
+                        "verifiedBootKey" to fallbackBootKey().toHex(),
+                        "verifiedBootHash" to fallbackBootHash().toHex(),
+                        "osVersion" to osVersion.toString(),
+                        "osPatchLevel" to osPatchLevel.toString(),
+                        "vendorPatchLevel" to vendorPatchLevel.toString(),
+                        "bootPatchLevel" to bootPatchLevel.toString(),
+                        "moduleHash" to computeModuleHash().toHex(),
+                    ),
+                    zero,
+                    zero,
                 ),
             harvestedAt = System.currentTimeMillis(),
         )
@@ -882,7 +1040,7 @@ object Harvester {
 
     fun toJson(r: Record): JSONObject =
         JSONObject().apply {
-            put("version", 1)
+            put("version", 2)
             put("harvestFailed", r.harvestFailed)
             put("frozen", !r.harvestFailed)
             put("verifiedBootKey", b64.encodeToString(r.verifiedBootKey))
@@ -909,15 +1067,34 @@ object Harvester {
             put("imei", r.imei)
             put("meid", r.meid)
             put("imei2", r.imei2)
-            put("fabricated", JSONObject(r.fabricated as Map<*, *>))
+            // The override layer, keyed by field. Each carries the machine value we present plus the
+            // metadata the WebUI needs: source (badge), editable (show an input), userEdited (came from
+            // overrides.json vs computed default). The captured fields above stay raw and honest.
+            put(
+                "overrides",
+                JSONObject().apply {
+                    for ((field, ov) in r.overrides) {
+                        put(
+                            field,
+                            JSONObject()
+                                .put("value", ov.value)
+                                .put("source", ov.source.name.lowercase())
+                                .put("editable", ov.editable)
+                                .put("userEdited", ov.userEdited),
+                        )
+                    }
+                },
+            )
             put("harvestedAt", r.harvestedAt)
         }
 
-    private fun fromJson(o: JSONObject): Record =
-        Record(
+    private fun fromJson(o: JSONObject): Record {
+        val bootKey = b64d.decode(o.getString("verifiedBootKey"))
+        val bootHash = b64d.decode(o.getString("verifiedBootHash"))
+        return Record(
             harvestFailed = o.optBoolean("harvestFailed", false),
-            verifiedBootKey = b64d.decode(o.getString("verifiedBootKey")),
-            verifiedBootHash = b64d.decode(o.getString("verifiedBootHash")),
+            verifiedBootKey = bootKey,
+            verifiedBootHash = bootHash,
             deviceLocked = o.optBoolean("deviceLocked", true),
             verifiedBootState = o.optInt("verifiedBootState", 0),
             attestationSecurityLevel = o.optInt("attestationSecurityLevel", Const.SECLEVEL_TEE),
@@ -941,12 +1118,42 @@ object Harvester {
             imei = o.optString("imei", ""),
             meid = o.optString("meid", ""),
             imei2 = o.optString("imei2", ""),
-            fabricated =
-                o.optJSONObject("fabricated")?.let { obj ->
-                    obj.keys().asSequence().associateWith { obj.getString(it) }
-                } ?: emptyMap(),
+            overrides = readOverrides(o, bootKey, bootHash),
             harvestedAt = o.optLong("harvestedAt", System.currentTimeMillis()),
         )
+    }
+
+    /** Rebuild the typed override map from persisted JSON: the v2 `overrides` object, or a legacy v1
+     *  `fabricated` value-map (migrated by re-deriving source/editability). Absent → empty. */
+    private fun readOverrides(o: JSONObject, bootKeyRaw: ByteArray, bootHashRaw: ByteArray): Map<String, Override> {
+        o.optJSONObject("overrides")?.let { obj ->
+            val m = LinkedHashMap<String, Override>()
+            for (field in obj.keys()) {
+                val e = obj.optJSONObject(field)
+                if (e != null) {
+                    val src =
+                        runCatching { OverrideSource.valueOf(e.optString("source", "required").uppercase()) }
+                            .getOrDefault(sourceFor(field))
+                    m[field] =
+                        Override(
+                            e.optString("value", ""),
+                            src,
+                            e.optBoolean("editable", editableFor(field, bootKeyRaw, bootHashRaw)),
+                            e.optBoolean("userEdited", false),
+                        )
+                }
+            }
+            return m
+        }
+        o.optJSONObject("fabricated")?.let { obj ->
+            return typedOverrides(
+                obj.keys().asSequence().associateWith { obj.getString(it) },
+                bootKeyRaw,
+                bootHashRaw,
+            )
+        }
+        return emptyMap()
+    }
 
     private fun JSONObject.optIntOrNull(k: String): Int? =
         if (isNull(k) || !has(k)) null else optInt(k)

--- a/app/src/main/java/org/matrix/teesim/KeyAdmin.kt
+++ b/app/src/main/java/org/matrix/teesim/KeyAdmin.kt
@@ -62,6 +62,16 @@ object KeyAdmin {
     fun start(record: Harvester.Record) {
         harvest = record
         token = newToken()
+        return startInner()
+    }
+
+    /** Swap in a freshly re-merged record after an overrides.json change, so /status reflects the live
+     *  override layer without restarting the daemon. */
+    fun updateHarvest(record: Harvester.Record) {
+        harvest = record
+    }
+
+    private fun startInner() {
         try {
             Const.adminTokenFile.parentFile?.mkdirs()
             Const.adminTokenFile.writeText(token)
@@ -246,7 +256,7 @@ object KeyAdmin {
     private fun listKeys(): JSONObject {
         val ks = androidKeyStore()
         val keys = JSONArray()
-        val ours = harvest?.verifiedBootKey
+        val ours = harvest?.effectiveBootKey()
         val aliases = ks.aliases()
         while (aliases.hasMoreElements()) {
             val alias = aliases.nextElement()

--- a/app/src/main/java/org/matrix/teesim/OverrideStore.kt
+++ b/app/src/main/java/org/matrix/teesim/OverrideStore.kt
@@ -1,0 +1,33 @@
+package org.matrix.teesim
+
+import org.json.JSONObject
+
+/**
+ * The user's edits to the harvest override layer, persisted at [Const.overridesFile]. This is a flat
+ * `{ field: value }` map in the machine form the daemon merges — the level integer, "true"/"false", the
+ * id string, or 64 hex chars for a boot key/hash. An empty value on a supplemented id declines it.
+ *
+ * The captured harvest ([Const.harvestedFile]) stays frozen and honest; this is the ONLY place a user's
+ * chosen value lives, so an edit survives a re-harvest. The WebUI writes it atomically through the same
+ * shell bridge as config.json, so the DATA_DIR FileObserver picks the change up and App.resolveAndPush
+ * re-merges + re-pushes. [Harvester.applyUserOverrides] is what actually validates and layers these on.
+ */
+object OverrideStore {
+
+    /** The persisted user overrides, or empty when the file is absent/unreadable/malformed. Never throws:
+     *  a broken overrides.json must not take the daemon's push path down — it just means "no user edits". */
+    fun load(): Map<String, String> {
+        val f = Const.overridesFile
+        if (!f.exists()) return emptyMap()
+        return try {
+            val o = JSONObject(f.readText())
+            val m = LinkedHashMap<String, String>()
+            for (k in o.keys()) m[k] = o.optString(k, "")
+            SystemLogger.info("Overrides loaded: ${m.keys.joinToString(",").ifEmpty { "(none)" }}")
+            m
+        } catch (e: Exception) {
+            SystemLogger.warning("Could not read overrides.json; ignoring user overrides", e)
+            emptyMap()
+        }
+    }
+}

--- a/app/src/main/java/org/matrix/teesim/Resolver.kt
+++ b/app/src/main/java/org/matrix/teesim/Resolver.kt
@@ -32,23 +32,25 @@ object Resolver {
         msg.put(
             "bootInfo",
             JSONObject().apply {
-                put("verifiedBootKey", b64.encodeToString(harvest.verifiedBootKey))
-                put("verifiedBootHash", b64.encodeToString(harvest.verifiedBootHash))
-                // Always present a locked, Verified boot state. Module users run
-                // unlocked bootloaders, and reporting the device's real state
-                // (unlocked / Unverified) fails attestation by construction. Only
-                // the boot key/hash come from the device (the Harvester guarantees
-                // they are non-zero — a real vbmeta digest or a stable fallback).
+                // Effective boot key/hash: the override when active (an unlocked device's all-zero capture
+                // replaced by ro.boot.vbmeta.*, a stable fallback, or the user's edit), else the real
+                // capture. Never all-zero, so the attested key still verifies.
+                put("verifiedBootKey", b64.encodeToString(harvest.effectiveBootKey()))
+                put("verifiedBootHash", b64.encodeToString(harvest.effectiveBootHash()))
+                // Always present a locked, Verified boot state. Module users run unlocked bootloaders, and
+                // reporting the device's real state (unlocked / Unverified) fails attestation by
+                // construction. These are the "required" overrides the WebUI shows read-only.
                 put("deviceLocked", true)
                 put("verifiedBootState", 0)
                 // Whether the device's StrongBox can really produce a hardware-backed attested key
                 // (probed at harvest). It gates patch mode at the StrongBox level: when false, keys
                 // requested at StrongBox fall back to generation even in a patch profile.
                 put("strongBoxAvailable", harvest.strongBoxAvailable)
-                // The attestationVersion each level reports: the real harvested value on a device that
-                // attested in hardware, or a fabricated OS-appropriate one when there is no working
-                // hardware (software-only / TEE-broken). StrongBox reuses it when it has no hardware.
-                val effVersion = Harvester.effectiveAttestation(harvest).second
+                // The attestationVersion each level reports: the harvested value on a device that attested
+                // in hardware, a synthesized OS-appropriate one with no working hardware, or the user's
+                // override — all captured by effectiveInt over the synthesized default. StrongBox reuses
+                // the TEE value when it has no hardware.
+                val effVersion = harvest.effectiveInt("attestationVersion", Harvester.effectiveAttestation(harvest).second)
                 put("attestVersionTee", effVersion)
                 put(
                     "attestVersionStrongBox",
@@ -83,7 +85,10 @@ object Resolver {
         // Security level is not a profile choice: it is the device's real harvested level, except that
         // a device with no working hardware attestation (software-only / TEE-broken) presents a
         // fabricated TrustedEnvironment so a spoofed key still claims hardware (see effectiveAttestation).
-        o.put("securityLevel", Harvester.effectiveAttestation(harvest).first)
+        o.put(
+            "securityLevel",
+            harvest.effectiveInt("attestationSecurityLevel", Harvester.effectiveAttestation(harvest).first),
+        )
 
         // osVersion: system_property -> the harvested device value, omitted when absent;
         // else the parsed literal, omitted when it can't be parsed. A missing osVersion is
@@ -107,17 +112,17 @@ object Resolver {
             o.put("bootPatchLevel", it)
         }
 
-        // Device IDs: an explicit profile value overrides; otherwise fall back to the real
-        // value captured at harvest, so an app's device-ID attestation request can be
-        // satisfied against the real ids. Omitted when neither is set (declines that id).
+        // Device IDs: an explicit profile value overrides; otherwise fall back to the harvest baseline —
+        // the real captured id, or (for serial/imei/meid, which the leaf never attests) the value read
+        // from the OS at harvest, exposed via effective(). Omitted when neither is set (declines that id).
         val ids = JSONObject()
         putId(ids, "brand", p.brand, harvest.brand)
         putId(ids, "device", p.device, harvest.device)
         putId(ids, "product", p.product, harvest.product)
-        putId(ids, "serial", p.serial, harvest.serial)
-        putId(ids, "imei", p.imei, harvest.imei)
-        putId(ids, "imei2", p.imei2, harvest.imei2)
-        putId(ids, "meid", p.meid, harvest.meid)
+        putId(ids, "serial", p.serial, harvest.effective("serial"))
+        putId(ids, "imei", p.imei, harvest.effective("imei"))
+        putId(ids, "imei2", p.imei2, harvest.effective("imei2"))
+        putId(ids, "meid", p.meid, harvest.effective("meid"))
         putId(ids, "manufacturer", p.manufacturer, harvest.manufacturer)
         putId(ids, "model", p.model, harvest.model)
         if (ids.length() > 0) o.put("deviceIds", ids)

--- a/app/src/main/java/org/matrix/teesim/SysProp.kt
+++ b/app/src/main/java/org/matrix/teesim/SysProp.kt
@@ -1,0 +1,40 @@
+package org.matrix.teesim
+
+/**
+ * Best-effort setter for read-only (`ro.*`) system properties. Plain `setprop` cannot touch `ro.*`, so
+ * this shells out to Magisk's `resetprop -n` (the `-n` skips re-triggering property_service, which is
+ * what lets a read-only prop be overwritten). Used when a user overrides the verified-boot key/hash so
+ * the matching `ro.boot.vbmeta.*` property reflects the spoofed value for anything that reads it directly.
+ *
+ * Never throws — a device without resetprop just leaves the property as-is, logged. The daemon's own
+ * attestation does not depend on these props (it uses the pushed config); this only keeps the visible
+ * system state consistent for other integrity readers.
+ */
+object SysProp {
+
+    /** Overwrite [name] with [value] via the first resetprop invocation that succeeds. Returns whether
+     *  any candidate reported success. Idempotent — safe to call on every push. */
+    fun set(name: String, value: String): Boolean {
+        val candidates =
+            listOf(
+                listOf("resetprop", "-n", name, value),
+                listOf("magisk", "resetprop", "-n", name, value),
+            )
+        for (cmd in candidates) {
+            try {
+                val p = ProcessBuilder(cmd).redirectErrorStream(true).start()
+                val out = p.inputStream.bufferedReader().readText().trim()
+                val code = p.waitFor()
+                if (code == 0) {
+                    SystemLogger.info("SysProp: set $name via '${cmd.first()}'")
+                    return true
+                }
+                SystemLogger.info("SysProp: '${cmd.first()}' exited $code for $name${if (out.isEmpty()) "" else " ($out)"}")
+            } catch (e: Exception) {
+                SystemLogger.info("SysProp: '${cmd.first()}' unavailable: ${e.javaClass.simpleName}: ${e.message}")
+            }
+        }
+        SystemLogger.warning("SysProp: could not set $name (no working resetprop)")
+        return false
+    }
+}

--- a/module/webroot/css/app.css
+++ b/module/webroot/css/app.css
@@ -406,12 +406,16 @@ html, body { overscroll-behavior-y: contain; }
 .kv-stack { flex-direction: column; align-items: stretch; gap: 4px; }
 .kv-stack .kv-label { justify-content: flex-start; }
 .kv-hex { font-family: ui-monospace, monospace; font-size: 12px; word-break: break-all; color: var(--fg); text-align: left; }
+/* A captured value that has a fabricated counterpart: dimmed + struck so it is clear it is what the
+ * device reported but NOT what we present (the presented value shows in the Fabricated group). */
+.kv-replaced .kv-val, .kv-replaced .kv-hex { color: var(--danger); text-decoration: line-through; }
+.kv-replaced .kv-label { color: var(--warn); }
 .harvest-body { display: flex; flex-direction: column; gap: 12px; }
 /* Level selector: the two chips split the line evenly, flat rather than pill-shaped. */
 .harvest-modes { display: flex; gap: 6px; }
 .harvest-modes .chip.clickable { flex: 1; justify-content: center; border-radius: var(--radius); }
 
-/* --- override source badges + inline editor (Harvest > Overrides) -------- */
+/* --- fabricated source badges + inline editor (Harvest > Fabricated) ----- */
 /* A small pill on each override row saying where the value comes from, so Captured vs Overrides reads
  * at a glance without any strike-through: required (forced for attestation), supplement (id read from the
  * OS), synthesized (no working hardware), edited (a user override is active). */

--- a/module/webroot/css/app.css
+++ b/module/webroot/css/app.css
@@ -406,14 +406,28 @@ html, body { overscroll-behavior-y: contain; }
 .kv-stack { flex-direction: column; align-items: stretch; gap: 4px; }
 .kv-stack .kv-label { justify-content: flex-start; }
 .kv-hex { font-family: ui-monospace, monospace; font-size: 12px; word-break: break-all; color: var(--fg); text-align: left; }
-/* A captured value the simulation will override: dimmed + struck so it's clear it isn't
- * what gets attested (the real value shows in the Fabricated group below). */
-.kv-replaced .kv-val, .kv-replaced .kv-hex { color: var(--danger); text-decoration: line-through; }
 .harvest-body { display: flex; flex-direction: column; gap: 12px; }
 /* Level selector: the two chips split the line evenly, flat rather than pill-shaped. */
 .harvest-modes { display: flex; gap: 6px; }
 .harvest-modes .chip.clickable { flex: 1; justify-content: center; border-radius: var(--radius); }
-.kv-replaced .kv-label { color: var(--warn); }
+
+/* --- override source badges + inline editor (Harvest > Overrides) -------- */
+/* A small pill on each override row saying where the value comes from, so Captured vs Overrides reads
+ * at a glance without any strike-through: required (forced for attestation), supplement (id read from the
+ * OS), synthesized (no working hardware), edited (a user override is active). */
+.badge { font-size: 10px; font-weight: 600; letter-spacing: 0.02em; text-transform: uppercase;
+  padding: 1px 6px; border-radius: 999px; border: 1px solid var(--line); color: var(--muted); }
+.badge-required { color: var(--warn); border-color: var(--warn); }
+.badge-supplement { color: var(--accent); border-color: var(--accent); }
+.badge-synthesized { color: var(--danger); border-color: var(--danger); }
+.badge-edited { color: var(--fg); border-color: var(--fg); }
+/* The inline editor for an editable override: input/select on its own line with Save + reset trailing. */
+.ov-edit { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.ov-input { flex: 1 1 160px; min-width: 0; padding: 6px 8px; font: inherit; font-size: 13px;
+  color: var(--fg); background: var(--bg); border: 1px solid var(--line); border-radius: var(--radius); }
+.ov-input.mono { font-family: ui-monospace, monospace; font-size: 12px; }
+.ov-input:focus-visible { outline: 2px solid var(--accent); outline-offset: 0; }
+.btn.small { padding: 5px 10px; font-size: 12px; flex: none; }
 
 /* --- keybox inspector --------------------------------------------------- */
 .kbi-key { gap: 12px; }

--- a/module/webroot/js/bridge/shell.js
+++ b/module/webroot/js/bridge/shell.js
@@ -15,6 +15,7 @@ import { exec } from "./ksu.js";
 export const DIR = "/data/adb/teesim";
 export const CONFIG = DIR + "/config.json";
 export const HARVEST = DIR + "/harvested.json";
+export const OVERRIDES = DIR + "/overrides.json";
 
 // POSIX single-quote one token. Everything between single quotes is literal in
 // the shell except a single quote itself, which we close-escape-reopen as '\''.

--- a/module/webroot/js/controllers/system-controller.js
+++ b/module/webroot/js/controllers/system-controller.js
@@ -13,10 +13,14 @@
 
 import { getStatus } from "../data/status.js";
 import { keyAdmin } from "../data/keyadmin.js";
+import * as overridesIo from "../data/overrides-io.js";
 import { renderSystem, refreshHealth as patchHealthCards } from "../ui/system-view.js";
 import { toast, confirmDialog } from "../ui/dom.js";
 
 const POLL_MS = 5000;
+// How long to wait after writing overrides.json before re-reading status: the daemon's DATA_DIR watcher
+// re-merges and re-pushes, then /status reflects the new override layer. The 5 s poll is the backstop.
+const OVERRIDE_SETTLE_MS = 600;
 
 export function create(mount, opts = {}) {
   const onHealth = opts.onHealth || (() => {});
@@ -58,7 +62,23 @@ export function create(mount, opts = {}) {
     } finally {
       inFlight = false;
     }
-    if (!patchHealthCards(mount, status)) render();
+    if (!patchHealthCards(mount, status, actions)) render();
+  }
+
+  // Persist one override edit to overrides.json, then let the daemon re-merge and re-push before we
+  // re-read status. Writing an empty value (or reset) removes the key so the field falls back to the
+  // daemon's computed default. Never throws to the view — surfaces failures as a toast.
+  async function writeOverride(field, value) {
+    const cur = await overridesIo.load();
+    if (!cur.ok) { toast("Cannot read overrides.json: " + cur.error); return; }
+    const next = { ...cur.overrides };
+    if (value == null || value === "") delete next[field];
+    else next[field] = value;
+    const res = await overridesIo.save(next);
+    if (!res.ok) { toast("Save failed: " + res.error); return; }
+    toast("Override saved — applying…");
+    await new Promise((r) => setTimeout(r, OVERRIDE_SETTLE_MS));
+    await refreshHealth();
   }
 
   // Canary probe: sets the update state and the nav badge. A daemon that is down or
@@ -80,6 +100,10 @@ export function create(mount, opts = {}) {
   }
 
   const actions = {
+    // Harvest override edits (System screen "Overrides" group). Both write overrides.json and refresh.
+    onSaveOverride(field, value) { writeOverride(field, value); },
+    onResetOverride(field) { writeOverride(field, ""); },
+
     onSelectVariant(v) {
       if (v === variant) return;
       variant = v;

--- a/module/webroot/js/controllers/system-controller.js
+++ b/module/webroot/js/controllers/system-controller.js
@@ -76,7 +76,7 @@ export function create(mount, opts = {}) {
     else next[field] = value;
     const res = await overridesIo.save(next);
     if (!res.ok) { toast("Save failed: " + res.error); return; }
-    toast("Override saved — applying…");
+    toast("Fabricated value saved — applying…");
     await new Promise((r) => setTimeout(r, OVERRIDE_SETTLE_MS));
     await refreshHealth();
   }

--- a/module/webroot/js/data/overrides-io.js
+++ b/module/webroot/js/data/overrides-io.js
@@ -1,0 +1,39 @@
+// Disk <-> plain-object adapter for overrides.json — the user's edits to the harvest override layer
+// (synthesized levels/versions, and an all-zero verified-boot key/hash). A flat { field: value } map in
+// the machine form the daemon merges: the level integer, 64 hex chars for a boot key/hash. Ids are NOT
+// written here — spoofing an id is a per-profile concern in config.json.
+//
+// This is the only module that knows overrides live at a path. Values are written verbatim; the daemon
+// (Harvester.applyUserOverrides) validates and ignores anything it does not recognize, so a stale or
+// hand-edited key can never corrupt a push. Written through the same atomic shell bridge as config.json,
+// so the daemon's DATA_DIR watcher re-merges and re-pushes on save.
+
+import { OVERRIDES, readFile, writeFileAtomic, deleteFile } from "../bridge/shell.js";
+
+// Load overrides.json into a plain { field: value } object.
+//   { ok: true,  overrides }   - a plain object (empty when the file is absent)
+//   { ok: false, error }       - present but unparseable (caller must NOT overwrite)
+export async function load() {
+  const raw = await readFile(OVERRIDES);
+  if (!raw || raw.trim() === "") return { ok: true, overrides: {} };
+  let overrides;
+  try {
+    overrides = JSON.parse(raw);
+  } catch (e) {
+    return { ok: false, error: "overrides.json is not valid JSON: " + e.message };
+  }
+  if (!overrides || typeof overrides !== "object" || Array.isArray(overrides)) {
+    return { ok: false, error: "overrides.json root must be a JSON object." };
+  }
+  return { ok: true, overrides };
+}
+
+// Serialize and atomically write. When the map is empty, remove the file so the daemon falls straight
+// back to its computed defaults rather than merging an empty object.
+//   { ok: true } | { ok: false, error }
+export async function save(overrides) {
+  const keys = Object.keys(overrides || {});
+  if (keys.length === 0) return deleteFile(OVERRIDES);
+  const text = JSON.stringify(overrides, null, 2) + "\n";
+  return writeFileAtomic(OVERRIDES, text);
+}

--- a/module/webroot/js/ui/system-view.js
+++ b/module/webroot/js/ui/system-view.js
@@ -151,25 +151,27 @@ function harvestCard(status, actions = {}) {
     }
     capturedBox.appendChild(el("h3", { text: "Captured" }));
     const rows = el("div", { class: "kv-list" });
+    // Show ONLY genuinely captured values. A field the leaf did not carry (null/undefined/empty) gets no
+    // row at all — never a "—" or any other placeholder. Every value passed here is the raw capture.
     const add = (label, val) => {
-      if (val != null && val !== "" && val !== "—") rows.appendChild(kvRow(label, val));
+      if (val != null && val !== "") rows.appendChild(kvRow(label, String(val)));
     };
 
     add("verifiedBootState", h.verifiedBootState == null ? null : named(h.verifiedBootState) + " (" + h.verifiedBootState + ")");
     add("deviceLocked", h.deviceLocked == null ? null : String(h.deviceLocked));
     if (h.verifiedBootKey) hexRow(rows, "verifiedBootKey", h.verifiedBootKey);
     if (h.verifiedBootHash) hexRow(rows, "verifiedBootHash", h.verifiedBootHash);
-    add("osVersion", show(h.osVersion));
-    add("osPatchLevel", show(h.osPatchLevel));
-    add("vendorPatchLevel", show(h.vendorPatchLevel));
-    add("bootPatchLevel", show(h.bootPatchLevel));
+    add("osVersion", h.osVersion);
+    add("osPatchLevel", h.osPatchLevel);
+    add("vendorPatchLevel", h.vendorPatchLevel);
+    add("bootPatchLevel", h.bootPatchLevel);
     // The device has one real captured level. StrongBox reads level 2 only when it actually works;
-    // otherwise it falls back to the captured level, so both chips honestly show that same value.
+    // otherwise it shows the captured level. Only render when the level was actually captured.
     const sbReal = sb && sbAvailable;
-    add("attestationSecurityLevel", secLevel(sbReal ? 2 : h.attestationSecurityLevel));
-    add("keymasterSecurityLevel", secLevel(sbReal ? 2 : h.keymasterSecurityLevel));
-    add("attestationVersion", show(sbReal ? h.strongBoxAttestationVersion : h.attestationVersion));
-    add("keymasterVersion", show(h.keymasterVersion));
+    add("attestationSecurityLevel", h.attestationSecurityLevel == null ? null : secLevel(sbReal ? 2 : h.attestationSecurityLevel));
+    add("keymasterSecurityLevel", h.keymasterSecurityLevel == null ? null : secLevel(sbReal ? 2 : h.keymasterSecurityLevel));
+    add("attestationVersion", sbReal ? h.strongBoxAttestationVersion : h.attestationVersion);
+    add("keymasterVersion", h.keymasterVersion);
     if (h.moduleHash) hexRow(rows, "moduleHash", h.moduleHash);
     // Device identity — only the ids the TEE actually attested (serial/imei are usually absent, and now
     // shown under Overrides as supplements rather than falsely claimed here).
@@ -260,8 +262,6 @@ function fmtOverrideValue(field, value) {
   if (field === "attestationSecurityLevel" || field === "keymasterSecurityLevel") return secLevel(Number(value));
   return String(value);
 }
-
-const show = (v) => (v == null || v === "" ? "—" : String(v));
 
 function secLevel(n) {
   if (n == null || Number.isNaN(n)) return "—";

--- a/module/webroot/js/ui/system-view.js
+++ b/module/webroot/js/ui/system-view.js
@@ -88,14 +88,14 @@ function healthCard(status) {
 // A deliberately honest dump of the device state the daemon harvested, split into two groups.
 // "Captured" is ONLY what the real TEE key generation actually reported (raw, never overwritten): the
 // verified-boot key/hash — shown even when all-zero — lock/boot state, patch and OS levels, security
-// levels, versions, and the device ids the leaf actually carried. "Overrides" is the layer we present
-// on top: values forced for attestation (deviceLocked, Verified), ids read from the OS because the leaf
-// omits them, and, on a device with no working hardware, a synthesized level/version. A value is never
-// shown in both groups — Captured stays truthful, Overrides shows exactly what we change.
+// levels, versions, and the device ids the leaf actually carried. A captured value that we do not present
+// (it has a fabricated counterpart) is struck + red. "Fabricated" is the layer we present on top: values
+// forced for attestation (deviceLocked, Verified), ids read from the OS because the leaf omits them, and,
+// on a device with no working hardware, a synthesized level/version.
 //
-// The overrides the user may edit (synthesized level/version, and an all-zero verified-boot key/hash) get
-// an inline editor; the rest are read-only, badged by source. Ids are shown but not editable here —
-// spoofing an id is a per-profile concern in the profile editor.
+// The fabricated values the user may edit (synthesized level/version, and an all-zero verified-boot
+// key/hash) get an inline editor; the rest are read-only, badged by source. Ids are shown but not editable
+// here — spoofing an id is a per-profile concern in the profile editor (that is what "override" means).
 //
 // The harvest level the user last selected, kept across the status poll so a StrongBox click doesn't snap
 // back to TrustedEnvironment a few seconds later.
@@ -152,15 +152,17 @@ function harvestCard(status, actions = {}) {
     capturedBox.appendChild(el("h3", { text: "Captured" }));
     const rows = el("div", { class: "kv-list" });
     // Show ONLY genuinely captured values. A field the leaf did not carry (null/undefined/empty) gets no
-    // row at all — never a "—" or any other placeholder. Every value passed here is the raw capture.
+    // row at all — never a "—" or any other placeholder. Every value passed here is the raw capture. A
+    // value that has a fabricated counterpart (it is what the device reported but NOT what we present) is
+    // struck + red; the value we present for it shows in the Fabricated group below.
     const add = (label, val) => {
-      if (val != null && val !== "") rows.appendChild(kvRow(label, String(val)));
+      if (val != null && val !== "") rows.appendChild(kvRow(label, String(val), overrides[label] != null));
     };
 
     add("verifiedBootState", h.verifiedBootState == null ? null : named(h.verifiedBootState) + " (" + h.verifiedBootState + ")");
     add("deviceLocked", h.deviceLocked == null ? null : String(h.deviceLocked));
-    if (h.verifiedBootKey) hexRow(rows, "verifiedBootKey", h.verifiedBootKey);
-    if (h.verifiedBootHash) hexRow(rows, "verifiedBootHash", h.verifiedBootHash);
+    if (h.verifiedBootKey) hexRow(rows, "verifiedBootKey", h.verifiedBootKey, overrides["verifiedBootKey"] != null);
+    if (h.verifiedBootHash) hexRow(rows, "verifiedBootHash", h.verifiedBootHash, overrides["verifiedBootHash"] != null);
     add("osVersion", h.osVersion);
     add("osPatchLevel", h.osPatchLevel);
     add("vendorPatchLevel", h.vendorPatchLevel);
@@ -172,7 +174,7 @@ function harvestCard(status, actions = {}) {
     add("keymasterSecurityLevel", h.keymasterSecurityLevel == null ? null : secLevel(sbReal ? 2 : h.keymasterSecurityLevel));
     add("attestationVersion", sbReal ? h.strongBoxAttestationVersion : h.attestationVersion);
     add("keymasterVersion", h.keymasterVersion);
-    if (h.moduleHash) hexRow(rows, "moduleHash", h.moduleHash);
+    if (h.moduleHash) hexRow(rows, "moduleHash", h.moduleHash, overrides["moduleHash"] != null);
     // Device identity — only the ids the TEE actually attested (serial/imei are usually absent, and now
     // shown under Overrides as supplements rather than falsely claimed here).
     for (const key of ["brand", "device", "product", "manufacturer", "model", "serial", "imei", "meid", "imei2"]) {
@@ -188,7 +190,7 @@ function harvestCard(status, actions = {}) {
   return card;
 }
 
-// The Overrides group: every field we present in place of (or absent from) the raw capture, each with a
+// The Fabricated group: every field we present in place of (or absent from) the raw capture, each with a
 // source badge. Editable ones (synthesized level/version, all-zero boot key/hash) get an inline editor.
 function overridesGroup(overrides, actions) {
   const fields = ORDER.filter((f) => overrides[f]).concat(
@@ -196,8 +198,7 @@ function overridesGroup(overrides, actions) {
   );
   if (!fields.length) return null;
   const box = el("div");
-  box.appendChild(el("h3", { text: "Overrides" }));
-  box.appendChild(el("div", { class: "muted small", text: "Values we present to apps in place of the captured ones." }));
+  box.appendChild(el("h3", { text: "Fabricated" }));
   const rows = el("div", { class: "kv-list" });
   for (const field of fields) rows.appendChild(overrideRow(field, overrides[field], actions));
   box.appendChild(rows);
@@ -269,8 +270,8 @@ function secLevel(n) {
   return (typeof n === "number" && names[n] ? names[n] : String(n)) + " (" + n + ")";
 }
 
-function kvRow(label, val) {
-  return el("div", { class: "kv" }, [
+function kvRow(label, val, replaced) {
+  return el("div", { class: "kv" + (replaced ? " kv-replaced" : "") }, [
     el("span", { class: "kv-label", text: label }),
     el("span", { class: "kv-val", text: val }),
   ]);
@@ -278,12 +279,12 @@ function kvRow(label, val) {
 
 // A verified-boot key / hash / module hash: base64 in the record, shown as wrapping hex
 // so the raw bytes are visible. An all-zero value is flagged (it is what an unlocked
-// device reports, and worth spotting).
-function hexRow(rows, label, b64) {
+// device reports, and worth spotting). `replaced` struck + red when it has a fabricated counterpart.
+function hexRow(rows, label, b64, replaced) {
   const hex = b64 ? b64ToHex(b64) : null;
   const allZero = hex != null && hex.length > 0 && /^0+$/.test(hex);
   const flag = allZero ? el("span", { class: "chip warn small", text: "all zero" }) : null;
-  rows.appendChild(el("div", { class: "kv kv-stack" }, [
+  rows.appendChild(el("div", { class: "kv kv-stack" + (replaced ? " kv-replaced" : "") }, [
     el("span", { class: "kv-label" }, [label, flag]),
     el("span", { class: "mono kv-hex", text: hex || "—" }),
   ]));

--- a/module/webroot/js/ui/system-view.js
+++ b/module/webroot/js/ui/system-view.js
@@ -27,21 +27,25 @@ export function renderSystem(mount, state, actions) {
   mount.appendChild(el("div", { class: "panel-head" }, [el("h1", { class: "panel-title", text: "System" })]));
 
   mount.appendChild(tag(healthCard(status), "health"));
-  mount.appendChild(tag(harvestCard(status), "harvest"));
+  mount.appendChild(tag(harvestCard(status, actions), "harvest"));
   mount.appendChild(tag(updateCard({ update, probed, variant, installing, installError, notesOpen }, actions), "update"));
 }
 
 // Patch ONLY the health + harvest cards from a fresh status snapshot, leaving the
 // interactive Update card (and any open disclosure / variant choice / focus) exactly
 // as it is. The 5 s health poll calls this instead of renderSystem so it never tears
-// down the updater. Returns false when the screen hasn't been fully rendered yet
-// (e.g. probed on boot before it's shown), so the caller can fall back to a full render.
-export function refreshHealth(mount, status) {
+// down the updater. The harvest card is skipped while one of its override inputs is
+// focused, so a re-render never wipes a value mid-edit. Returns false when the screen
+// hasn't been fully rendered yet (e.g. probed on boot before it's shown), so the caller
+// can fall back to a full render.
+export function refreshHealth(mount, status, actions) {
   const oldHealth = mount.querySelector('[data-card="health"]');
   const oldHarvest = mount.querySelector('[data-card="harvest"]');
   if (!oldHealth || !oldHarvest) return false;
   oldHealth.replaceWith(tag(healthCard(status), "health"));
-  oldHarvest.replaceWith(tag(harvestCard(status), "harvest"));
+  const active = document.activeElement;
+  const editing = active && active.tagName === "INPUT" && oldHarvest.contains(active);
+  if (!editing) oldHarvest.replaceWith(tag(harvestCard(status, actions), "harvest"));
   return true;
 }
 
@@ -81,33 +85,33 @@ function healthCard(status) {
 }
 
 // --- harvest summary -----------------------------------------------------
-// A deliberately complete, honest dump of the device state the daemon harvested before
-// any simulation, split into two groups. "Captured" is the RAW values read from the real
-// TEE key generation (verified-boot key/hash shown even when all-zero, lock/boot state,
-// patch and OS levels, security levels, versions). "Fabricated" is the values we override
-// or synthesize for attestation — usually deviceLocked and verifiedBootState, since an
-// unlocked / unverified device fails attestation. A debugging view: it shows what the real
-// TEE reported and exactly what the simulation changes on top of it.
-// The harvest level the user last selected, kept across the 5 s status poll's re-render so a click
-// on StrongBox doesn't snap back to TrustedEnvironment a few seconds later.
+// A deliberately honest dump of the device state the daemon harvested, split into two groups.
+// "Captured" is ONLY what the real TEE key generation actually reported (raw, never overwritten): the
+// verified-boot key/hash — shown even when all-zero — lock/boot state, patch and OS levels, security
+// levels, versions, and the device ids the leaf actually carried. "Overrides" is the layer we present
+// on top: values forced for attestation (deviceLocked, Verified), ids read from the OS because the leaf
+// omits them, and, on a device with no working hardware, a synthesized level/version. A value is never
+// shown in both groups — Captured stays truthful, Overrides shows exactly what we change.
+//
+// The overrides the user may edit (synthesized level/version, and an all-zero verified-boot key/hash) get
+// an inline editor; the rest are read-only, badged by source. Ids are shown but not editable here —
+// spoofing an id is a per-profile concern in the profile editor.
+//
+// The harvest level the user last selected, kept across the status poll so a StrongBox click doesn't snap
+// back to TrustedEnvironment a few seconds later.
 let harvestMode = "tee";
 
-function harvestCard(status) {
+function harvestCard(status, actions = {}) {
   const h = status && status.harvest;
   const card = el("div", { class: "card" }, [el("h2", { text: "Harvest" })]);
   if (!status) { card.appendChild(el("p", { class: "muted", text: "—" })); return card; }
   if (!h) { card.appendChild(el("p", { class: "muted", text: "No harvest record yet." })); return card; }
 
-  const failed = h.failed || h.harvestFailed;
-  // fabricated is a map of JSON field name -> the display value we override it to. The
-  // record's own fields hold the RAW captured values, so the two groups stay honest.
-  const fab = (h.fabricated && typeof h.fabricated === "object" && !Array.isArray(h.fabricated)) ? h.fabricated : {};
-  const fabKeys = Object.keys(fab);
+  const failed = !!h.harvestFailed;
+  // overrides: { field: { value, source, editable, userEdited } }. `value` is the machine form (level
+  // integer, "true", hex); the display formatting per field happens in fmtOverrideValue.
+  const overrides = (h.overrides && typeof h.overrides === "object" && !Array.isArray(h.overrides)) ? h.overrides : {};
   const sbAvailable = !!h.strongBoxAvailable;
-  // The two hardware levels a spoofed key can present. We ASK for TrustedEnvironment (the default), and
-  // always offer StrongBox too; there is no Software chip because we never present Software — a device
-  // with no real TEE has its captured Software level fabricated up to TrustedEnvironment (shown struck
-  // in Captured, corrected in Fabricated). Selecting a chip switches the level-specific rows below.
   const modes = [
     { key: "tee", label: "TrustedEnvironment" },
     { key: "strongbox", label: "StrongBox" },
@@ -122,89 +126,151 @@ function harvestCard(status) {
   if (!failed) card.appendChild(el("div", { class: "harvest-modes" }, chipEls));
 
   const body = el("div", { class: "harvest-body" });
+  // Captured is chip-dependent (StrongBox reads a different level), so it is rebuilt on every chip click.
+  // The Overrides group does not depend on the chip and holds the edit inputs, so it is built once and
+  // left untouched — a chip click never tears down a value being typed.
+  const capturedBox = el("div");
+  body.appendChild(capturedBox);
   card.appendChild(body);
 
   function select(m) {
     harvestMode = m;
     modes.forEach((mode, i) => chipEls[i].classList.toggle("selected", mode.key === m));
-    renderBody();
+    renderCaptured();
   }
 
-  function renderBody() {
-    body.replaceChildren();
+  function renderCaptured() {
+    capturedBox.replaceChildren();
     const sb = harvestMode === "strongbox";
     if (failed) {
-      body.appendChild(el("div", { class: "muted small", text: "No key was attestable (common on certain models after unlocking the bootloader), so every value below is synthesized rather than captured from a real TEE." }));
-    } else if (sb && !sbAvailable) {
-      body.appendChild(el("div", { class: "muted small", text: "StrongBox has no working hardware on this device; keys requested at StrongBox are generated (not patched) at the TEE version." }));
+      capturedBox.appendChild(el("div", { class: "muted small", text: "No key was attestable (common on certain models after unlocking the bootloader), so nothing was captured — every value below is synthesized." }));
+      return;
     }
-
-    // Captured: the real values read from the device, shown honestly — only when actually captured (no
-    // placeholders), and nothing at all when the harvest failed (everything is then fabricated below).
-    // A value we override for attestation (present in `fab`) is shown struck, to signal it is replaced.
-    if (!failed) {
-      body.appendChild(el("h3", { text: "Captured" }));
-      const rows = el("div", { class: "kv-list" });
-      const add = (label, val) => {
-        if (val != null && val !== "" && val !== "—")
-          rows.appendChild(kvRow(label, val, fab[label] !== undefined));
-      };
-
-      add("verifiedBootState", h.verifiedBootState == null ? null : named(h.verifiedBootState) + " (" + h.verifiedBootState + ")");
-      add("deviceLocked", h.deviceLocked == null ? null : String(h.deviceLocked));
-      if (h.verifiedBootKey) hexRow(rows, "verifiedBootKey", h.verifiedBootKey, fab["verifiedBootKey"] !== undefined);
-      if (h.verifiedBootHash) hexRow(rows, "verifiedBootHash", h.verifiedBootHash, fab["verifiedBootHash"] !== undefined);
-      add("osVersion", show(h.osVersion));
-      add("osPatchLevel", show(h.osPatchLevel));
-      add("vendorPatchLevel", show(h.vendorPatchLevel));
-      add("bootPatchLevel", show(h.bootPatchLevel));
-      // The device has one real captured level. StrongBox reads level 2 only when it actually works;
-      // otherwise it falls back to the captured level (Software on a device with no secure element), so
-      // both chips honestly show that same captured value.
-      const sbReal = sb && sbAvailable;
-      add("attestationSecurityLevel", secLevel(sbReal ? 2 : h.attestationSecurityLevel));
-      add("keymasterSecurityLevel", secLevel(sbReal ? 2 : h.keymasterSecurityLevel));
-      add("attestationVersion", show(sbReal ? h.strongBoxAttestationVersion : h.attestationVersion));
-      add("keymasterVersion", show(h.keymasterVersion));
-      if (h.moduleHash) hexRow(rows, "moduleHash", h.moduleHash, fab["moduleHash"] !== undefined);
-      // Device identity captured for ID attestation (only the ids the TEE actually provided).
-      for (const key of ["brand", "device", "product", "manufacturer", "model", "serial", "imei", "meid", "imei2"]) {
-        if (h[key]) add(key, h[key]);
-      }
-      if (h.harvestedAt) add("harvestedAt", fmtTime(h.harvestedAt));
-      body.appendChild(rows);
+    if (sb && !sbAvailable) {
+      capturedBox.appendChild(el("div", { class: "muted small", text: "StrongBox has no working hardware on this device; keys requested at StrongBox are generated (not patched) at the TEE version." }));
     }
+    capturedBox.appendChild(el("h3", { text: "Captured" }));
+    const rows = el("div", { class: "kv-list" });
+    const add = (label, val) => {
+      if (val != null && val !== "" && val !== "—") rows.appendChild(kvRow(label, val));
+    };
 
-    // Fabricated: the values we present to apps in place of the captured ones. The security level is the
-    // level of the chip being viewed — we present both TrustedEnvironment and StrongBox; the versions and
-    // the device ids are the same for both.
-    if (fabKeys.length) {
-      body.appendChild(el("h3", { text: "Fabricated" }));
-      body.appendChild(el("div", { class: "muted small", text: "Values we present to apps in place of the captured ones." }));
-      const fabRows = el("div", { class: "kv-list" });
-      const fabLevel = secLevel(sb ? 2 : 1);
-      for (const key of fabKeys) {
-        const isLevel = key === "attestationSecurityLevel" || key === "keymasterSecurityLevel";
-        fabRows.appendChild(kvRow(key, isLevel ? fabLevel : show(fab[key])));
-      }
-      body.appendChild(fabRows);
+    add("verifiedBootState", h.verifiedBootState == null ? null : named(h.verifiedBootState) + " (" + h.verifiedBootState + ")");
+    add("deviceLocked", h.deviceLocked == null ? null : String(h.deviceLocked));
+    if (h.verifiedBootKey) hexRow(rows, "verifiedBootKey", h.verifiedBootKey);
+    if (h.verifiedBootHash) hexRow(rows, "verifiedBootHash", h.verifiedBootHash);
+    add("osVersion", show(h.osVersion));
+    add("osPatchLevel", show(h.osPatchLevel));
+    add("vendorPatchLevel", show(h.vendorPatchLevel));
+    add("bootPatchLevel", show(h.bootPatchLevel));
+    // The device has one real captured level. StrongBox reads level 2 only when it actually works;
+    // otherwise it falls back to the captured level, so both chips honestly show that same value.
+    const sbReal = sb && sbAvailable;
+    add("attestationSecurityLevel", secLevel(sbReal ? 2 : h.attestationSecurityLevel));
+    add("keymasterSecurityLevel", secLevel(sbReal ? 2 : h.keymasterSecurityLevel));
+    add("attestationVersion", show(sbReal ? h.strongBoxAttestationVersion : h.attestationVersion));
+    add("keymasterVersion", show(h.keymasterVersion));
+    if (h.moduleHash) hexRow(rows, "moduleHash", h.moduleHash);
+    // Device identity — only the ids the TEE actually attested (serial/imei are usually absent, and now
+    // shown under Overrides as supplements rather than falsely claimed here).
+    for (const key of ["brand", "device", "product", "manufacturer", "model", "serial", "imei", "meid", "imei2"]) {
+      if (h[key]) add(key, h[key]);
     }
+    if (h.harvestedAt) add("harvestedAt", fmtTime(h.harvestedAt));
+    capturedBox.appendChild(rows);
   }
 
   select(harvestMode);
+  const ov = overridesGroup(overrides, actions);
+  if (ov) body.appendChild(ov);
   return card;
+}
+
+// The Overrides group: every field we present in place of (or absent from) the raw capture, each with a
+// source badge. Editable ones (synthesized level/version, all-zero boot key/hash) get an inline editor.
+function overridesGroup(overrides, actions) {
+  const fields = ORDER.filter((f) => overrides[f]).concat(
+    Object.keys(overrides).filter((f) => !ORDER.includes(f)),
+  );
+  if (!fields.length) return null;
+  const box = el("div");
+  box.appendChild(el("h3", { text: "Overrides" }));
+  box.appendChild(el("div", { class: "muted small", text: "Values we present to apps in place of the captured ones." }));
+  const rows = el("div", { class: "kv-list" });
+  for (const field of fields) rows.appendChild(overrideRow(field, overrides[field], actions));
+  box.appendChild(rows);
+  return box;
+}
+
+// A stable, readable order for the override rows (unknown fields fall to the end).
+const ORDER = [
+  "deviceLocked", "verifiedBootState", "verifiedBootKey", "verifiedBootHash",
+  "attestationSecurityLevel", "keymasterSecurityLevel", "attestationVersion", "keymasterVersion",
+  "moduleHash", "osVersion", "osPatchLevel", "vendorPatchLevel", "bootPatchLevel",
+  "serial", "imei", "imei2", "meid",
+];
+
+const SOURCE_LABEL = { required: "required", supplement: "supplement", synthesized: "synthesized" };
+const HEX_FIELDS = new Set(["verifiedBootKey", "verifiedBootHash", "moduleHash"]);
+
+function overrideRow(field, o, actions) {
+  const badge = el("span", { class: "badge badge-" + (o.source || "required"), text: SOURCE_LABEL[o.source] || o.source || "" });
+  const edited = o.userEdited ? el("span", { class: "badge badge-edited", text: "edited" }) : null;
+  const label = el("span", { class: "kv-label" }, [field, badge, edited]);
+
+  if (!o.editable) {
+    const val = el("span", { class: "kv-val" + (HEX_FIELDS.has(field) ? " mono kv-hex" : ""), text: fmtOverrideValue(field, o.value) });
+    return el("div", { class: "kv" + (HEX_FIELDS.has(field) ? " kv-stack" : "") }, [label, val]);
+  }
+
+  // Editable: an inline editor + Save, and Reset (revert to the computed default) when user-edited.
+  const input = editorFor(field, o.value);
+  const save = el("button", {
+    class: "btn small", type: "button",
+    onclick: () => actions.onSaveOverride && actions.onSaveOverride(field, String(input.value).trim()),
+  }, "Save");
+  const reset = o.userEdited
+    ? el("button", { class: "linklike small", type: "button", onclick: () => actions.onResetOverride && actions.onResetOverride(field) }, "reset")
+    : null;
+  return el("div", { class: "kv kv-stack" }, [label, el("div", { class: "ov-edit" }, [input, save, reset])]);
+}
+
+// The right input for an editable field: a level picker, a version number, or a 64-hex boot value.
+function editorFor(field, value) {
+  if (field === "attestationSecurityLevel" || field === "keymasterSecurityLevel") {
+    const sel = el("select", { class: "ov-input" });
+    for (const [n, name] of [[0, "Software"], [1, "TrustedEnvironment"], [2, "StrongBox"]]) {
+      const opt = el("option", { value: String(n), text: name + " (" + n + ")" });
+      if (String(n) === String(value)) opt.selected = true;
+      sel.appendChild(opt);
+    }
+    return sel;
+  }
+  if (HEX_FIELDS.has(field)) {
+    return el("input", { class: "ov-input mono", type: "text", value: value || "", maxlength: "64",
+      spellcheck: "false", autocapitalize: "none", placeholder: "64 hex chars" });
+  }
+  return el("input", { class: "ov-input", type: "number", inputmode: "numeric", value: value || "" });
+}
+
+// Display formatting for an override's machine value, by field.
+function fmtOverrideValue(field, value) {
+  if (value == null || value === "") return "—";
+  if (field === "verifiedBootState") return named(Number(value)) + " (" + value + ")";
+  if (field === "attestationSecurityLevel" || field === "keymasterSecurityLevel") return secLevel(Number(value));
+  return String(value);
 }
 
 const show = (v) => (v == null || v === "" ? "—" : String(v));
 
 function secLevel(n) {
-  if (n == null) return "—";
+  if (n == null || Number.isNaN(n)) return "—";
   const names = ["Software", "TrustedEnvironment", "StrongBox"];
   return (typeof n === "number" && names[n] ? names[n] : String(n)) + " (" + n + ")";
 }
 
-function kvRow(label, val, replaced) {
-  return el("div", { class: "kv" + (replaced ? " kv-replaced" : "") }, [
+function kvRow(label, val) {
+  return el("div", { class: "kv" }, [
     el("span", { class: "kv-label", text: label }),
     el("span", { class: "kv-val", text: val }),
   ]);
@@ -213,11 +279,11 @@ function kvRow(label, val, replaced) {
 // A verified-boot key / hash / module hash: base64 in the record, shown as wrapping hex
 // so the raw bytes are visible. An all-zero value is flagged (it is what an unlocked
 // device reports, and worth spotting).
-function hexRow(rows, label, b64, replaced) {
+function hexRow(rows, label, b64) {
   const hex = b64 ? b64ToHex(b64) : null;
   const allZero = hex != null && hex.length > 0 && /^0+$/.test(hex);
   const flag = allZero ? el("span", { class: "chip warn small", text: "all zero" }) : null;
-  rows.appendChild(el("div", { class: "kv kv-stack" + (replaced ? " kv-replaced" : "") }, [
+  rows.appendChild(el("div", { class: "kv kv-stack" }, [
     el("span", { class: "kv-label" }, [label, flag]),
     el("span", { class: "mono kv-hex", text: hex || "—" }),
   ]));


### PR DESCRIPTION
The harvest record conflated two things: what the TEE actually attested, and what the module presents on top of it. Supplemented ids and the resolved boot key were written back over the captured fields, so the WebUI listed values under "Captured" that the leaf never carried — struck through, as though a genuine capture were being replaced.

Split the two. Each field now holds only what the leaf carried; anything it omitted — an id, a module hash — is absent from Captured entirely, and the value we compute for attestation appears only as a synthesized override. A typed override map carries what we present, each entry tagged required, supplement, or synthesized; the effective value is override-or-capture, resolved only where consumed.

Overrides persist in overrides.json and merge over the frozen capture on every push. Only synthesized levels and an all-zero boot key/hash are editable — ids remain per-profile, lock state stays forced — and a boot key/hash edit also resetprops the matching ro.boot.vbmeta property.

The panel now shows the capture exactly as taken, with the override layer beside it.
