### PR TITLE
Add a device-aware picker for a profile's target apps

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -51,9 +51,21 @@ Once the framework is up, `App.main` wires the daemon and enters `Looper.loop()`
    regardless of package. The record is cached to `harvested.json`, and each parsed field is logged.
 2. **`ConfigStore`** parses, validates, and `FileObserver`-watches `config.json`; **`Resolver`**
    turns a validated config plus the frozen harvest, system properties, and the clock into the
-   full-replace `config` message the native lib applies — resolving package names to uids
-   (**`Packages`**), the patch mini-language, and the harvested device ids and security level.
+   full-replace `config` message the native lib applies — resolving the profile's targets via
+   **`Scope`**, the patch mini-language, and the harvested device ids and security level.
    **`PackageWatch`** re-resolves and re-pushes on `PACKAGE_ADDED/REMOVED/REPLACED`.
+
+   **`Scope`** is the one place a profile's `apps[]` becomes the two wire arrays the native router
+   matches on — `packages[]` (attestation package-name match, kept verbatim so a not-yet-installed
+   name still matches once the app lands) and `uids[]` (caller-uid match, the effective set with no
+   `-1`). An `apps[]` entry is a package name, an advanced `uid:N` token that targets a caller uid
+   directly (for a shared-uid app or one whose package is unknown), or — per profile —
+   `autoIncludeNewApps`, which folds in only apps installed AFTER a one-time baseline snapshot
+   (`known_packages.json`, seeded from the currently-installed set the first time the daemon runs), so
+   genuinely new apps are covered without an edit while existing apps are never silently captured. Every
+   entry is logged as it resolves (`Scope[<id>]: 'com.foo' -> uid 10123`, `-> NOT INSTALLED (dropped)`),
+   and a uid below the app range (a `shell`/`system_server`-style uid) is flagged with a warning — the
+   instrumentation that makes "which app is actually intercepted" answerable from the log.
 3. **`Injector`** finds the keystore daemon's pid (`keystore2` on API ≥ 31, `keystore` on 10/11),
    runs the packaged `inject` binary to load the right interceptor, and re-injects whenever the
    pid changes; it confirms the library actually checked in over `@teesim` and warns otherwise
@@ -91,7 +103,19 @@ The root-manager WebUI talks to the daemon over a tiny loopback HTTP endpoint, s
 has a real `Context` and root that the webview alone does not:
 
 - **`KeyAdmin`** — HTTP/1.1 on `127.0.0.1:8790`, gated by a random token in a root-only file
-  (`admin.token`). It serves the WebUI's status, key, keybox, logs, and canary routes.
+  (`admin.token`). It serves the WebUI's status, key, keybox, logs, and canary routes, plus the
+  **Scope** app-picker's routes: **`GET /packages`** (the installed-app list collapsed by uid — label,
+  packages, system / launchable / enabled, install time, plus per-app request frequency, last-used, and
+  a since-boot "recent" flag), **`GET /icon`** (a rendered app icon PNG, token-in-query so an `<img>`
+  can load it, cached in memory), and **`POST /usage/clear`** (wipe the frequency memory). So a
+  profile's targets are chosen from the live device — searchable, sortable by real usage, with icons —
+  rather than typed as raw package names.
+- **`UsageStore`** — the per-package frequency/recency memory behind the picker's "Recent" group and
+  its frequency/recently-used sorts. The injected interceptor tallies each `generateKey` caller uid in
+  memory (a short locked bump, never any I/O on the crypto path); the daemon polls that snapshot over
+  the control socket (`getUsage`, ~15s), resolves each uid to a package, and folds the per-uid delta
+  into `usage.json` keyed by package — a persisted per-uid cursor keeps the accumulation exact across
+  daemon restarts, and "recent" is the in-memory set seen since this boot.
 - **`KeystoreDb`** — on API ≥ 31, snapshots keystore2's SQLite database and reads the `keyentry`
   table so the WebUI can list the keys targeted apps actually created (they live in each app's
   own namespace, which the daemon's `AndroidKeyStore` can't enumerate).

--- a/app/src/main/java/org/matrix/teesim/App.kt
+++ b/app/src/main/java/org/matrix/teesim/App.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.ContextWrapper
 import android.os.Build
 import android.os.Looper
+import android.os.SystemClock
 import java.io.File
 import java.security.Security
 import org.bouncycastle.jce.provider.BouncyCastleProvider
@@ -33,6 +34,16 @@ object App {
     @Volatile private var lastBootProps: Map<String, String> = emptyMap()
     // Cleared after the first committed push, so the startup-only attest-key purge runs exactly once.
     private val firstCommit = java.util.concurrent.atomic.AtomicBoolean(true)
+
+    // How often the usage poll asks the lib for its per-uid key-request tallies (spec B4).
+    private const val USAGE_POLL_MS = 15_000L
+    // Serializes the WHOLE fetch→delta→apply cycle of [pollUsageOnce]. Two callers race — the 15s poll
+    // thread and KeyAdmin's /packages handler (its own thread) — and although Control.fetchUsage is
+    // itself serialized, applying two snapshots out of order would drive a stale (smaller) count into
+    // UsageStore's "count shrank ⇒ lib restarted" branch and fold a whole cumulative as a phantom delta.
+    // A DEDICATED lock (never the App monitor, which resolveAndPush holds) keeps polls single-file
+    // without blocking the config path across the multi-second fetch.
+    private val usagePollLock = Any()
 
     // The delete-helper child body (see main): keystore2 only lets a key's OWNER delete it, and only the
     // owner's delete evicts keystore2's in-memory cache (a direct database delete does not). binder tells
@@ -105,9 +116,13 @@ object App {
             }
         }
             Control.start()
+            // Freeze the auto-include baseline (known_packages.json) at a known moment, before the first
+            // resolve reads it — so "future installs only" is measured from daemon-start, not lazily.
+            Scope.baselineKnownPackages()
             resolveAndPush()
             ConfigStore.watch { resolveAndPush() }
             PackageWatch.start(appContext) { resolveAndPush() }
+            startUsagePoll()
 
             SystemLogger.info("Daemon initialised; entering main loop")
             Looper.loop()
@@ -210,6 +225,68 @@ object App {
         } catch (e: Exception) {
             SystemLogger.error("Failed to resolve/push config", e)
         }
+    }
+
+    /**
+     * The background loop that keeps [UsageStore] current: every [USAGE_POLL_MS] it polls the lib for
+     * its per-uid key-request tallies and folds the deltas in ([pollUsageOnce]). Runs off the control
+     * reader thread (Control delivers the reply there), so it lives on its own daemon thread. A slow or
+     * absent lib just means an empty poll; the loop keeps going.
+     */
+    private fun startUsagePoll() {
+        Thread({ usagePollLoop() }, "teesim-usage-poll").apply {
+            isDaemon = true
+            start()
+        }
+        SystemLogger.info("Usage poll thread started (every ${USAGE_POLL_MS}ms)")
+    }
+
+    private fun usagePollLoop() {
+        while (true) {
+            try {
+                Thread.sleep(USAGE_POLL_MS)
+            } catch (_: InterruptedException) {
+                return
+            }
+            try {
+                pollUsageOnce()
+            } catch (e: Throwable) {
+                SystemLogger.warning("usage poll: iteration failed: ${e.message}")
+            }
+        }
+    }
+
+    /**
+     * Ask the lib for its usage snapshot and fold it into [UsageStore]. For each reported uid: resolve a
+     * representative package (PackageManager reverse map, or the lib's pkg hint as a fallback), convert
+     * the CLOCK_BOOTTIME lastBootMs to a wall-clock epoch via the current boot/wall offset, and hand it
+     * to [UsageStore.applyLibSample], which owns the per-uid cursor and the delta math under its own
+     * lock. This method therefore holds NO lock — in particular it must never block the config path:
+     * [Control.fetchUsage] can wait seconds for the lib, and an earlier version @Synchronized on the App
+     * monitor (shared with [resolveAndPush]) stalled config pushes for that whole window.
+     */
+    fun pollUsageOnce() = synchronized(usagePollLock) {
+        val apps = Control.fetchUsage() ?: return@synchronized
+        val bootNowMs = SystemClock.elapsedRealtime()
+        val wallNow = System.currentTimeMillis()
+        var recorded = 0
+        for (i in 0 until apps.length()) {
+            val e = apps.optJSONObject(i) ?: continue
+            val uid = e.optInt("uid", -1)
+            if (uid < 0) continue
+            val current = e.optLong("count", 0L)
+            val lastBootMs = e.optLong("lastBootMs", 0L)
+            val hint = e.optString("pkg", "")
+
+            val pkg = Packages.packagesForUid(uid).firstOrNull()?.takeIf { it.isNotEmpty() }
+                ?: hint.takeIf { it.isNotEmpty() }
+                ?: continue // no resolvable package: leave the cursor untouched so the count isn't lost
+            // lastBootMs is on CLOCK_BOOTTIME; the same offset (wallNow - bootNowMs) maps it to wall time.
+            val lastUsedEpoch = if (lastBootMs > 0) wallNow - (bootNowMs - lastBootMs) else wallNow
+            UsageStore.applyLibSample(uid, pkg, current, lastUsedEpoch)
+            recorded++
+        }
+        SystemLogger.info("usage poll: ${apps.length()} uid(s) reported, $recorded merged")
     }
 
     /**

--- a/app/src/main/java/org/matrix/teesim/App.kt
+++ b/app/src/main/java/org/matrix/teesim/App.kt
@@ -35,7 +35,7 @@ object App {
     // Cleared after the first committed push, so the startup-only attest-key purge runs exactly once.
     private val firstCommit = java.util.concurrent.atomic.AtomicBoolean(true)
 
-    // How often the usage poll asks the lib for its per-uid key-request tallies (spec B4).
+    // How often the usage poll asks the lib for its per-uid key-request tallies.
     private const val USAGE_POLL_MS = 15_000L
     // Serializes the WHOLE fetch→delta→apply cycle of [pollUsageOnce]. Two callers race — the 15s poll
     // thread and KeyAdmin's /packages handler (its own thread) — and although Control.fetchUsage is

--- a/app/src/main/java/org/matrix/teesim/ConfigStore.kt
+++ b/app/src/main/java/org/matrix/teesim/ConfigStore.kt
@@ -13,6 +13,10 @@ object ConfigStore {
 
     class ConfigException(message: String) : Exception(message)
 
+    // The two accepted apps[] entry shapes: a package name, or the advanced raw-uid token uid:N.
+    private val PKG_RE = Regex("^[A-Za-z0-9_.]+$")
+    private val UID_RE = Regex("^uid:\\d+$")
+
     /** One profile as written by the WebUI, before resolution against the device. */
     data class ProfileConfig(
         val id: String,
@@ -32,6 +36,11 @@ object ConfigStore {
         val meid: String,
         val imei2: String,
         val apps: List<String>,
+        // When true, the profile ALSO targets every installed user app (uid >= first app uid) that no
+        // OTHER profile claims — including apps installed later, since the daemon re-resolves on each
+        // package change. At most one profile may set this (checked below); it lets the apps list be
+        // empty, the auto set covering it.
+        val autoIncludeNewApps: Boolean,
     )
 
     data class Config(val version: Int, val profiles: List<ProfileConfig>)
@@ -56,7 +65,9 @@ object ConfigStore {
                 ?: throw ConfigException("config.json has no \"profiles\" object")
         if (profilesObj.length() == 0) throw ConfigException("config.json has no profiles")
 
-        val seenApps = HashMap<String, String>() // package -> owning profile id
+        val seenApps = HashMap<String, String>() // apps[] entry (package or uid:N) -> owning profile id
+        val seenUids = HashMap<Int, String>() // effective caller uid -> owning profile id (cross-check)
+        var autoIncludeProfiles = 0 // how many profiles set autoIncludeNewApps (at most one allowed)
         val profiles = ArrayList<ProfileConfig>()
 
         val ids = profilesObj.keys()
@@ -82,14 +93,60 @@ object ConfigStore {
                 p.optJSONArray("apps")?.let { arr ->
                     (0 until arr.length()).map { arr.getString(it).trim() }
                 } ?: emptyList()
-            if (apps.isEmpty()) throw ConfigException("profile '$id' has no apps")
-            for (pkg in apps) {
-                val prev = seenApps.put(pkg, id)
+
+            // A profile that auto-includes every user app may legitimately name no apps of its own;
+            // otherwise it must target at least one, or it routes nothing.
+            val autoIncludeNewApps = p.optBoolean("autoIncludeNewApps", false)
+            if (autoIncludeNewApps) autoIncludeProfiles++
+            if (autoIncludeProfiles > 1)
+                throw ConfigException(
+                    "profile '$id' also sets autoIncludeNewApps, but at most one profile may " +
+                        "auto-include new apps (two would both claim every unowned user app)"
+                )
+            if (apps.isEmpty() && !autoIncludeNewApps)
+                throw ConfigException("profile '$id' has no apps (and does not auto-include new apps)")
+
+            // Each apps[] entry is either a package name or the advanced raw-uid token uid:N. Validate
+            // the shape here so a typo can't silently slip through to routing, and keep the per-entry
+            // uniqueness (a package name OR a uid token may live in only one profile — the router needs
+            // exactly one owner per caller).
+            for (entry in apps) {
+                if (PKG_RE.matches(entry)) {
+                    // a plain package name — nothing further to validate
+                } else if (UID_RE.matches(entry)) {
+                    val n = entry.substring(4).toIntOrNull()
+                    if (n == null || n < 0)
+                        throw ConfigException(
+                            "profile '$id' app entry '$entry' is not a valid uid:N token (N must be a non-negative integer)"
+                        )
+                } else {
+                    throw ConfigException(
+                        "profile '$id' app entry '$entry' is neither a package name nor a uid:N token"
+                    )
+                }
+                val prev = seenApps.put(entry, id)
                 if (prev != null && prev != id)
                     throw ConfigException(
-                        "package '$pkg' appears in both profile '$prev' and '$id' " +
-                            "(routing requires one profile per package)"
+                        "app entry '$entry' appears in both profile '$prev' and '$id' " +
+                            "(routing requires one profile per package/uid)"
                     )
+                // The literal-string check above misses two entries that DIFFER textually but resolve to
+                // the SAME caller uid — a package vs a uid:N token (com.foo vs uid:10123), or two packages
+                // that share a uid (a sharedUserId pair). Both would put two profiles' keyboxes on one
+                // caller (last-writer-wins in routing). Reject on the effective uid too, when it resolves.
+                val uid =
+                    when {
+                        UID_RE.matches(entry) -> entry.substring(4).toIntOrNull() ?: -1
+                        else -> Packages.uidForPackage(entry)
+                    }
+                if (uid >= 0) {
+                    val prevUid = seenUids.put(uid, id)
+                    if (prevUid != null && prevUid != id)
+                        throw ConfigException(
+                            "app entry '$entry' resolves to uid $uid, already claimed by profile " +
+                                "'$prevUid' (one profile per caller uid)"
+                        )
+                }
             }
 
             profiles.add(
@@ -116,6 +173,7 @@ object ConfigStore {
                     meid = p.optString("meid", ""),
                     imei2 = p.optString("imei2", ""),
                     apps = apps,
+                    autoIncludeNewApps = autoIncludeNewApps,
                 )
             )
         }

--- a/app/src/main/java/org/matrix/teesim/Const.kt
+++ b/app/src/main/java/org/matrix/teesim/Const.kt
@@ -14,6 +14,14 @@ object Const {
     val overridesFile = File(DATA_DIR, "overrides.json")
     val adminTokenFile = File(DATA_DIR, "admin.token")
 
+    /** Persistent per-package key-request frequency memory (Scope v2 usage stats). Keyed by package name
+     *  because a uid can change across reinstalls; accumulated across boots from per-poll lib deltas. */
+    val usageFile = File(DATA_DIR, "usage.json")
+
+    /** The baseline set of package names present when TEESimulator first ran on this device. Seeded once
+     *  (when absent) and never rewritten, so auto-include can add only packages installed AFTER it. */
+    val knownPackagesFile = File(DATA_DIR, "known_packages.json")
+
     /** keystore's uid; the control socket only sends the keybox once the peer is it. */
     const val AID_KEYSTORE = 1017
 

--- a/app/src/main/java/org/matrix/teesim/Const.kt
+++ b/app/src/main/java/org/matrix/teesim/Const.kt
@@ -14,7 +14,7 @@ object Const {
     val overridesFile = File(DATA_DIR, "overrides.json")
     val adminTokenFile = File(DATA_DIR, "admin.token")
 
-    /** Persistent per-package key-request frequency memory (Scope v2 usage stats). Keyed by package name
+    /** Persistent per-package key-request frequency memory (Scope picker usage stats). Keyed by package name
      *  because a uid can change across reinstalls; accumulated across boots from per-poll lib deltas. */
     val usageFile = File(DATA_DIR, "usage.json")
 

--- a/app/src/main/java/org/matrix/teesim/Control.kt
+++ b/app/src/main/java/org/matrix/teesim/Control.kt
@@ -283,7 +283,7 @@ object Control {
     }
 
     /**
-     * Poll the lib for its per-uid key-request usage (spec C1), mirroring [resign]'s request/reply
+     * Poll the lib for its per-uid key-request usage, mirroring [resign]'s request/reply
      * shape: write `{"type":"getUsage"}`, wait for the matching `usage` frame, and hand back its `apps`
      * array (one entry per uid that has requested a key since the lib loaded), or null on no connection /
      * timeout / malformed reply. Serialized by [usageLock] so at most one request is outstanding.

--- a/app/src/main/java/org/matrix/teesim/Control.kt
+++ b/app/src/main/java/org/matrix/teesim/Control.kt
@@ -9,6 +9,7 @@ import java.util.concurrent.Executors
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import org.json.JSONArray
 import org.json.JSONObject
 
 /**
@@ -26,6 +27,8 @@ object Control {
 
     private const val RESIGN_TIMEOUT_MS = 10_000L
 
+    private const val USAGE_TIMEOUT_MS = 5_000L
+
     private val lock = Object()
     @Volatile private var latest: String? = null
     private var seq = 0L
@@ -37,6 +40,11 @@ object Control {
     // Responses to the one in-flight resign request. Buffered (size 1) so a reply that arrives before
     // the sender polls is not lost; the sender drains it before each request.
     private val resignReplies = LinkedBlockingQueue<JSONObject>(1)
+
+    // The one in-flight usage-poll reply, same buffered(1) rationale as [resignReplies]. [usageLock]
+    // serializes fetchUsage() so only a single getUsage request is ever outstanding on the wire.
+    private val usageReplies = LinkedBlockingQueue<JSONObject>(1)
+    private val usageLock = Object()
 
     // Invoked (on [commitExecutor]) after the lib acks a config commit, so the daemon can re-attest
     // pre-existing keys against the just-committed profile set. Coalesced by [commitPending].
@@ -216,6 +224,12 @@ object Control {
                 resignReplies.clear()
                 resignReplies.offer(msg)
             }
+            "usage" -> {
+                // The poll thread parks on usageReplies; hand the frame over and never do the (uid->pkg,
+                // disk) merge here — this is the reader thread, and the merge can block on PackageManager.
+                usageReplies.clear()
+                usageReplies.offer(msg)
+            }
             "pong" -> SystemLogger.verbose("control: pong ${msg.optLong("epoch")}")
         }
     }
@@ -267,6 +281,40 @@ object Control {
             null
         }
     }
+
+    /**
+     * Poll the lib for its per-uid key-request usage (spec C1), mirroring [resign]'s request/reply
+     * shape: write `{"type":"getUsage"}`, wait for the matching `usage` frame, and hand back its `apps`
+     * array (one entry per uid that has requested a key since the lib loaded), or null on no connection /
+     * timeout / malformed reply. Serialized by [usageLock] so at most one request is outstanding.
+     *
+     * MUST be called off the reader thread ([App]'s poll thread) — [handleFrame] delivers the reply, so
+     * blocking here on that same thread would deadlock. The reply is consumed as-is; the caller resolves
+     * uid->package and folds deltas into [UsageStore].
+     */
+    fun fetchUsage(): JSONArray? =
+        synchronized(usageLock) {
+            val out =
+                activeOut
+                    ?: run {
+                        SystemLogger.verbose("control: getUsage skipped — no live connection")
+                        return null
+                    }
+            usageReplies.clear()
+            try {
+                writeFrame(out, "{\"type\":\"getUsage\"}")
+            } catch (e: Exception) {
+                SystemLogger.warning("control: getUsage send failed: ${e.message}")
+                return null
+            }
+            val reply =
+                usageReplies.poll(USAGE_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                    ?: run {
+                        SystemLogger.warning("control: getUsage timed out")
+                        return null
+                    }
+            reply.optJSONArray("apps")
+        }
 
     // --- framing: [u32 BE length][UTF-8 JSON] -----------------------------------
 

--- a/app/src/main/java/org/matrix/teesim/KeyAdmin.kt
+++ b/app/src/main/java/org/matrix/teesim/KeyAdmin.kt
@@ -42,7 +42,7 @@ import org.json.JSONObject
  * keystore2's DB on API >= 31; empty + available=false on 10/11 where there is no such database) GET
  * /packages -> { ok, firstAppUid, apps:[ {uid, packages:[..], label, system, launchable, enabled,
  * installTime, freq, lastUsed, recent} ] } (every installed app, one entry per uid, for the Scope
- * v2 picker: installTime = epoch ms of first install; freq = persistent key-request count; lastUsed =
+ * picker: installTime = epoch ms of first install; freq = persistent key-request count; lastUsed =
  * epoch ms of last request; recent = requested a key since this boot) GET /icon?pkg=P&token=T -> raw
  * image/png (query-token auth, like /logs/download; 404 when the package has no icon) POST /usage/clear
  * -> { ok, cleared } (wipes the frequency memory) POST
@@ -350,7 +350,7 @@ object KeyAdmin {
         }
 
     /**
-     * Every installed app, one entry per uid, for the WebUI's Scope v2 picker (spec C3). The daemon runs
+     * Every installed app, one entry per uid, for the WebUI's Scope picker. The daemon runs
      * as root so [Packages.installedAppsByUid] sees all apps; `system` additionally folds in any uid
      * below the first app uid. Each entry also carries the usage face the picker sorts/badges on:
      * `installTime`, and (from [UsageStore], reduced over the entry's package names) `freq` (max count),
@@ -395,14 +395,14 @@ object KeyAdmin {
             .put("apps", arr)
     }
 
-    /** Wipe the persistent frequency memory (spec C5 / point 9). Returns how many entries were cleared. */
+    /** Wipe the persistent frequency memory. Returns how many entries were cleared. */
     private fun usageClear(): JSONObject {
         val cleared = UsageStore.clear()
         return JSONObject().put("ok", true).put("cleared", cleared)
     }
 
     /**
-     * Stream the rendered PNG icon for `?pkg=` (spec C4). Validates the package shape before touching
+     * Stream the rendered PNG icon for `?pkg=`. Validates the package shape before touching
      * PackageManager, answers 404 (as JSON) when the package has no icon or rendering fails, and relies
      * on [Packages.iconPng]'s in-memory cache so a scrolling list of <img> hits stays cheap.
      */

--- a/app/src/main/java/org/matrix/teesim/KeyAdmin.kt
+++ b/app/src/main/java/org/matrix/teesim/KeyAdmin.kt
@@ -39,7 +39,13 @@ import org.json.JSONObject
  * { ok, version, harvest{...}, lib{hook,api} } GET /keys -> { ok, keys:[ {alias, securityLevel, ours,
  * cert{...}} ] } GET /keys/db -> { ok, available, apiLevel, keys:[ {id, alias, uid, package, state, class,
  * created?, keybox?, keyAlgorithm?, purposes?} ] } (target-app keys with a stored attestation cert, from
- * keystore2's DB on API >= 31; empty + available=false on 10/11 where there is no such database) POST
+ * keystore2's DB on API >= 31; empty + available=false on 10/11 where there is no such database) GET
+ * /packages -> { ok, firstAppUid, apps:[ {uid, packages:[..], label, system, launchable, enabled,
+ * installTime, freq, lastUsed, recent} ] } (every installed app, one entry per uid, for the Scope
+ * v2 picker: installTime = epoch ms of first install; freq = persistent key-request count; lastUsed =
+ * epoch ms of last request; recent = requested a key since this boot) GET /icon?pkg=P&token=T -> raw
+ * image/png (query-token auth, like /logs/download; 404 when the package has no icon) POST /usage/clear
+ * -> { ok, cleared } (wipes the frequency memory) POST
  * /keys/db/delete?ids=1,2,3 -> { ok, deleted, requested } (removes those keyentry ids from keystore2,
  * marker- and target-verified) GET /keys/inspect?alias=A -> { ok, alias, attestation{...} | null }
  * POST /keys/delete?alias=A -> { ok, deleted } GET /logs?after=N&max=M
@@ -51,6 +57,9 @@ import org.json.JSONObject
 object KeyAdmin {
 
     private const val ATTEST_OID = "1.3.6.1.4.1.11129.2.1.17"
+    // A plausible package name for the /icon query, so a caller can't smuggle path/argument junk through
+    // ?pkg= into PackageManager. Same shape ConfigStore validates apps[] package entries with.
+    private val PKG_RE = Regex("^[A-Za-z0-9_.]+$")
     // Upper bound on a request body (bytes). The admin socket is localhost + token-authed, but a bogus
     // Content-Length should still never be trusted as an allocation size.
     private const val MAX_BODY_BYTES = 8 * 1024 * 1024
@@ -169,6 +178,17 @@ object KeyAdmin {
                 downloadLogs(out, dlQuery)
                 return
             }
+            // App icons are loaded by a browser <img src>, which likewise cannot set the token header,
+            // so /icon authenticates by ?token= exactly like /logs/download and streams a raw PNG.
+            if (method == "GET" && rawPath.substringBefore('?') == "/icon") {
+                val iconQuery = parseQuery(rawPath.substringAfter('?', ""))
+                if (iconQuery["token"] != token) {
+                    respond(out, 403, JSONObject().put("ok", false).put("error", "invalid token"))
+                    return
+                }
+                serveIcon(out, iconQuery)
+                return
+            }
             if (headerToken == null || headerToken != token) {
                 respond(out, 403, JSONObject().put("ok", false).put("error", "invalid token"))
                 return
@@ -210,6 +230,8 @@ object KeyAdmin {
                         method == "GET" && path == "/status" -> status()
                         method == "GET" && path == "/keys" -> listKeys()
                         method == "GET" && path == "/keys/db" -> keysDb()
+                        method == "GET" && path == "/packages" -> packages()
+                        method == "POST" && path == "/usage/clear" -> usageClear()
                         method == "POST" && path == "/keys/db/delete" -> deleteDbKeys(query)
                         method == "GET" && path == "/keys/inspect" ->
                             inspect(query["alias"] ?: error("alias required"))
@@ -313,21 +335,89 @@ object KeyAdmin {
         return JSONObject().put("ok", true).put("deleted", n).put("requested", ids.size)
     }
 
-    /** uid -> package for every installed app named across the live config's profiles. */
-    private fun targetUidToPackage(): Map<Int, String> {
-        val cfg =
-            try {
-                ConfigStore.load()
-            } catch (e: Exception) {
-                SystemLogger.warning("KeyAdmin: config load failed for /keys/db", e)
-                return emptyMap()
-            }
-        val map = HashMap<Int, String>()
-        for (p in cfg.profiles) for (pkg in p.apps) {
-            val uid = Packages.uidForPackage(pkg)
-            if (uid >= 0) map[uid] = pkg
+    /**
+     * uid -> a representative package name for every effective target across the live config, via
+     * [Scope.uidToPackage] (which folds in raw uid:N tokens and auto-included apps, mapping the
+     * package-less ones to their uid:token). Keeps the try/catch + empty-map fallback so a broken
+     * config just yields an empty stored-keys view rather than a 500.
+     */
+    private fun targetUidToPackage(): Map<Int, String> =
+        try {
+            Scope.uidToPackage(ConfigStore.load())
+        } catch (e: Exception) {
+            SystemLogger.warning("KeyAdmin: config load failed for /keys/db", e)
+            emptyMap()
         }
-        return map
+
+    /**
+     * Every installed app, one entry per uid, for the WebUI's Scope v2 picker (spec C3). The daemon runs
+     * as root so [Packages.installedAppsByUid] sees all apps; `system` additionally folds in any uid
+     * below the first app uid. Each entry also carries the usage face the picker sorts/badges on:
+     * `installTime`, and (from [UsageStore], reduced over the entry's package names) `freq` (max count),
+     * `lastUsed` (max epoch), `recent` (any package seen this boot). Sorted server-side by label then uid;
+     * the client re-sorts per its chosen order. A best-effort usage poll runs first so the freq/recent
+     * columns reflect the very latest requests without waiting for the 15s background poll.
+     */
+    private fun packages(): JSONObject {
+        try {
+            App.pollUsageOnce()
+        } catch (e: Exception) {
+            SystemLogger.verbose("KeyAdmin: pre-/packages usage poll skipped: ${e.message}")
+        }
+        val firstAppUid = Packages.firstAppUid()
+        val entries =
+            Packages.installedAppsByUid().sortedWith(
+                compareBy({ it.label.lowercase() }, { it.uid })
+            )
+        val arr = JSONArray()
+        for (e in entries) {
+            val freq = e.packages.maxOfOrNull { UsageStore.freqOf(it) } ?: 0L
+            val lastUsed = e.packages.maxOfOrNull { UsageStore.lastUsedOf(it) } ?: 0L
+            val recent = e.packages.any { UsageStore.isRecent(it) }
+            arr.put(
+                JSONObject()
+                    .put("uid", e.uid)
+                    .put("packages", JSONArray(e.packages))
+                    .put("label", e.label)
+                    .put("system", e.system || e.uid < firstAppUid)
+                    .put("launchable", e.launchable)
+                    .put("enabled", e.enabled)
+                    .put("installTime", e.installTime)
+                    .put("freq", freq)
+                    .put("lastUsed", lastUsed)
+                    .put("recent", recent)
+            )
+        }
+        SystemLogger.info("KeyAdmin: /packages -> ${entries.size} uid entr(ies), firstAppUid=$firstAppUid")
+        return JSONObject()
+            .put("ok", true)
+            .put("firstAppUid", firstAppUid)
+            .put("apps", arr)
+    }
+
+    /** Wipe the persistent frequency memory (spec C5 / point 9). Returns how many entries were cleared. */
+    private fun usageClear(): JSONObject {
+        val cleared = UsageStore.clear()
+        return JSONObject().put("ok", true).put("cleared", cleared)
+    }
+
+    /**
+     * Stream the rendered PNG icon for `?pkg=` (spec C4). Validates the package shape before touching
+     * PackageManager, answers 404 (as JSON) when the package has no icon or rendering fails, and relies
+     * on [Packages.iconPng]'s in-memory cache so a scrolling list of <img> hits stays cheap.
+     */
+    private fun serveIcon(out: OutputStream, query: Map<String, String>) {
+        val pkg = query["pkg"]
+        if (pkg == null || !PKG_RE.matches(pkg)) {
+            respond(out, 400, JSONObject().put("ok", false).put("error", "bad pkg"))
+            return
+        }
+        val png = Packages.iconPng(pkg)
+        if (png == null) {
+            respond(out, 404, JSONObject().put("ok", false).put("error", "no icon"))
+            return
+        }
+        respondRaw(out, 200, "image/png", listOf("Cache-Control: max-age=86400"), png)
     }
 
     private fun inspect(alias: String): JSONObject {

--- a/app/src/main/java/org/matrix/teesim/Packages.kt
+++ b/app/src/main/java/org/matrix/teesim/Packages.kt
@@ -123,7 +123,7 @@ object Packages {
         return out
     }
 
-    /** Every installed package name on the device, for the auto-include baseline seed (spec C6). Empty on
+    /** Every installed package name on the device, for the auto-include baseline seed. Empty on
      *  failure so a broken enumeration never seeds an empty baseline that later mislabels everything new. */
     fun allInstalledPackageNames(): Set<String> =
         try {

--- a/app/src/main/java/org/matrix/teesim/Packages.kt
+++ b/app/src/main/java/org/matrix/teesim/Packages.kt
@@ -1,10 +1,18 @@
 package org.matrix.teesim
 
 import android.content.Context
+import android.content.pm.ApplicationInfo
 import android.content.pm.IPackageManager
 import android.content.pm.PackageManager
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
 import android.os.Build
+import android.os.Process
 import android.os.ServiceManager
+import android.util.LruCache
+import java.io.ByteArrayOutputStream
 
 /**
  * Package-name to uid resolution. Prefers the public [PackageManager] from the system context (it
@@ -29,6 +37,146 @@ object Packages {
             SystemLogger.warning("uidForPackage($pkg) failed", e)
             -1
         }
+
+    /** The first uid the platform hands to a normal app; anything below is a system/shell uid. */
+    fun firstAppUid(): Int = Process.FIRST_APPLICATION_UID
+
+    /**
+     * One installed app collapsed to its uid — the shape the Scope page and `GET /packages` render.
+     * A shared-uid app contributes several [packages] under one entry; [label] is the best human
+     * name; [system]/[launchable]/[enabled] are the aggregate flags described on [installedAppsByUid].
+     */
+    data class AppEntry(
+        val uid: Int,
+        val packages: List<String>,
+        val label: String,
+        val system: Boolean,
+        val launchable: Boolean,
+        val enabled: Boolean,
+        // Epoch ms of first install, taken as the earliest firstInstallTime across the uid's members (a
+        // shared-uid group's "age" is its oldest member); 0 when PackageManager yields nothing usable.
+        val installTime: Long,
+    )
+
+    /**
+     * Every installed application on the device, grouped by uid (the daemon runs as root, so its
+     * PackageManager sees all apps as one uid namespace). Packages that share a uid collapse into a
+     * single entry whose [AppEntry.packages] lists them sorted. [AppEntry.system] is true when ANY
+     * member carries FLAG_SYSTEM; [AppEntry.launchable] when ANY member has a launcher entry;
+     * [AppEntry.label]/[AppEntry.enabled] come from the group's representative (first sorted) package.
+     * Failures are logged and swallowed per app so one bad entry never empties the whole list.
+     */
+    fun installedAppsByUid(): List<AppEntry> {
+        val infos =
+            try {
+                @Suppress("DEPRECATION") pm.getInstalledApplications(0)
+            } catch (e: Exception) {
+                SystemLogger.warning("installedAppsByUid: getInstalledApplications failed", e)
+                return emptyList()
+            }
+        val byUid = HashMap<Int, MutableList<ApplicationInfo>>()
+        for (ai in infos) byUid.getOrPut(ai.uid) { ArrayList() }.add(ai)
+
+        val out = ArrayList<AppEntry>(byUid.size)
+        for ((uid, members) in byUid) {
+            try {
+                members.sortBy { it.packageName }
+                val pkgNames = members.map { it.packageName }
+                val rep = members.first()
+                val label =
+                    try {
+                        pm.getApplicationLabel(rep).toString().takeIf { it.isNotBlank() }
+                            ?: rep.packageName
+                    } catch (e: Exception) {
+                        rep.packageName
+                    }
+                val system = members.any { (it.flags and ApplicationInfo.FLAG_SYSTEM) != 0 }
+                // getLaunchIntentForPackage(pkg) is the simplest "has a launcher entry" probe — it is
+                // exactly what a home screen would use to start the app.
+                val launchable = pkgNames.any { pm.getLaunchIntentForPackage(it) != null }
+                // Oldest member's first-install time is the group's install age; a per-package failure
+                // contributes nothing (0) rather than aborting the whole entry.
+                val installTime =
+                    pkgNames.mapNotNull { p ->
+                        try {
+                            @Suppress("DEPRECATION") pm.getPackageInfo(p, 0).firstInstallTime
+                        } catch (e: Exception) {
+                            null
+                        }
+                    }.minOrNull() ?: 0L
+                out.add(
+                    AppEntry(
+                        uid = uid,
+                        packages = pkgNames,
+                        label = label,
+                        system = system,
+                        launchable = launchable,
+                        enabled = rep.enabled,
+                        installTime = installTime,
+                    )
+                )
+            } catch (e: Exception) {
+                SystemLogger.warning("installedAppsByUid: skipping uid $uid", e)
+            }
+        }
+        SystemLogger.info("Packages: enumerated ${infos.size} app(s) across ${out.size} uid(s)")
+        return out
+    }
+
+    /** Every installed package name on the device, for the auto-include baseline seed (spec C6). Empty on
+     *  failure so a broken enumeration never seeds an empty baseline that later mislabels everything new. */
+    fun allInstalledPackageNames(): Set<String> =
+        try {
+            @Suppress("DEPRECATION")
+            pm.getInstalledApplications(0).mapTo(HashSet()) { it.packageName }
+        } catch (e: Exception) {
+            SystemLogger.warning("allInstalledPackageNames: getInstalledApplications failed", e)
+            emptySet()
+        }
+
+    // Rendered PNG icons keyed by package. A browser <img> re-hits /icon on every list scroll, so caching
+    // the encoded bytes (small; ~a few KB each) keeps those repeats off PackageManager + the PNG encoder.
+    private const val ICON_PX = 96
+    private val iconCache = LruCache<String, ByteArray>(256)
+
+    /**
+     * The app icon for [pkg] rendered to a [ICON_PX]×[ICON_PX] PNG, or null when the package has no icon
+     * or anything fails. Adaptive/vector icons have no intrinsic bitmap, so the drawable is always drawn
+     * onto a fixed ARGB_8888 canvas rather than read as a bitmap. Results are memoized in [iconCache].
+     */
+    fun iconPng(pkg: String): ByteArray? {
+        iconCache.get(pkg)?.let {
+            return it
+        }
+        return try {
+            val drawable: Drawable = pm.getApplicationIcon(pkg)
+            val png = drawableToPng(drawable)
+            if (png != null) iconCache.put(pkg, png)
+            png
+        } catch (e: Exception) {
+            SystemLogger.warning("iconPng($pkg) failed", e)
+            null
+        }
+    }
+
+    private fun drawableToPng(drawable: Drawable): ByteArray? {
+        // Honor an intrinsic bitmap's aspect where present, but never exceed ICON_PX — most launcher
+        // icons are already square, and a fixed cap keeps the wire payload predictable.
+        val w = ICON_PX
+        val h = ICON_PX
+        val bmp =
+            if (drawable is BitmapDrawable && drawable.bitmap != null) {
+                Bitmap.createScaledBitmap(drawable.bitmap, w, h, true)
+            } else {
+                val b = Bitmap.createBitmap(w, h, Bitmap.Config.ARGB_8888)
+                val canvas = Canvas(b)
+                drawable.setBounds(0, 0, w, h)
+                drawable.draw(canvas)
+                b
+            }
+        val bos = ByteArrayOutputStream()
+        return if (bmp.compress(Bitmap.CompressFormat.PNG, 100, bos)) bos.toByteArray() else null
+    }
 
     // --- IPackageManager (reverse mapping: uid -> package) -----------------------
 

--- a/app/src/main/java/org/matrix/teesim/ReAttest.kt
+++ b/app/src/main/java/org/matrix/teesim/ReAttest.kt
@@ -30,11 +30,9 @@ object ReAttest {
      * it reloads from the (now smaller) database; the injector re-injects on the new pid.
      */
     fun purgeTargetAttestKeys(config: ConfigStore.Config): Boolean {
-        val uids = HashSet<Int>()
-        for (profile in config.profiles) for (pkg in profile.apps) {
-            val uid = Packages.uidForPackage(pkg)
-            if (uid >= 0) uids.add(uid)
-        }
+        // Every effective target uid across the config (resolved packages + raw uid:N + auto-include),
+        // computed and logged once by Scope.
+        val uids = Scope.allTargetUids(config)
         if (uids.isEmpty()) return false
         // deleteTargetAttestKeys removes each key as its owning app first (which evicts keystore2's cache);
         // it returns only the count that could not be owner-deleted and fell back to a raw database delete.
@@ -62,14 +60,9 @@ object ReAttest {
 
     /** Re-attest every eligible pre-existing key of [config]'s target apps against the live profiles. */
     fun run(config: ConfigStore.Config) {
-        // uid -> the profile whose keybox should sign that app's keys (one profile per package).
-        val uidToProfile = HashMap<Int, String>()
-        for (profile in config.profiles) {
-            for (pkg in profile.apps) {
-                val uid = Packages.uidForPackage(pkg)
-                if (uid >= 0) uidToProfile[uid] = profile.id
-            }
-        }
+        // uid -> the profile whose keybox should sign that app's keys (one profile per package),
+        // resolved and logged centrally by Scope so raw uid:N tokens and auto-include are covered too.
+        val uidToProfile = Scope.uidToProfile(config)
         if (uidToProfile.isEmpty()) return
 
         val keys = KeystoreDb.attestedKeys(uidToProfile.keys)

--- a/app/src/main/java/org/matrix/teesim/Resolver.kt
+++ b/app/src/main/java/org/matrix/teesim/Resolver.kt
@@ -15,8 +15,11 @@ import org.json.JSONObject
  * verifiedBootKey(b64), verifiedBootHash(b64), deviceLocked, verifiedBootState, strongBoxAvailable,
  * attestVersionTee, attestVersionStrongBox profile: id, keyboxB64, mode, securityLevel(int),
  * osVersion, osPatchLevel, vendorPatchLevel,
- * bootPatchLevel, deviceIds{...}, packages[], uids[] uids[] is parallel to packages[] (same length,
- * -1 where not installed).
+ * bootPatchLevel, deviceIds{...}, packages[], uids[]. packages[] is every explicit package-name
+ * entry verbatim (kept even when not installed, since a name-match still fires on a later install);
+ * uids[] is the independent effective caller-uid set (resolved packages + raw uid:N tokens +
+ * autoIncludeNewApps expansion, never -1). The router matches package name first, uid second, so the
+ * two arrays need not be the same length. See [Scope].
  */
 object Resolver {
 
@@ -62,7 +65,7 @@ object Resolver {
 
         val profiles = JSONArray()
         for (p in config.profiles) {
-            profiles.put(resolveProfile(p, harvest))
+            profiles.put(resolveProfile(p, config.profiles.filter { it.id != p.id }, harvest))
         }
         msg.put("profiles", profiles)
         return msg
@@ -70,6 +73,7 @@ object Resolver {
 
     private fun resolveProfile(
         p: ConfigStore.ProfileConfig,
+        others: List<ConfigStore.ProfileConfig>,
         harvest: Harvester.Record,
     ): JSONObject {
         val o = JSONObject()
@@ -127,14 +131,14 @@ object Resolver {
         putId(ids, "model", p.model, harvest.model)
         if (ids.length() > 0) o.put("deviceIds", ids)
 
-        // packages[] with a parallel uids[] (-1 where not installed).
-        val packages = JSONArray()
+        // packages[] (attestation name-match, verbatim incl. not-yet-installed) and uids[] (caller-uid
+        // fallback, effective set with no -1) resolved centrally by Scope, which also folds in raw
+        // uid:N tokens and the autoIncludeNewApps expansion and logs the per-entry detail. The two
+        // arrays are independent here (uids[] may be longer or shorter than packages[]).
+        val scope = Scope.resolve(p, others)
+        o.put("packages", JSONArray(scope.packageNames))
         val uids = JSONArray()
-        for (pkg in p.apps) {
-            packages.put(pkg)
-            uids.put(Packages.uidForPackage(pkg))
-        }
-        o.put("packages", packages)
+        for (u in scope.uids) uids.put(u)
         o.put("uids", uids)
         return o
     }

--- a/app/src/main/java/org/matrix/teesim/Scope.kt
+++ b/app/src/main/java/org/matrix/teesim/Scope.kt
@@ -1,0 +1,287 @@
+package org.matrix.teesim
+
+import java.io.File
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * The one place that turns a profile's `apps[]` list into the two wire arrays the native router
+ * matches against — `packages[]` (attestation package-name match, primary) and `uids[]` (caller-uid
+ * match, fallback) — plus the derived sets the WebUI and re-attest paths need. Resolver, ReAttest
+ * and KeyAdmin all go through here so uid resolution, the raw-`uid:N` syntax, the auto-include
+ * expansion and the low-uid warnings live once, not copied three ways with drift between them.
+ *
+ * An `apps[]` entry is one of three shapes (see [parse]): a plain package name, an advanced
+ * `uid:N` token that targets a caller uid directly, or something malformed. A package name is kept
+ * on the wire verbatim even when the app is not installed yet, because a later install still
+ * name-matches; a uid is only ever pushed when it actually resolves (never -1).
+ */
+object Scope {
+
+    // android.os.Process.FIRST_APPLICATION_UID. A const avoids importing Process into every caller
+    // (and works in unit reasoning), but it is the same 10000 the platform uses for the app range.
+    const val FIRST_APP_UID = 10000
+
+    enum class Kind {
+        /** A package name that is currently installed; [Explicit.uid] is its resolved app uid. */
+        PACKAGE,
+        /** An advanced `uid:N` token; [Explicit.uid] is N, [Explicit.pkg] is null. */
+        RAW_UID,
+        /** A package-shaped name that is not installed (uid -1, but [Explicit.pkg] is kept), or a
+         *  genuinely malformed entry (uid -1, [Explicit.pkg] null). */
+        INVALID,
+    }
+
+    /**
+     * One resolved `apps[]` entry, in the same order as written. [pkg] is non-null for anything
+     * package-shaped (installed or not) and null for a `uid:N` token or a malformed entry — which is
+     * exactly the "is this a wire package name?" test [ProfileScope.packageNames] uses.
+     */
+    data class Explicit(val entry: String, val kind: Kind, val uid: Int, val pkg: String?)
+
+    /** The fully resolved scope of one profile against the live device. */
+    data class ProfileScope(
+        val profileId: String,
+        val explicit: List<Explicit>, // one per apps[] entry, in order
+        val autoUids: Set<Int>, // extra uids contributed by autoIncludeNewApps
+        val packageNames: List<String>, // wire packages[]: every package-shaped entry, verbatim
+        val uids: Set<Int>, // wire uids[]: effective caller uids, never containing -1
+        val lowUids: Set<Int>, // effective uids below FIRST_APP_UID, for the privileged-uid warning
+    )
+
+    /** Classify a single `apps[]` entry. Never throws — a malformed entry becomes [Kind.INVALID]. */
+    fun parse(entry: String): Explicit {
+        val e = entry.trim()
+        if (e.startsWith("uid:")) {
+            val digits = e.substring(4)
+            val n = if (digits.isNotEmpty() && digits.all { it.isDigit() }) digits.toIntOrNull() else null
+            return if (n != null) Explicit(e, Kind.RAW_UID, n, null)
+            else Explicit(e, Kind.INVALID, -1, null)
+        }
+        if (e.isNotEmpty() && e.all { it.isLetterOrDigit() || it == '_' || it == '.' }) {
+            val uid = Packages.uidForPackage(e)
+            // Package-shaped: PACKAGE when installed, INVALID (but pkg kept) when not — the name still
+            // rides the wire so a later install name-matches, yet contributes no uid until it resolves.
+            return if (uid >= 0) Explicit(e, Kind.PACKAGE, uid, e)
+            else Explicit(e, Kind.INVALID, -1, e)
+        }
+        return Explicit(e, Kind.INVALID, -1, null)
+    }
+
+    /**
+     * Resolve one profile against the live device. [others] are the config's OTHER profiles; their
+     * explicit package/uid claims are excluded from this profile's auto-include expansion so a
+     * user-app deliberately assigned elsewhere is never silently re-captured here.
+     *
+     * [quiet] suppresses the per-entry / low-uid / summary logging. The authoritative, verbose
+     * resolution log belongs to the ONE write path that actually pushes config (Resolver); the
+     * read-only aggregators below ([allTargetUids], [uidToProfile], [uidToPackage]) — some driven by
+     * a WebUI endpoint that may be polled — re-derive the same uids and would otherwise re-emit every
+     * line (and re-warn about every privileged uid) on each call, so they resolve quietly.
+     */
+    fun resolve(
+        profile: ConfigStore.ProfileConfig,
+        others: List<ConfigStore.ProfileConfig>,
+        quiet: Boolean = false,
+    ): ProfileScope {
+        val id = profile.id
+        val explicit = profile.apps.map { parse(it) }
+
+        val packageNames = ArrayList<String>()
+        val uids = LinkedHashSet<Int>()
+        for (x in explicit) {
+            if (x.pkg != null) packageNames.add(x.pkg)
+            when (x.kind) {
+                Kind.PACKAGE -> {
+                    uids.add(x.uid)
+                    if (!quiet) SystemLogger.info("Scope[$id]: '${x.entry}' -> uid ${x.uid}")
+                }
+                Kind.RAW_UID -> {
+                    uids.add(x.uid)
+                    if (!quiet) SystemLogger.info("Scope[$id]: raw uid:${x.uid}")
+                }
+                Kind.INVALID -> {
+                    if (quiet) Unit
+                    else if (x.pkg != null)
+                        SystemLogger.info("Scope[$id]: '${x.entry}' -> NOT INSTALLED (dropped)")
+                    else SystemLogger.warning("Scope[$id]: '${x.entry}' is not a valid package name or uid:N token (dropped)")
+                }
+            }
+        }
+
+        // Auto-include (v2, future-installs only): a user-app uid (>= FIRST_APP_UID) is folded in ONLY
+        // when NONE of its package names was present at the baseline — i.e. the app was installed AFTER
+        // TEESimulator first ran — and no OTHER profile claims it and this profile does not already name
+        // it. The baseline (known_packages.json, seeded once) is what makes this "new apps only": every
+        // app that already existed is by definition in the baseline and never auto-added.
+        val autoUids = LinkedHashSet<Int>()
+        if (profile.autoIncludeNewApps) {
+            val baseline = baselineKnownPackages()
+            // An EMPTY baseline (never seeded, or an empty/corrupt known_packages.json) must NOT be
+            // trusted: with it, `app.packages.all { it in baseline }` is false for every app, so
+            // auto-include would fold in the whole device and apply the keybox everywhere. Fail safe —
+            // add nothing until a real baseline exists (the seed retries on a later resolve).
+            if (baseline.isEmpty()) {
+                if (!quiet)
+                    SystemLogger.warning(
+                        "Scope[$id]: auto-include skipped — no package baseline yet (nothing auto-added)"
+                    )
+            } else {
+            val claimedElsewhere = explicitUidsOf(others)
+            val mine = explicit.mapNotNull { if (it.uid >= 0) it.uid else null }.toHashSet()
+            for (app in Packages.installedAppsByUid()) {
+                if (app.uid < FIRST_APP_UID) continue
+                if (app.uid in claimedElsewhere) continue
+                if (app.uid in mine) continue
+                // Every member package known at baseline => pre-existing app, skip. Any member absent from
+                // the baseline => installed after it, so this uid is genuinely new and auto-includes.
+                if (app.packages.all { it in baseline }) continue
+                autoUids.add(app.uid)
+            }
+            uids.addAll(autoUids)
+            if (!quiet)
+                SystemLogger.info(
+                    "Scope[$id]: auto-include added ${autoUids.size} post-baseline user uid(s)"
+                )
+            }
+        }
+
+        val lowUids = uids.filter { it < FIRST_APP_UID }.toSet()
+        if (!quiet)
+            for (u in lowUids)
+                SystemLogger.warning(
+                    "Scope[$id]: WARNING targeting privileged uid $u (< first app uid $FIRST_APP_UID) — " +
+                        "this is a system/shell uid (e.g. shell, system_server), not a normal app"
+                )
+
+        val invalidCount = explicit.count { it.kind == Kind.INVALID }
+        if (!quiet)
+            SystemLogger.info(
+                "Scope[$id]: effective = ${packageNames.size} package-match name(s), ${uids.size} caller uid(s) " +
+                    "${uids.sorted()}, $invalidCount invalid/uninstalled, ${autoUids.size} auto"
+            )
+
+        return ProfileScope(
+            profileId = id,
+            explicit = explicit,
+            autoUids = autoUids,
+            packageNames = packageNames,
+            uids = uids,
+            lowUids = lowUids,
+        )
+    }
+
+    // The baseline set, cached after the first read/seed. The file is written exactly once (when absent)
+    // and never rewritten, so an in-memory cache is safe for the daemon's lifetime.
+    @Volatile private var baselineCache: Set<String>? = null
+
+    /**
+     * The set of package names that existed when TEESimulator first ran (spec C6), read from
+     * [Const.knownPackagesFile]. Seeds the file — with every currently-installed package name — the first
+     * time it is absent, then persists it, so the "future-installs only" auto-include has a fixed frame
+     * of reference. Call once at daemon start (before the first resolve) to freeze the baseline at a
+     * known moment; later calls reuse the cache / the persisted file.
+     *
+     * The baseline must be seeded from a REAL package enumeration exactly once. A transient
+     * PackageManager failure (empty enumeration) is NEVER persisted or cached — freezing an empty
+     * baseline would make `packages.all { it in baseline }` false for every app and auto-include the
+     * entire device, the opposite of "future-installs only". An empty seed therefore returns empty for
+     * this call WITHOUT writing the file, so the very next call retries and seeds properly once
+     * PackageManager answers. A genuinely-present baseline file (even if it read back empty because the
+     * device really had nothing) is honoured; only the seed path guards against the transient case.
+     */
+    fun baselineKnownPackages(): Set<String> {
+        baselineCache?.let {
+            return it
+        }
+        val f = Const.knownPackagesFile
+        if (f.exists()) {
+            val set =
+                try {
+                    val arr = JSONObject(f.readText()).optJSONArray("packages") ?: JSONArray()
+                    (0 until arr.length()).mapTo(HashSet()) { arr.getString(it) }
+                } catch (e: Exception) {
+                    // A corrupt baseline file is a hard problem retrying can't fix, but caching an empty
+                    // set here would auto-include everything — so return empty WITHOUT caching and let a
+                    // later call try again (a user can also delete the file to force a fresh seed).
+                    SystemLogger.warning("Scope: known_packages.json unreadable; not caching empty baseline", e)
+                    return emptySet()
+                }
+            // An EMPTY existing baseline (truncated write, hand-edit) is never cached and falls through
+            // to a reseed below — auto-include is disabled (resolve() guards on empty) until a real set
+            // is written, rather than freezing "everything is new".
+            if (set.isNotEmpty()) {
+                baselineCache = set
+                return set
+            }
+            SystemLogger.warning("Scope: known_packages.json is empty; reseeding from a live enumeration")
+        }
+        // No baseline yet: seed from a live enumeration. If it comes back empty, treat it as a transient
+        // failure — do not write or cache — so the baseline is only ever frozen from a real package set.
+        val seeded = Packages.allInstalledPackageNames()
+        if (seeded.isEmpty()) {
+            SystemLogger.warning("Scope: package enumeration empty; deferring known_packages.json seed (will retry)")
+            return emptySet()
+        }
+        try {
+            val root = JSONObject().put("version", 1).put("packages", JSONArray(seeded.sorted()))
+            f.parentFile?.mkdirs()
+            val tmp = File(f.parentFile, "${f.name}.tmp")
+            tmp.writeText(root.toString())
+            if (!tmp.renameTo(f)) {
+                f.writeText(root.toString())
+                tmp.delete()
+            }
+            SystemLogger.info("Scope: seeded known_packages.json baseline with ${seeded.size} package(s)")
+        } catch (e: Exception) {
+            SystemLogger.warning("Scope: failed to seed known_packages.json", e)
+        }
+        baselineCache = seeded
+        return seeded
+    }
+
+    /** The set of explicit caller uids (installed packages + `uid:N` tokens) named across [profiles]. */
+    private fun explicitUidsOf(profiles: List<ConfigStore.ProfileConfig>): Set<Int> {
+        val s = HashSet<Int>()
+        for (p in profiles) for (entry in p.apps) {
+            val x = parse(entry)
+            if (x.uid >= 0) s.add(x.uid)
+        }
+        return s
+    }
+
+    /** Every effective target uid across the whole config (union of each profile's wire uids[]). */
+    fun allTargetUids(config: ConfigStore.Config): Set<Int> {
+        val all = LinkedHashSet<Int>()
+        for (p in config.profiles)
+            all.addAll(resolve(p, config.profiles.filter { it.id != p.id }, quiet = true).uids)
+        return all
+    }
+
+    /**
+     * uid -> owning profile id across the config. The one-profile-per-package/uid rule makes real
+     * collisions a validation error, so last-writer-wins here is only ever exercised by auto-include
+     * overlap, which validation already forbids (at most one auto profile).
+     */
+    fun uidToProfile(config: ConfigStore.Config): Map<Int, String> {
+        val map = HashMap<Int, String>()
+        for (p in config.profiles)
+            for (u in resolve(p, config.profiles.filter { it.id != p.id }, quiet = true).uids) map[u] = p.id
+        return map
+    }
+
+    /**
+     * uid -> a representative package name for the WebUI's stored-keys view. A resolved package entry
+     * maps to its name; a raw or auto-included uid has no package, so it maps to its `uid:N` token so
+     * the UI still shows something recognisable. Package names win over tokens on the same uid.
+     */
+    fun uidToPackage(config: ConfigStore.Config): Map<Int, String> {
+        val map = HashMap<Int, String>()
+        for (p in config.profiles) {
+            val scope = resolve(p, config.profiles.filter { it.id != p.id }, quiet = true)
+            for (x in scope.explicit) if (x.kind == Kind.PACKAGE && x.pkg != null) map[x.uid] = x.pkg
+            for (u in scope.uids) if (u !in map) map[u] = "uid:$u"
+        }
+        return map
+    }
+}

--- a/app/src/main/java/org/matrix/teesim/Scope.kt
+++ b/app/src/main/java/org/matrix/teesim/Scope.kt
@@ -109,7 +109,7 @@ object Scope {
             }
         }
 
-        // Auto-include (v2, future-installs only): a user-app uid (>= FIRST_APP_UID) is folded in ONLY
+        // Auto-include (future-installs only): a user-app uid (>= FIRST_APP_UID) is folded in ONLY
         // when NONE of its package names was present at the baseline — i.e. the app was installed AFTER
         // TEESimulator first ran — and no OTHER profile claims it and this profile does not already name
         // it. The baseline (known_packages.json, seeded once) is what makes this "new apps only": every
@@ -176,7 +176,7 @@ object Scope {
     @Volatile private var baselineCache: Set<String>? = null
 
     /**
-     * The set of package names that existed when TEESimulator first ran (spec C6), read from
+     * The set of package names that existed when TEESimulator first ran, read from
      * [Const.knownPackagesFile]. Seeds the file — with every currently-installed package name — the first
      * time it is absent, then persists it, so the "future-installs only" auto-include has a fixed frame
      * of reference. Call once at daemon start (before the first resolve) to freeze the baseline at a

--- a/app/src/main/java/org/matrix/teesim/UsageStore.kt
+++ b/app/src/main/java/org/matrix/teesim/UsageStore.kt
@@ -1,0 +1,187 @@
+package org.matrix.teesim
+
+import java.io.File
+import org.json.JSONObject
+
+/**
+ * The persistent key-request frequency memory behind Scope v2 (spec C2, [Const.usageFile]). Every uid
+ * that asks keystore for a key is recorded by the lib and polled by [App]; that poll turns per-uid
+ * deltas into per-PACKAGE updates here. Package name (not uid) is the key because a uid is recycled on
+ * reinstall/clear-data while the package identity the user recognises persists — so "com.foo asked for
+ * 42 keys" survives an uninstall/reinstall and even a factory boot.
+ *
+ * On disk: { "version":1, "apps": { "com.foo": { "count":42, "lastUsed":<epochMs> } } }. [count]
+ * accumulates across boots (the poller adds deltas); [lastUsed] is the wall-clock epoch of the most
+ * recent request. Separately, [sinceBoot] is the in-memory set of packages seen during THIS daemon run
+ * — the "Recent" group in the picker — and is deliberately NOT persisted (it means "since this boot").
+ *
+ * Writes are debounced: a busy device can poll many packages in a burst, and rewriting usage.json on
+ * every [record] would be wasteful, so a dirty flag is flushed at most once per [WRITE_DEBOUNCE_MS] via
+ * an atomic temp-file rename, exactly like the other DATA_DIR stores.
+ */
+object UsageStore {
+
+    private const val WRITE_DEBOUNCE_MS = 3_000L
+
+    /** One package's accumulated frequency and most-recent use. Mutable so [record] can update in place. */
+    data class Stat(var count: Long, var lastUsed: Long)
+
+    private val lock = Object()
+    private var loaded = false
+    private val map = HashMap<String, Stat>()
+    // Packages that requested a key during THIS daemon run — the picker's "Recent" group. Not persisted.
+    private val sinceBoot = HashSet<String>()
+    // Per-uid "cumulative count already folded in": the lib reports counts cumulative since ITS load, so
+    // each poll records only (current - cursor). This MUST persist, or a daemon-only restart (the lib in
+    // keystore2 keeps counting) would see no cursor, treat the lib's whole cumulative as a delta, and
+    // double-add it on top of the counts already in usage.json. Persisted in usage.json under "cursors";
+    // deliberately NOT wiped by clear() (so a clear doesn't make the next poll re-add the lib's history).
+    private val cursors = HashMap<Int, Long>()
+
+    // Debounce state: [dirty] means the in-memory map diverges from disk; [lastWriteMs] gates the flush.
+    private var dirty = false
+    private var lastWriteMs = 0L
+
+    /** Lazily load usage.json the first time any accessor runs; never throws — a broken file just means
+     *  "no remembered usage yet" and starts fresh (the next flush overwrites it). Caller holds [lock]. */
+    private fun ensureLoaded() {
+        if (loaded) return
+        loaded = true
+        val f = Const.usageFile
+        if (!f.exists()) {
+            SystemLogger.info("UsageStore: no usage.json yet; starting empty")
+            return
+        }
+        try {
+            val root = JSONObject(f.readText())
+            val apps = root.optJSONObject("apps") ?: JSONObject()
+            for (pkg in apps.keys()) {
+                val s = apps.optJSONObject(pkg) ?: continue
+                map[pkg] = Stat(s.optLong("count", 0L), s.optLong("lastUsed", 0L))
+            }
+            val cur = root.optJSONObject("cursors")
+            if (cur != null)
+                for (k in cur.keys()) k.toIntOrNull()?.let { cursors[it] = cur.optLong(k, 0L) }
+            SystemLogger.info("UsageStore: loaded ${map.size} package(s), ${cursors.size} cursor(s) from usage.json")
+        } catch (e: Exception) {
+            SystemLogger.warning("UsageStore: usage.json unreadable; starting empty", e)
+            map.clear()
+        }
+    }
+
+    /**
+     * Fold one poll's worth of activity for [pkg] into the memory: add [deltaCount] new requests to the
+     * running count, advance [lastUsed] to the newer of the stored/observed epoch, and mark the package
+     * as seen this boot. A zero/negative delta with a fresh timestamp still updates recency (the app was
+     * active) without inflating the count. Flushes to disk debounced.
+     */
+    fun record(pkg: String, deltaCount: Long, lastUsedEpoch: Long) {
+        if (pkg.isEmpty()) return
+        synchronized(lock) {
+            ensureLoaded()
+            val s = map.getOrPut(pkg) { Stat(0L, 0L) }
+            if (deltaCount > 0) s.count += deltaCount
+            if (lastUsedEpoch > s.lastUsed) s.lastUsed = lastUsedEpoch
+            sinceBoot.add(pkg)
+            dirty = true
+            maybeFlush()
+        }
+    }
+
+    /**
+     * Fold one lib usage sample into the memory, computing the delta against the PERSISTED per-uid
+     * cursor so a daemon-only restart never re-adds history. [currentCumulative] is the lib's count for
+     * [uid] since the lib loaded; the delta is `current - cursor`, or `current` when the cursor is
+     * unknown OR the value shrank (the lib restarted, resetting near zero). The delta lands on [pkg]
+     * (package-keyed frequency), the cursor advances to [currentCumulative], and recency updates. Doing
+     * the whole read-delta-update atomically here (under [lock]) is why [App]'s poll needs no lock and
+     * must never hold one across the blocking control fetch.
+     */
+    fun applyLibSample(uid: Int, pkg: String, currentCumulative: Long, lastUsedEpoch: Long) {
+        if (pkg.isEmpty()) return
+        synchronized(lock) {
+            ensureLoaded()
+            val prev = cursors[uid]
+            val delta =
+                if (prev == null || currentCumulative < prev) currentCumulative
+                else currentCumulative - prev
+            cursors[uid] = currentCumulative
+            val s = map.getOrPut(pkg) { Stat(0L, 0L) }
+            if (delta > 0) s.count += delta
+            if (lastUsedEpoch > s.lastUsed) s.lastUsed = lastUsedEpoch
+            sinceBoot.add(pkg)
+            dirty = true
+            maybeFlush()
+        }
+    }
+
+    /** Persisted request count for [pkg] (0 if never seen). */
+    fun freqOf(pkg: String): Long =
+        synchronized(lock) {
+            ensureLoaded()
+            map[pkg]?.count ?: 0L
+        }
+
+    /** Wall-clock epoch ms of [pkg]'s most recent key request (0 if never). */
+    fun lastUsedOf(pkg: String): Long =
+        synchronized(lock) {
+            ensureLoaded()
+            map[pkg]?.lastUsed ?: 0L
+        }
+
+    /** Whether [pkg] has requested a key since THIS daemon started — the picker's "Recent" test. */
+    fun isRecent(pkg: String): Boolean =
+        synchronized(lock) {
+            ensureLoaded()
+            pkg in sinceBoot
+        }
+
+    /**
+     * Wipe the whole frequency memory (spec point 9 / route C5): clears both the persisted map and the
+     * since-boot recency set and rewrites usage.json empty immediately (no debounce — the user asked for
+     * it and expects it gone). Returns how many package entries were cleared.
+     */
+    fun clear(): Int =
+        synchronized(lock) {
+            ensureLoaded()
+            val n = map.size
+            map.clear()
+            sinceBoot.clear()
+            dirty = true
+            flush(force = true)
+            SystemLogger.info("UsageStore: cleared $n package(s) of usage memory")
+            n
+        }
+
+    /** Flush if dirty and the debounce window has elapsed. Caller holds [lock]. */
+    private fun maybeFlush() {
+        val now = System.currentTimeMillis()
+        if (dirty && now - lastWriteMs >= WRITE_DEBOUNCE_MS) flush(force = false)
+    }
+
+    /** Serialize the map to usage.json atomically (temp + rename). Caller holds [lock]. */
+    private fun flush(force: Boolean) {
+        if (!dirty && !force) return
+        try {
+            val apps = JSONObject()
+            for ((pkg, s) in map)
+                apps.put(pkg, JSONObject().put("count", s.count).put("lastUsed", s.lastUsed))
+            val cur = JSONObject()
+            for ((uid, c) in cursors) cur.put(uid.toString(), c)
+            val root = JSONObject().put("version", 1).put("apps", apps).put("cursors", cur)
+            val f = Const.usageFile
+            f.parentFile?.mkdirs()
+            val tmp = File(f.parentFile, "${f.name}.tmp")
+            tmp.writeText(root.toString())
+            if (!tmp.renameTo(f)) {
+                // rename can fail across some overlays; fall back to a direct overwrite so we still persist.
+                f.writeText(root.toString())
+                tmp.delete()
+            }
+            dirty = false
+            lastWriteMs = System.currentTimeMillis()
+        } catch (e: Exception) {
+            SystemLogger.warning("UsageStore: failed to write usage.json", e)
+        }
+    }
+}

--- a/app/src/main/java/org/matrix/teesim/UsageStore.kt
+++ b/app/src/main/java/org/matrix/teesim/UsageStore.kt
@@ -4,7 +4,7 @@ import java.io.File
 import org.json.JSONObject
 
 /**
- * The persistent key-request frequency memory behind Scope v2 (spec C2, [Const.usageFile]). Every uid
+ * The persistent key-request frequency memory behind the Scope picker ([Const.usageFile]). Every uid
  * that asks keystore for a key is recorded by the lib and polled by [App]; that poll turns per-uid
  * deltas into per-PACKAGE updates here. Package name (not uid) is the key because a uid is recycled on
  * reinstall/clear-data while the package identity the user recognises persists — so "com.foo asked for
@@ -137,7 +137,7 @@ object UsageStore {
         }
 
     /**
-     * Wipe the whole frequency memory (spec point 9 / route C5): clears both the persisted map and the
+     * Wipe the whole frequency memory (the /usage/clear route): clears both the persisted map and the
      * since-boot recency set and rewrites usage.json empty immediately (no debounce — the user asked for
      * it and expects it gone). Returns how many package entries were cleared.
      */

--- a/common/control.cpp
+++ b/common/control.cpp
@@ -337,6 +337,15 @@ void HandleConnection(int fd) {
       resp += sc.certs;
       resp += "]}";
       WriteFrame(fd, resp);
+    } else if (t == "getUsage") {
+      // Poll the router's per-caller key-usage snapshot (see control.h). The router owns the JSON
+      // array; we wrap it in the reply envelope and free it.
+      char* j = teesim_usage_json_alloc();
+      std::string resp = "{\"type\":\"usage\",\"apps\":";
+      resp += (j ? j : "[]");
+      resp += "}";
+      free(j);
+      WriteFrame(fd, resp);
     } else if (t == "ping") {
       const tjson::Value *e = msg.get("epoch");
       std::string pong = "{\"type\":\"pong\",\"epoch\":";

--- a/common/control.h
+++ b/common/control.h
@@ -78,6 +78,17 @@ bool teesim_cfg_resign(const char *profile_id, const uint8_t *leaf, size_t leaf_
 // Which hook this lib is, for the hello message: "keymint" or "keystore1".
 const char *teesim_hook_name(void);
 
+// Snapshot the per-caller key-usage stats this lib has recorded since it loaded,
+// as a malloc'd, NUL-terminated JSON ARRAY the caller must free(). Each element
+// is one uid that has requested a key this boot:
+//   [{"uid":N,"count":N,"lastBootMs":N,"pkg":"..."}]
+// count is the cumulative generateKey requests from that uid, lastBootMs is the
+// CLOCK_BOOTTIME (ms) of its most recent request, and pkg is a best-effort
+// package hint (usually "" — the daemon resolves uid->package itself). The
+// keymint router fills this in; the keystore1 router returns "[]" (out of scope).
+// The daemon polls it via the control channel's getUsage request.
+char *teesim_usage_json_alloc(void);
+
 // --- control server, implemented in common/control.cpp -----------------------
 
 // Bind the abstract socket @teesim, listen, and serve config pushes on a

--- a/keymint/keymint_router.cpp
+++ b/keymint/keymint_router.cpp
@@ -12,6 +12,8 @@
 #include <aidl/android/hardware/security/keymint/BnKeyMintOperation.h>
 #include <android/binder_ibinder.h>  // AIBinder_getCallingUid
 
+#include <ctime>
+#include <cstdlib>
 #include <cstring>
 #include <map>
 #include <memory>
@@ -74,6 +76,41 @@ int32_t g_stage_vb_state = 0;
 bool g_stage_strongbox_ok = false;
 int32_t g_stage_attest_version_tee = 400;
 int32_t g_stage_attest_version_strongbox = 400;
+
+// --- Per-caller usage stats --------------------------------------------------
+// Every app that asks us for a key this boot is recorded here from generateKey,
+// so the daemon can surface a "Recent" group and a frequency ordering in the
+// scope picker. Keyed by caller uid because a uid outlives a single request; the
+// daemon maps uid->package (uids get reassigned across installs, packages are
+// stable). This is a hot path, so the record is a short locked map update with
+// no I/O — never touch the crypto path's latency.
+struct UsageEntry {
+  uint64_t count = 0;         // cumulative generateKey requests from this uid since load
+  uint64_t last_boot_ms = 0;  // CLOCK_BOOTTIME (ms) of the most recent request
+  std::string pkg;            // best-effort package hint, usually empty (daemon resolves uid->pkg)
+};
+std::mutex g_usage_mu;
+std::map<int32_t, UsageEntry> g_usage;
+
+// Milliseconds on CLOCK_BOOTTIME: a monotonic clock that keeps counting across
+// suspend, matching the daemon's SystemClock.elapsedRealtime so it can convert
+// our lastBootMs back to a wall-clock instant.
+uint64_t NowBootMs() {
+  struct timespec ts{};
+  clock_gettime(CLOCK_BOOTTIME, &ts);
+  return static_cast<uint64_t>(ts.tv_sec) * 1000u + static_cast<uint64_t>(ts.tv_nsec) / 1000000u;
+}
+
+// Record one key request from `caller_uid` (target or not). Cheap by design: the
+// daemon does the uid->package resolution, so we only bump the count and stamp
+// the time. A caller with no valid uid (-1) is skipped.
+void RecordUsage(int32_t caller_uid) {
+  if (caller_uid < 0) return;
+  std::lock_guard<std::mutex> lk(g_usage_mu);
+  UsageEntry& e = g_usage[caller_uid];
+  ++e.count;
+  e.last_boot_ms = NowBootMs();
+}
 
 // RAII guard: mark the current thread as forwarding to the real HAL.
 struct ForwardGuard {
@@ -380,6 +417,7 @@ class TeesimKeyMintDevice : public BnKeyMintDevice {
                                  const std::optional<AttestationKey>& attestationKey,
                                  KeyCreationResult* out) override {
     const uid_t caller_uid = AIBinder_getCallingUid();
+    RecordUsage(static_cast<int32_t>(caller_uid));  // every app that asks for a key, for the daemon's usage view
     RequestTarget t = ProfileForRequest(keyParams, caller_uid);
     LOGI("generateKey: level=%d, %zu param(s), caller_uid=%d, caller_attest_key=%d, target=%d, "
          "patch_mode=%d, strongbox_ok=%d",
@@ -741,6 +779,37 @@ class TeesimKeyMintDevice : public BnKeyMintDevice {
 // --- C entry points ----------------------------------------------------------
 
 extern "C" const char* teesim_hook_name(void) { return "keymint"; }
+
+// Snapshot the usage map as a JSON array (see control.h). Built under the usage
+// lock only; no crypto state is touched, so the daemon can poll this freely.
+extern "C" char* teesim_usage_json_alloc(void) {
+  std::string out = "[";
+  {
+    std::lock_guard<std::mutex> lk(g_usage_mu);
+    bool first = true;
+    for (const auto& kv : g_usage) {
+      if (!first) out += ",";
+      first = false;
+      out += "{\"uid\":";
+      out += std::to_string(kv.first);
+      out += ",\"count\":";
+      out += std::to_string(kv.second.count);
+      out += ",\"lastBootMs\":";
+      out += std::to_string(kv.second.last_boot_ms);
+      out += ",\"pkg\":\"";
+      // pkg is a plain package name or empty, but escape the JSON-significant bytes defensively.
+      for (char c : kv.second.pkg) {
+        if (c == '"' || c == '\\') out += '\\';
+        out += c;
+      }
+      out += "\"}";
+    }
+  }
+  out += "]";
+  char* buf = static_cast<char*>(malloc(out.size() + 1));
+  if (buf) memcpy(buf, out.c_str(), out.size() + 1);
+  return buf;
+}
 
 // Config-staging API (see common/control.h). teesim_cfg_begin/add_profile run on
 // the control thread before the swap; only teesim_cfg_commit touches live tables.

--- a/keystore/keystore_router.cpp
+++ b/keystore/keystore_router.cpp
@@ -25,6 +25,7 @@
 #include <openssl/x509.h>
 
 #include <ctime>
+#include <cstdlib>
 #include <cstring>
 #include <map>
 #include <memory>
@@ -778,6 +779,10 @@ bool HandleAbort(int /*uid*/, Parcel& in, Parcel* reply) {
 }  // namespace
 
 extern "C" const char* teesim_hook_name(void) { return "keystore1"; }
+
+// Usage stats are a keystore2/KeyMint-only feature; Android 10/11 is out of scope
+// for the scope picker, so this router reports an empty array (see control.h).
+extern "C" char* teesim_usage_json_alloc(void) { return strdup("[]"); }
 
 // Config-staging API (see common/control.h). teesim_cfg_begin/add_profile run on
 // the control thread; only teesim_cfg_commit touches the live routing tables.

--- a/module/webroot/css/app.css
+++ b/module/webroot/css/app.css
@@ -448,3 +448,114 @@ html, body { overscroll-behavior-y: contain; }
 .linklike:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 3px; }
 .editor-note { margin: 0; }
 .resolve-hint.missing { color: var(--warn); }
+
+/* --- toggle switch (schema 'toggle' widget + Scope auto-include) --------- */
+/* A checkbox styled as an iOS-style switch: the real <input> lies invisible over the
+ * whole control so a tap anywhere flips it, and the track/thumb are driven off :checked. */
+.switch { position: relative; display: inline-flex; flex: none; width: 52px; height: 32px; align-self: flex-start; }
+.switch-input { position: absolute; inset: 0; width: 100%; height: 100%; margin: 0; opacity: 0; cursor: pointer; z-index: 1; }
+.switch-track { width: 100%; height: 100%; border-radius: 999px; background: var(--line); transition: background .15s; position: relative; }
+.switch-thumb { position: absolute; top: 3px; left: 3px; width: 26px; height: 26px; border-radius: 50%; background: var(--card); box-shadow: 0 1px 3px rgba(0, 0, 0, .35); transition: transform .15s; }
+.switch-input:checked + .switch-track { background: var(--accent); }
+.switch-input:checked + .switch-track .switch-thumb { transform: translateX(20px); }
+.switch-input:focus-visible + .switch-track { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+/* --- scope field face (inside the profile editor, v2 compact) ----------- */
+.scope-field { display: flex; flex-direction: column; gap: 10px; }
+.scope-field-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.scope-field-count { font-weight: 600; font-size: 14px; }
+.scope-preview { gap: 6px; }
+.scope-chip { max-width: 100%; display: inline-flex; align-items: center; gap: 6px; }
+.scope-chip .chip-text { overflow-wrap: anywhere; }
+.scope-chip.more { color: var(--muted); font-weight: 600; }
+.scope-chip.advanced { border: 1px solid var(--accent); background: transparent; }
+.scope-chip.warn { border: 1px solid var(--warn); background: transparent; color: var(--warn); }
+/* The small state dot on a preview chip: accent for an advanced uid chip, warn for not-installed. */
+.scope-chip-dot { width: 7px; height: 7px; border-radius: 50%; flex: none; background: var(--warn); }
+.scope-chip.advanced .scope-chip-dot { background: var(--accent); }
+.chip-sub { color: var(--muted); font-size: 11px; }
+.chip-avatar-uid { display: inline-flex; align-items: center; justify-content: center; width: 18px; height: 18px; border-radius: 50%; background: var(--accent-weak); color: var(--accent); font-size: 11px; font-weight: 700; }
+/* The auto-include toggle when another profile owns it: the switch plus a short "used by" note. */
+.toggle-locked { display: inline-flex; align-items: center; gap: 10px; }
+.switch.disabled { opacity: .5; }
+
+/* Compact toggle field: one row — title + help stacked on the left, switch inline on the right. */
+.toggle-field { gap: 0; }
+.toggle-row { display: flex; align-items: center; justify-content: space-between; gap: 14px; min-height: 44px; }
+.toggle-main { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; cursor: pointer; }
+.toggle-main .field-help { margin: 0; }
+
+/* --- scope picker page (drill-in) --------------------------------------- */
+/* Search row: a rounded field with a leading search-icon button and a trailing sort-icon button,
+ * both inside the field. Sticky so it rides the top of the scrolling body. */
+.scope-search { position: sticky; top: 0; z-index: 3; background: var(--bg); padding: 4px 0; flex: none; }
+.scope-search-field { display: flex; align-items: center; gap: 4px; background: var(--card); border: 1px solid var(--line); border-radius: 999px; padding: 0 6px; }
+.scope-search-field:focus-within { border-color: var(--accent); }
+.scope-search-input { flex: 1; min-width: 0; border: 0; background: transparent; padding: 10px 2px; color: var(--fg); font: inherit; outline: none; }
+/* The field container owns the focus affordance (its border turns accent); the input inside must show
+ * NO ring of its own. This :focus rule is needed to beat the base `.input:focus` outline it inherits. */
+.scope-search-input:focus { outline: none; box-shadow: none; border: 0; }
+.scope-search-btn, .scope-sort-btn { flex: none; display: inline-flex; align-items: center; justify-content: center; width: 40px; height: 40px; border: 0; background: transparent; color: var(--muted); cursor: pointer; border-radius: 50%; }
+.scope-search-btn { color: var(--accent); }
+.scope-sort-btn:hover { color: var(--accent); background: var(--accent-weak); }
+.scope-sort-btn:focus-visible, .scope-search-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+/* Search + sort glyphs are inline SVG (svgIcon) inheriting currentColor from the button — no CSS icon. */
+.scope-search-btn svg, .scope-sort-btn svg { display: block; }
+
+/* Group filter: full-width segmented control, each seg spanning evenly. */
+.scope-filters { display: flex; align-self: stretch; max-width: 100%; flex: none; }
+.scope-filters .seg { flex: 1; padding: 8px 6px; white-space: nowrap; min-width: 0; }
+
+/* Ops row: the bulk selection verbs on the left, a live selected-count on the right. */
+.scope-ops { display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap; flex: none; padding: 2px 2px 0; }
+.scope-ops-btns { display: flex; align-items: center; gap: 16px; flex-wrap: wrap; }
+.scope-ops-btns .linklike { min-height: 32px; }
+.linklike.danger { color: var(--danger); }
+
+.scope-status { display: flex; align-items: center; gap: 10px; padding: 12px 0; }
+.scope-pinned { display: flex; flex-direction: column; gap: 8px; flex: none; }
+.scope-section-title { font-size: 12px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted); font-weight: 600; }
+
+.scope-list { display: flex; flex-direction: column; gap: 6px; }
+.scope-row { display: flex; align-items: center; gap: 12px; width: 100%; text-align: left; background: var(--card); border: 1px solid var(--line); border-radius: var(--radius-sm); padding: 8px 12px; min-height: 56px; font: inherit; color: var(--fg); cursor: pointer; }
+.scope-row:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+.scope-row.selected { border-color: var(--accent); background: var(--accent-weak); }
+.scope-row.claimed { opacity: .5; cursor: default; }
+.scope-row:disabled { cursor: default; }
+
+/* Row icon: the lazy <img> and its letter-avatar fallback share one 40x40 rounded box. The
+ * avatar is the ONE place a colour is computed inline (an hsl() from a hash of label/uid), so
+ * its white glyph is the sole intentional hard-coded colour in this file. */
+.scope-ico { flex: none; width: 40px; height: 40px; }
+.scope-ico-img { width: 40px; height: 40px; border-radius: 10px; object-fit: cover; background: var(--chip); display: block; }
+.scope-avatar { width: 40px; height: 40px; border-radius: 10px; display: inline-flex; align-items: center; justify-content: center; color: #fff; font-weight: 700; font-size: 16px; }
+/* The compact scope-face preview and any legacy caller still use .avatar; keep it as an alias. */
+.avatar { flex: none; width: 40px; height: 40px; border-radius: 10px; display: inline-flex; align-items: center; justify-content: center; color: #fff; font-weight: 700; font-size: 16px; }
+
+.scope-meta { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 3px; }
+.scope-label { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.scope-name { font-weight: 600; font-size: 14px; overflow-wrap: anywhere; }
+.scope-pkg { color: var(--muted); font-size: 11px; overflow-wrap: anywhere; }
+.scope-pill { font-size: 10px; padding: 2px 8px; }
+.scope-claimed { color: var(--muted); }
+/* Usage badges: a small accent dot when the app has asked for a key since boot, and a pill with
+ * the recorded request count. */
+.scope-recent-dot { width: 8px; height: 8px; border-radius: 50%; flex: none; background: var(--accent); }
+.scope-freq { font-size: 10px; font-weight: 700; padding: 1px 7px; border-radius: 999px; background: var(--chip); color: var(--muted); }
+
+/* The right-side selection box; a check appears when the row is in scope. */
+.scope-check { flex: none; width: 24px; height: 24px; border-radius: 6px; border: 2px solid var(--line); position: relative; }
+.scope-row.selected .scope-check, .scope-check.on { border-color: var(--accent); background: var(--accent); }
+.scope-row.selected .scope-check::after, .scope-check.on::after { content: ""; position: absolute; left: 7px; top: 3px; width: 6px; height: 11px; border: solid var(--accent-fg); border-width: 0 2px 2px 0; transform: rotate(45deg); }
+
+/* --- sort bottom-sheet (scope picker) ----------------------------------- */
+.sort-sheet { display: flex; flex-direction: column; gap: 12px; }
+.sort-list { display: flex; flex-direction: column; gap: 6px; }
+.sort-opt { display: flex; align-items: center; gap: 12px; width: 100%; text-align: left; background: var(--bg); border: 1px solid var(--line); border-radius: var(--radius-sm); padding: 12px 14px; font: inherit; color: var(--fg); cursor: pointer; }
+.sort-opt.on { border-color: var(--accent); background: var(--accent-weak); }
+.sort-opt:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+.sort-opt-main { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+.sort-opt-label { font-weight: 600; font-size: 14px; }
+.sort-opt-check { flex: none; width: 20px; height: 20px; border-radius: 50%; border: 2px solid var(--line); position: relative; }
+.sort-opt-check.on { border-color: var(--accent); background: var(--accent); }
+.sort-opt-check.on::after { content: ""; position: absolute; left: 6px; top: 2px; width: 5px; height: 10px; border: solid var(--accent-fg); border-width: 0 2px 2px 0; transform: rotate(45deg); }

--- a/module/webroot/css/app.css
+++ b/module/webroot/css/app.css
@@ -460,7 +460,7 @@ html, body { overscroll-behavior-y: contain; }
 .switch-input:checked + .switch-track .switch-thumb { transform: translateX(20px); }
 .switch-input:focus-visible + .switch-track { outline: 2px solid var(--accent); outline-offset: 2px; }
 
-/* --- scope field face (inside the profile editor, v2 compact) ----------- */
+/* --- scope field face (compact, inside the profile editor) -------------- */
 .scope-field { display: flex; flex-direction: column; gap: 10px; }
 .scope-field-head { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
 .scope-field-count { font-weight: 600; font-size: 14px; }

--- a/module/webroot/css/theme.css
+++ b/module/webroot/css/theme.css
@@ -19,6 +19,7 @@
   --danger-fg: #fff;
   --warn: #c9821a;
   --chip: #eef1f5;
+  --accent-weak: #e7effb;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -36,6 +37,7 @@
     --danger-fg: #fff;
     --warn: #e6a94d;
     --chip: #262b33;
+    --accent-weak: #223046;
   }
 }
 
@@ -53,6 +55,7 @@
   --danger-fg: #fff;
   --warn: #e6a94d;
   --chip: #262b33;
+  --accent-weak: #223046;
 }
 
 * { box-sizing: border-box; }

--- a/module/webroot/index.html
+++ b/module/webroot/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <!-- Offline by contract: nothing external may ever load. All CSS/JS are local 'self' files. -->
 <meta http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self' http://127.0.0.1:8790; object-src 'none'; base-uri 'none'">
+      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: http://127.0.0.1:8790; font-src 'self'; connect-src 'self' http://127.0.0.1:8790; object-src 'none'; base-uri 'none'">
 <title>TEESimulator</title>
 <link rel="stylesheet" href="css/theme.css">
 <link rel="stylesheet" href="css/app.css">

--- a/module/webroot/js/controllers/config-controller.js
+++ b/module/webroot/js/controllers/config-controller.js
@@ -11,11 +11,17 @@
 
 import { load as ioLoad, save as ioSave, listKeyboxes } from "../data/config-io.js";
 import { getStatus } from "../data/status.js";
+import { keyAdmin, API_BASE, adminToken } from "../data/keyadmin.js";
 import { validateConfig } from "../domain/validate.js";
 import { emptyProfile, emptyConfig, FIELDS, PROFILE_RE } from "../domain/schema.js";
 import { setPath, getPath } from "../domain/path.js";
 import { renderProfileList, renderProfileEditor } from "../ui/config-view.js";
-import { el, clear, toast, confirmDialog, promptDialog, openOverlay } from "../ui/dom.js";
+import { renderScope } from "../ui/scope-view.js";
+import { el, clear, toast, confirmDialog, promptDialog, openOverlay, openSheet } from "../ui/dom.js";
+
+// How often the open Scope page re-fetches the device app list so fresh usage/recency data
+// flows in without a manual reload (point 10). Pull-to-refresh forces one immediately.
+const SCOPE_REFRESH_MS = 9000;
 
 const IDENTITY_FIELDS = FIELDS.filter((f) => f.group === "identity");
 
@@ -33,8 +39,65 @@ export function create(mount) {
   let openGroups = {};       // per-group disclosure state, { groupId: bool }
   let harvest = null;        // the daemon's harvest record, for the resolution hints
 
+  // Scope drill-in state (a second overlay opened ON TOP of the editor). Only one is open
+  // at a time. `packagesCache` is the live device app list fetched lazily the first time the
+  // Scope page opens; it is cached for the life of the page so a second open is instant and
+  // the editor's chips can show real app labels once it exists.
+  //
+  // DRAFT model (point 3): the Scope page edits `scopeDraft`, a private copy of the profile's
+  // apps, and never touches the profile directly. EVERY way out funnels through onScopeClosed,
+  // which — when the draft changed and Done didn't already commit — asks whether to keep the
+  // changes (committing into the in-memory profile; disk still only changes on the editor's Save).
+  // Putting the confirm in onScopeClosed rather than on the buttons is what makes a hardware/gesture
+  // Back ask too, not silently discard. Done pre-commits and sets `scopeCommitted` so it isn't asked.
+  let scoping = null;        // profile name whose scope is being edited
+  let scopeHost = null;      // content element inside the scope overlay
+  let scopeOverlay = null;   // { close } from openOverlay
+  let scopeDraft = [];       // the working copy of the profile's apps (committed only on confirm)
+  let scopeCommitted = false; // Done pre-committed the draft, so onScopeClosed must not ask again
+  let scopeSearch = "";      // the Scope page's search text
+  let scopeSearchTimer = null; // debounce handle for search-driven re-renders
+  let scopeFilter = "recent"; // "recent" (default) | "user" | "system" | "selected"
+  let scopeSort = "freq";    // "freq" (default) | "recent" | "name" | "install"
+  let scopeLoading = false;  // the /packages fetch is in flight
+  let scopeError = null;     // the /packages fetch failed with this message
+  let scopeRefreshTimer = null; // periodic /packages re-fetch while the page is open
+  let packagesCache = null;  // the keyAdmin("packages") result, or null before first fetch
+  let scopeFetchGen = 0;     // monotonic id of the newest /packages fetch, so stale replies are dropped
+  let iconToken = null;      // the admin token, prefetched so /icon URLs build synchronously
+  let scopePullBound = false; // pull-to-refresh listeners attached to scopeHost yet?
+
   function revalidate() {
     errors = validateConfig(config).errors;
+  }
+
+  // A label/installed index over the cached device app list, handed to the editor so a scope
+  // chip can show the app's real name and flag a package that is not installed. Null until the
+  // Scope page has been opened once (before that the chips just show raw package names).
+  function scopeMeta() {
+    if (!packagesCache || !Array.isArray(packagesCache.apps)) return null;
+    const labelMap = new Map();
+    const installedSet = new Set();
+    for (const row of packagesCache.apps) {
+      for (const p of (row.packages || [])) {
+        installedSet.add(p);
+        if (!labelMap.has(p)) labelMap.set(p, row.label || p);
+      }
+    }
+    return { labelMap, installedSet };
+  }
+
+  // uid/package entries claimed by profiles OTHER than `name`, as entry -> owning profile.
+  // The Scope page greys these out so an app can't be double-assigned.
+  function claimedByOther(name) {
+    const m = new Map();
+    for (const other of Object.keys(config.profiles)) {
+      if (other === name) continue;
+      const a = config.profiles[other] && config.profiles[other].apps;
+      if (!Array.isArray(a)) continue;
+      for (const entry of a) if (!m.has(entry)) m.set(entry, other);
+    }
+    return m;
   }
 
   // Best-effort: what `harvested` (and, roughly, `system_property`) resolves to, so the
@@ -61,9 +124,23 @@ export function create(mount) {
     renderProfileList(mount, { config, errors, dirty }, listActions);
   }
 
+  // Which OTHER profile (if any) already owns auto-include, relative to `name`. Only one profile
+  // may, so the editor greys this profile's toggle when another claims it.
+  function autoTakenBy(name) {
+    for (const other of Object.keys(config.profiles)) {
+      if (other === name) continue;
+      if (config.profiles[other] && config.profiles[other].autoIncludeNewApps === true) return other;
+    }
+    return null;
+  }
+
   function renderEditor() {
     if (!editing || !editorHost) return;
-    renderProfileEditor(editorHost, { config, name: editing, errors, keyboxFiles, openGroups, resolved: resolvedLevels() }, editorActions);
+    renderProfileEditor(
+      editorHost,
+      { config, name: editing, errors, keyboxFiles, openGroups, resolved: resolvedLevels(),
+        scopeMeta: scopeMeta(), autoTakenBy: autoTakenBy(editing) },
+      editorActions);
   }
 
   // ---- editor lifecycle -------------------------------------------------
@@ -94,6 +171,333 @@ export function create(mount) {
 
   function closeEditor() {
     if (editorOverlay) editorOverlay.close();
+  }
+
+  // ---- scope drill-in lifecycle (opens on top of the editor) ------------
+  // A URL for the daemon's /icon route. The admin token is prefetched into `iconToken` on open,
+  // so this builds synchronously (a browser <img> cannot set the token header, so it rides the
+  // query, exactly like the log-download route). Null until the token is in hand — the row then
+  // shows a letter-avatar instead.
+  function iconUrl(pkg) {
+    if (!iconToken || !pkg) return null;
+    return API_BASE + "/icon?pkg=" + encodeURIComponent(pkg) + "&token=" + encodeURIComponent(iconToken);
+  }
+
+  function renderScopeView() {
+    if (!scoping || !scopeHost) return;
+    const p = config.profiles[scoping];
+    if (!p) { closeScope(); return; }
+    const scrollTop = captureScopeScroll();
+    renderScope(scopeHost, {
+      profileName: scoping,
+      apps: scopeDraft,
+      packages: packagesCache,
+      claimedByOther: claimedByOther(scoping),
+      firstAppUid: (packagesCache && packagesCache.firstAppUid) || 10000,
+      search: scopeSearch, filter: scopeFilter, sort: scopeSort,
+      loading: scopeLoading, error: scopeError, iconUrl,
+    }, scopeActions);
+    restoreScopeScroll(scrollTop);
+  }
+
+  // Scroll retention across the stateless rebuild (a periodic refresh or a filter tap rebuilds
+  // the whole body). Grab the scrolling body's offset before teardown and reinstate it after.
+  function captureScopeScroll() {
+    const body = scopeHost && scopeHost.querySelector(".drill-body");
+    return body ? body.scrollTop : 0;
+  }
+  function restoreScopeScroll(top) {
+    const body = scopeHost && scopeHost.querySelector(".drill-body");
+    if (!body) return;
+    body.scrollTop = top;
+    requestAnimationFrame(() => { body.scrollTop = top; });
+  }
+
+  // Fetch the live app list and re-render. `initial` shows the spinner (first open); a periodic
+  // or pull refresh replaces the cache silently, preserving the draft/search/filter/sort/scroll.
+  function fetchPackages(initial) {
+    if (initial) { scopeLoading = true; scopeError = null; renderScopeView(); }
+    // Overlapping fetches (the 9s poll racing a pull-to-refresh, or a slow daemon) can resolve out of
+    // order; stamp each with a generation and ignore any response that is not the latest, so an older
+    // in-flight reply can never clobber a newer app list.
+    const gen = ++scopeFetchGen;
+    return keyAdmin("packages")
+      .then((res) => {
+        if (gen !== scopeFetchGen) return; // a newer fetch already superseded this one
+        packagesCache = res || null;
+        scopeError = null; // a later refresh that succeeds must clear a stale initial-load error banner
+        const n = (res && Array.isArray(res.apps)) ? res.apps.length : 0;
+        console.log("[config] scope: /packages returned %d uid entr(y/ies)%s", n, initial ? "" : " (refresh)");
+      })
+      .catch((e) => {
+        if (gen !== scopeFetchGen) return;
+        const msg = (e && e.message) || String(e);
+        if (initial) scopeError = msg;
+        console.warn("[config] scope: /packages failed:", msg);
+      })
+      .finally(() => {
+        if (gen !== scopeFetchGen) return; // stale completion: leave state to the newer fetch
+        scopeLoading = false;
+        if (scoping) renderScopeView();
+      });
+  }
+
+  function openScope(name) {
+    if (!config.profiles[name]) return;
+    scoping = name;
+    scopeSearch = "";
+    scopeFilter = "recent";
+    scopeSort = "freq";
+    scopeError = null;
+    // Draft = a private copy of the profile's current picks. The Scope page mutates this alone;
+    // the profile changes only when kept on the way out (onScopeClosed) or committed by Done.
+    const cur = config.profiles[name].apps;
+    scopeDraft = Array.isArray(cur) ? cur.slice() : [];
+    scopeCommitted = false;
+    scopePullBound = false;
+    scopeHost = el("div", { class: "editor-host" });
+    scopeOverlay = openOverlay(scopeHost, { variant: "panel", label: "Scope", onClose: onScopeClosed });
+
+    // Prefetch the admin token so /icon URLs build synchronously as rows render.
+    adminToken().then((t) => { iconToken = t || null; if (scoping === name) renderScopeView(); }).catch(() => {});
+
+    // Fetch the live app list; if a cache already exists, still refresh it in the background.
+    fetchPackages(!packagesCache);
+    renderScopeView();
+    bindScopePull();
+
+    // Periodic refresh so fresh usage/recency data flows in while the page stays open (point 10).
+    clearInterval(scopeRefreshTimer);
+    scopeRefreshTimer = setInterval(() => { if (scoping === name) fetchPackages(false); }, SCOPE_REFRESH_MS);
+
+    const title = scopeHost.querySelector(".drill-title");
+    if (title) title.focus();
+  }
+
+  // Pull-to-refresh scoped to the Scope page's own scroll container (the .drill-body), not the
+  // document. Kept deliberately small: claim the gesture only when dragging down from the very
+  // top, and force an immediate /packages refetch past a threshold. Listeners bind once to the
+  // persistent scopeHost; the handler reads the current .drill-body each time (it is rebuilt on
+  // every render).
+  function bindScopePull() {
+    if (scopePullBound || !scopeHost) return;
+    scopePullBound = true;
+    const THRESHOLD = 64;
+    let startY = 0, pulling = false, dy = 0, busy = false;
+    const bodyNow = () => scopeHost.querySelector(".drill-body");
+    scopeHost.addEventListener("touchstart", (e) => {
+      const b = bodyNow();
+      pulling = false;
+      if (busy || !b || e.touches.length !== 1 || b.scrollTop > 0) return;
+      startY = e.touches[0].clientY; pulling = true; dy = 0;
+    }, { passive: true });
+    scopeHost.addEventListener("touchmove", (e) => {
+      if (!pulling) return;
+      const b = bodyNow();
+      dy = e.touches[0].clientY - startY;
+      if (dy <= 0 || !b || b.scrollTop > 0) { pulling = false; return; }
+    }, { passive: true });
+    const end = () => {
+      if (!pulling) return;
+      pulling = false;
+      if (dy < THRESHOLD || busy) return;
+      busy = true;
+      console.log("[config] scope: pull-to-refresh");
+      Promise.resolve(fetchPackages(false)).finally(() => { busy = false; });
+    };
+    scopeHost.addEventListener("touchend", end, { passive: true });
+    scopeHost.addEventListener("touchcancel", () => { pulling = false; }, { passive: true });
+  }
+
+  // The SINGLE exit point every close funnels through — the ▸back button, a hardware/gesture Back
+  // (both land here via the overlay's popstate close), and Done (which pre-commits, below). The
+  // confirm lives HERE, not on the buttons, precisely so a hardware Back can't slip past it: when the
+  // draft differs from the profile and Done didn't already commit, we ask — over the editor the page
+  // just closed onto — whether to keep the changes. This is why onScopeClosed launches an async
+  // confirm even though it runs from a sync popstate: the scope DOM is already gone, but the decision
+  // is only "commit the draft into the in-memory profile or not" (disk still waits for the editor's
+  // Save), which needs no scope DOM.
+  function onScopeClosed() {
+    clearTimeout(scopeSearchTimer); // a pending search render must not fire into a torn-down host
+    clearInterval(scopeRefreshTimer);
+    scopeRefreshTimer = null;
+    const name = scoping;
+    const draft = scopeDraft.slice();
+    const committed = scopeCommitted; // Done already wrote the draft in; don't re-ask
+    scoping = null;
+    scopeHost = null;
+    scopeOverlay = null;
+    scopeDraft = [];
+    scopeCommitted = false;
+
+    const p = name && config.profiles[name];
+    if (p && !committed && !sameEntries(draft, p.apps)) {
+      // We are running inside the popstate that just closed this overlay. confirmDialog opens ANOTHER
+      // overlay, which pushes a history entry — and history.pushState fired mid-popstate can be dropped
+      // by the browser, desyncing the nav stack from history (a later Back would then over-pop). Defer
+      // to a fresh task so the confirm's history push happens cleanly after this traversal finishes.
+      setTimeout(() => {
+        confirmDialog("Keep the app selection changes you made?", {
+          confirmLabel: "Keep", cancelLabel: "Discard", danger: false,
+        }).then((keep) => {
+          if (keep && config.profiles[name]) {
+            config.profiles[name].apps = draft;
+            dirty = true;
+            revalidate();
+            console.log("[config] scope: kept %d pick(s) for %s", draft.length, name);
+          } else {
+            console.log("[config] scope: discarded draft changes for %s", name);
+          }
+          renderEditor();
+        });
+      }, 0);
+      return;
+    }
+    renderEditor(); // the editor underneath now reflects the committed chips (or the unchanged ones)
+  }
+
+  function closeScope() {
+    if (scopeOverlay) scopeOverlay.close();
+  }
+
+  // Done: an explicit "use these" — commit the draft into the in-memory profile straight away (no
+  // ask — the tap IS the confirmation), flag it so onScopeClosed doesn't ask again, then close.
+  function commitAndCloseScope() {
+    const p = config.profiles[scoping];
+    if (p && !sameEntries(scopeDraft, p.apps)) {
+      p.apps = scopeDraft.slice();
+      dirty = true;
+      revalidate();
+      console.log("[config] scope: committed %d pick(s) into %s (Done)", p.apps.length, scoping);
+    }
+    scopeCommitted = true;
+    closeScope();
+  }
+
+  // Order-insensitive set comparison of two entry lists (a reorder is not a real change).
+  function sameEntries(a, b) {
+    const A = new Set(Array.isArray(a) ? a : []);
+    const B = new Set(Array.isArray(b) ? b : []);
+    if (A.size !== B.size) return false;
+    for (const x of A) if (!B.has(x)) return false;
+    return true;
+  }
+
+  // The uid an entry resolves to, from the cached device list — so a system/shell pick can be
+  // confirmed before it lands. A uid: token carries its uid directly; a package is looked up in
+  // the /packages inventory. Returns -1 when unknown (uninstalled package: no privileged risk).
+  function uidForEntry(entry) {
+    const m = /^uid:(\d+)$/.exec(entry);
+    if (m) return Number(m[1]);
+    if (packagesCache && Array.isArray(packagesCache.apps)) {
+      for (const row of packagesCache.apps) {
+        if ((row.packages || []).includes(entry)) return row.uid;
+      }
+    }
+    return -1;
+  }
+
+  const scopeActions = {
+    onClose() { closeScope(); },       // leave → onScopeClosed asks to keep changes if the draft moved
+    onDone() { commitAndCloseScope(); }, // Done → commit the draft, then leave without re-asking
+    async onToggleApp(entry) {
+      if (scopeDraft.includes(entry)) {
+        scopeDraft = scopeDraft.filter((a) => a !== entry);
+        console.log("[config] scope: removed %s from draft", entry);
+      } else {
+        // Adding a privileged (system/shell) uid is almost never what a normal user wants —
+        // confirm it explicitly so a mis-tap on a low uid can't silently target system_server.
+        const uid = uidForEntry(entry);
+        const firstAppUid = (packagesCache && packagesCache.firstAppUid) || 10000;
+        if (uid >= 0 && uid < firstAppUid) {
+          const ok = await confirmDialog(
+            `Target privileged uid ${uid}?\n\nThis is a system/shell uid (e.g. shell, system_server), not a normal app. Only do this if you know exactly why.`,
+            { confirmLabel: "Target it", danger: true });
+          if (!ok) return;
+        }
+        scopeDraft = scopeDraft.concat([entry]);
+        console.log("[config] scope: added %s to draft", entry);
+      }
+      renderScopeView();
+    },
+    // Search re-renders the whole page (a few hundred rows), so coalesce fast typing: keep the
+    // value live immediately (so a pending render paints the right text) but defer the rebuild.
+    onSetSearch(text) {
+      scopeSearch = text;
+      clearTimeout(scopeSearchTimer);
+      scopeSearchTimer = setTimeout(() => renderScopeView(), 140);
+    },
+    // The in-field search button / Enter: render right now rather than on the debounce.
+    onSearchSubmit() { clearTimeout(scopeSearchTimer); renderScopeView(); },
+    onSetFilter(id) { scopeFilter = id; renderScopeView(); },
+    onOpenSort() { openSortSheet(); },
+    // The three bulk ops act on the visible entries the view computed, each { add, cur }:
+    // `add` is the entry a select would add, `cur` the entry currently selecting the row.
+    onSelectAllVisible(entries) {
+      const set = new Set(scopeDraft);
+      for (const e of entries) if (!e.cur) set.add(e.add);
+      scopeDraft = Array.from(set);
+      console.log("[config] scope: select-all over %d visible row(s)", entries.length);
+      renderScopeView();
+    },
+    onClearVisible(entries) {
+      const drop = new Set();
+      for (const e of entries) if (e.cur) drop.add(e.cur);
+      scopeDraft = scopeDraft.filter((a) => !drop.has(a));
+      console.log("[config] scope: cleared %d visible pick(s)", drop.size);
+      renderScopeView();
+    },
+    onInvertVisible(entries) {
+      const set = new Set(scopeDraft);
+      for (const e of entries) {
+        if (e.cur) set.delete(e.cur);
+        else set.add(e.add);
+      }
+      scopeDraft = Array.from(set);
+      console.log("[config] scope: inverted %d visible row(s)", entries.length);
+      renderScopeView();
+    },
+    async onClearUsage() {
+      const ok = await confirmDialog(
+        "Clear the recorded app-usage (frequency) memory?\n\nThis wipes the request counts used to sort and populate Recent. It does not change any profile.",
+        { confirmLabel: "Clear usage", danger: true });
+      if (!ok) return;
+      try {
+        const r = await keyAdmin("usageClear");
+        toast("Cleared " + ((r && r.cleared) || 0) + " app" + (((r && r.cleared) || 0) === 1 ? "" : "s"));
+        console.log("[config] scope: usage cleared (%o)", r);
+      } catch (e) {
+        toast("Clear failed: " + ((e && e.message) || e));
+      }
+      fetchPackages(false);
+    },
+  };
+
+  // The sort bottom-sheet (point 8): four options, each with a one-line meaning. Selecting one
+  // sets scopeSort and re-renders. It is a plain sheet built here (the controller owns dom.js).
+  function openSortSheet() {
+    const OPTIONS = [
+      { id: "freq", label: "Frequency", meaning: "Most key requests first (default)." },
+      { id: "recent", label: "Recently used", meaning: "Last requested first." },
+      { id: "name", label: "Name", meaning: "A→Z." },
+      { id: "install", label: "Install time", meaning: "Newest installs first." },
+    ];
+    let handle = null;
+    const pick = (id) => { scopeSort = id; if (handle) handle.close(); renderScopeView(); };
+    const content = el("div", { class: "sort-sheet" }, [
+      el("div", { class: "sheet-head" }, [el("h2", { text: "Sort by" })]),
+      el("div", { class: "sort-list" }, OPTIONS.map((o) => el("button", {
+        type: "button", class: "sort-opt" + (scopeSort === o.id ? " on" : ""),
+        "aria-pressed": scopeSort === o.id ? "true" : "false", onclick: () => pick(o.id),
+      }, [
+        el("span", { class: "sort-opt-main" }, [
+          el("span", { class: "sort-opt-label", text: o.label }),
+          el("span", { class: "sort-opt-meaning muted small", text: o.meaning }),
+        ]),
+        el("span", { class: "sort-opt-check" + (scopeSort === o.id ? " on" : ""), "aria-hidden": "true" }),
+      ]))),
+    ]);
+    handle = openSheet(content, { label: "Sort order" });
   }
 
   // ---- the one save path (used by both the list bar and the editor) -----
@@ -200,6 +604,10 @@ export function create(mount) {
       openGroups[id] = !openGroups[id];
       renderEditor();
     },
+
+    // The scope widget's "Configure scope" button: open the app-picker drill-in for this
+    // profile on top of the editor.
+    openScope(name) { openScope(name); },
 
     // The "empty means harvested — see Harvest" link: close the editor and jump to the
     // System screen, where the harvested values are shown.

--- a/module/webroot/js/controllers/config-controller.js
+++ b/module/webroot/js/controllers/config-controller.js
@@ -20,7 +20,7 @@ import { renderScope } from "../ui/scope-view.js";
 import { el, clear, toast, confirmDialog, promptDialog, openOverlay, openSheet } from "../ui/dom.js";
 
 // How often the open Scope page re-fetches the device app list so fresh usage/recency data
-// flows in without a manual reload (point 10). Pull-to-refresh forces one immediately.
+// flows in without a manual reload. Pull-to-refresh forces one immediately.
 const SCOPE_REFRESH_MS = 9000;
 
 const IDENTITY_FIELDS = FIELDS.filter((f) => f.group === "identity");
@@ -44,7 +44,7 @@ export function create(mount) {
   // Scope page opens; it is cached for the life of the page so a second open is instant and
   // the editor's chips can show real app labels once it exists.
   //
-  // DRAFT model (point 3): the Scope page edits `scopeDraft`, a private copy of the profile's
+  // DRAFT model: the Scope page edits `scopeDraft`, a private copy of the profile's
   // apps, and never touches the profile directly. EVERY way out funnels through onScopeClosed,
   // which — when the draft changed and Done didn't already commit — asks whether to keep the
   // changes (committing into the in-memory profile; disk still only changes on the editor's Save).
@@ -266,7 +266,7 @@ export function create(mount) {
     renderScopeView();
     bindScopePull();
 
-    // Periodic refresh so fresh usage/recency data flows in while the page stays open (point 10).
+    // Periodic refresh so fresh usage/recency data flows in while the page stays open.
     clearInterval(scopeRefreshTimer);
     scopeRefreshTimer = setInterval(() => { if (scoping === name) fetchPackages(false); }, SCOPE_REFRESH_MS);
 
@@ -473,7 +473,7 @@ export function create(mount) {
     },
   };
 
-  // The sort bottom-sheet (point 8): four options, each with a one-line meaning. Selecting one
+  // The sort bottom-sheet: four options, each with a one-line meaning. Selecting one
   // sets scopeSort and re-renders. It is a plain sheet built here (the controller owns dom.js).
   function openSortSheet() {
     const OPTIONS = [

--- a/module/webroot/js/data/keyadmin.js
+++ b/module/webroot/js/data/keyadmin.js
@@ -32,7 +32,7 @@
 //       true for a framework/system-flagged app or any uid below firstAppUid, `launchable`
 //       whether it has a launcher activity, `enabled` the representative app's state.
 //       firstAppUid is Process.FIRST_APPLICATION_UID (10000). Feeds the Scope picker.
-//       The v2 usage columns: `installTime` epoch ms of first install (0 unknown), `freq`
+//       The usage columns: `installTime` epoch ms of first install (0 unknown), `freq`
 //       the persistent count of key requests this app has made (max over its package names,
 //       0 if none), `lastUsed` epoch ms of the last request (0 if never), `recent` true when
 //       the app has asked for a key since THIS boot. These drive the Scope sort/badges.

--- a/module/webroot/js/data/keyadmin.js
+++ b/module/webroot/js/data/keyadmin.js
@@ -23,6 +23,22 @@
 //   keyAdmin("keysDbDelete", { ids }) -> { ok, deleted, requested }
 //       remove those keyentry ids from keystore2; the daemon re-verifies each is one of
 //       our marked target-app keys before deleting, so a stray id is a no-op.
+//   keyAdmin("packages")             -> { ok, firstAppUid,
+//                                          apps:[{ uid, packages:[…], label, system,
+//                                                  launchable, enabled, installTime, freq,
+//                                                  lastUsed, recent }] }
+//       the live device app list, ONE entry per uid (packages sharing a uid are collapsed;
+//       `packages` lists them all, sorted). `label` is the best human name, `system` is
+//       true for a framework/system-flagged app or any uid below firstAppUid, `launchable`
+//       whether it has a launcher activity, `enabled` the representative app's state.
+//       firstAppUid is Process.FIRST_APPLICATION_UID (10000). Feeds the Scope picker.
+//       The v2 usage columns: `installTime` epoch ms of first install (0 unknown), `freq`
+//       the persistent count of key requests this app has made (max over its package names,
+//       0 if none), `lastUsed` epoch ms of the last request (0 if never), `recent` true when
+//       the app has asked for a key since THIS boot. These drive the Scope sort/badges.
+//   keyAdmin("usageClear")           -> { ok, cleared }
+//       wipes the daemon's persisted frequency memory (usage.json). The Scope page's "Clear
+//       usage" button calls this; `cleared` is how many package entries were dropped.
 //   keyAdmin("inspect", { alias })   -> { ok, alias, cert{…}, attestation:{…}|null }
 //   keyAdmin("delete",  { alias })   -> { ok, deleted }
 //   keyAdmin("logs", { after, max }) -> { ok, lines:[{ seq, level, tag, text }], nextAfter }
@@ -73,6 +89,17 @@ function getToken() {
 export const API_BASE = BASE;
 export function adminToken() {
   return getToken();
+}
+
+// GET /icon?pkg=<package>&token=<token> -> raw PNG (the daemon renders the app icon and
+// caches it). A browser <img> cannot set the X-Teesim-Token header, so — exactly like the
+// log-download route — the token rides in the query string. The URL is what an <img src> or
+// CSS background points at; this seam owns the base+token so the view never names either.
+// The Scope controller prefetches adminToken() once and then builds row URLs synchronously,
+// but this async helper is here for any caller that just wants one URL without that dance.
+export async function iconUrlAsync(pkg) {
+  const t = await getToken();
+  return BASE + "/icon?pkg=" + encodeURIComponent(pkg || "") + "&token=" + encodeURIComponent(t || "");
 }
 
 // One request helper: attach the token header, parse JSON, and convert any non-200
@@ -143,6 +170,10 @@ export async function keyAdmin(action, args = {}) {
       return request("GET", "/keys");
     case "keysDb":
       return request("GET", "/keys/db");
+    case "packages":
+      return request("GET", "/packages");
+    case "usageClear":
+      return request("POST", "/usage/clear");
     case "keysDbDelete":
       return request("POST", "/keys/db/delete" + idsQuery(args));
     case "inspect":

--- a/module/webroot/js/domain/schema.js
+++ b/module/webroot/js/domain/schema.js
@@ -16,6 +16,13 @@ export const VERSION = 1;
 // same regexes double as the shell-injection backstop (defence in depth — even
 // unmatched input stays quoted by bridge/shell.js).
 export const PKG_RE = /^[A-Za-z0-9_.]+$/;
+// A raw-uid targeting token (advanced): "uid:" followed by one or more digits, e.g.
+// "uid:10123". It lets a profile target a caller uid directly — a shared-uid app, or an
+// app whose package name is unknown — bypassing package-name resolution. An apps[] entry
+// is valid when it is EITHER a package name OR a uid token; APP_ENTRY_RE is that union and
+// is the per-item check the schema/validator use in place of the package-only PKG_RE.
+export const UID_RE = /^uid:\d+$/;
+export const APP_ENTRY_RE = /^([A-Za-z0-9_.]+|uid:\d+)$/;
 export const PROFILE_RE = /^[A-Za-z0-9_-]{1,32}$/;
 export const KEYBOX_RE = /^[A-Za-z0-9._-]+\.xml$/;
 // harvested | system_property | today | no | YYYY-MM | YYYY-MM-DD, with month 01-12
@@ -92,9 +99,14 @@ export const FIELDS = [
   { key: "imei2", path: ["imei2"], label: "IMEI2", group: "identity", type: "text", required: false, default: "" },
   // --- targeting ----------------------------------------------------------
   {
-    key: "apps", path: ["apps"], label: "Apps", group: "apps", type: "applist",
-    re: PKG_RE, required: true, default: [],
-    help: "Package names this profile attests for. At least one, unique across profiles.",
+    key: "apps", path: ["apps"], label: "Apps", group: "apps", type: "scope",
+    re: APP_ENTRY_RE, required: true, default: [],
+    help: "The apps this profile attests for.",
+  },
+  {
+    key: "autoIncludeNewApps", path: ["autoIncludeNewApps"], label: "Auto-include new apps",
+    group: "apps", type: "toggle", required: false, default: false,
+    help: "Target apps installed after now; existing apps stay untouched.",
   },
 ];
 

--- a/module/webroot/js/domain/validate.js
+++ b/module/webroot/js/domain/validate.js
@@ -3,7 +3,7 @@
 // tests/domain.test.mjs, which is why nothing here touches the DOM or the bridge.
 
 import {
-  FIELDS, KEYBOX_RE, PKG_RE, PROFILE_RE, VERSION,
+  FIELDS, KEYBOX_RE, APP_ENTRY_RE, PROFILE_RE, VERSION,
 } from "./schema.js";
 import { getPath } from "./path.js";
 
@@ -24,14 +24,19 @@ export function validateProfile(name, profile) {
   for (const f of FIELDS) {
     const value = getPath(profile, f.path);
 
-    if (f.type === "applist") {
+    if (f.type === "applist" || f.type === "scope") {
       const apps = Array.isArray(value) ? value : [];
-      if (f.required && apps.length < 1) {
-        errors.push({ field: f.key, msg: "At least one app is required." });
+      // "At least one app" no longer holds when auto-include covers the profile: an empty
+      // apps list is fine precisely when autoIncludeNewApps is on (the daemon then targets
+      // every unclaimed user app, so there is nothing to hand-pick).
+      const autoIncludes = profile.autoIncludeNewApps === true;
+      if (f.required && apps.length < 1 && !autoIncludes) {
+        errors.push({ field: f.key, msg: "At least one app is required (or turn on Auto-include new apps)." });
       }
-      for (const pkg of apps) {
-        if (typeof pkg !== "string" || !PKG_RE.test(pkg)) {
-          errors.push({ field: f.key, msg: `Invalid package name: ${pkg}` });
+      // Each entry is a package name OR a raw uid: token (APP_ENTRY_RE), not package-only.
+      for (const entry of apps) {
+        if (typeof entry !== "string" || !APP_ENTRY_RE.test(entry)) {
+          errors.push({ field: f.key, msg: `Invalid app entry: ${entry}` });
         }
       }
       continue;
@@ -43,6 +48,11 @@ export function validateProfile(name, profile) {
       }
       continue;
     }
+
+    // A toggle carries a boolean, not a string, so it is never format-checked (its regex-less
+    // descriptor already skips the scalar branch below, but guard explicitly so a future
+    // required/re on a non-string type can't misfire against the empty-string check).
+    if (f.type === "toggle") continue;
 
     // Generic scalar. Format is checked only when a value is present, so an
     // optional field left blank is fine; presence is a separate, explicit flag.
@@ -98,9 +108,23 @@ export function validateConfig(config) {
       for (const name of claimants) {
         errors.push({
           profile: name, field: "apps",
-          msg: `Package ${pkg} is claimed by ${claimants.length} profiles; it must be unique.`,
+          msg: `App entry ${pkg} is claimed by ${claimants.length} profiles; it must be unique.`,
         });
       }
+    }
+  }
+
+  // Auto-include is a whole-device catch-all ("every unclaimed user app"), so two profiles
+  // both asking for it would fight over the same apps — the daemon allows at most one. Flag
+  // every offender so the user sees exactly which profiles to reconcile.
+  const autoProfiles = Object.keys(profiles).filter(
+    (name) => profiles[name] && profiles[name].autoIncludeNewApps === true);
+  if (autoProfiles.length > 1) {
+    for (const name of autoProfiles) {
+      errors.push({
+        profile: name, field: "autoIncludeNewApps",
+        msg: `Only one profile may auto-include new apps; ${autoProfiles.length} do.`,
+      });
     }
   }
 

--- a/module/webroot/js/ui/config-view.js
+++ b/module/webroot/js/ui/config-view.js
@@ -133,7 +133,7 @@ export function renderProfileEditor(host, state, actions) {
   const scrollTop = captureScroll(host);
   clear(host);
 
-  const { config, name, errors = [], keyboxFiles = [], openGroups = {}, resolved = {} } = state;
+  const { config, name, errors = [], keyboxFiles = [], openGroups = {}, resolved = {}, scopeMeta = null, autoTakenBy = null } = state;
   const profile = config.profiles[name];
   if (!profile) { actions.onClose(); return; }
 
@@ -191,6 +191,18 @@ export function renderProfileEditor(host, state, actions) {
       id: fieldId(name, d.key), keyboxFiles,
       addApp: (pkg) => actions.onAddApp(name, pkg),
       removeApp: (pkg) => actions.onRemoveApp(name, pkg),
+      // The scope widget only shows the current picks and a button that opens the picker;
+      // labelMap/installedSet let its chips show real app names and flag uninstalled ones,
+      // and are null until the Scope page has been opened once (then the chips light up).
+      openScope: () => actions.openScope(name),
+      labelMap: scopeMeta && scopeMeta.labelMap,
+      installedSet: scopeMeta && scopeMeta.installedSet,
+      // So the scope face can say "auto-include on — new apps added automatically" instead of
+      // "no apps" when the profile relies on auto-include rather than explicit picks.
+      autoInclude: getPath(profile, ["autoIncludeNewApps"]) === true,
+      // The auto-include toggle disables itself (with a note) when ANOTHER profile already owns
+      // auto-include — only one profile may, so the conflict shows before Save rejects it.
+      autoTakenBy,
     };
     const onChange = (path, v) => actions.onFieldChange(name, path, v);
     const fieldEl = renderField(d, value, onChange, ctx);

--- a/module/webroot/js/ui/dom.js
+++ b/module/webroot/js/ui/dom.js
@@ -35,6 +35,37 @@ export function clear(node) {
   while (node.firstChild) node.removeChild(node.firstChild);
 }
 
+// An inline SVG icon built the same crisp, theme-adaptive way as the bottom-nav icons: a 24x24
+// stroke icon that inherits `currentColor`, so it tints with the surrounding text in either theme.
+// `paths` is an array of <path>/<circle>/<line> descriptors { d } or { cx, cy, r } etc.; SVG needs
+// the SVG namespace, which document.createElement (used by el()) does not set — hence createElementNS.
+const SVG_NS = "http://www.w3.org/2000/svg";
+export function svgIcon(shapes, { size = 20, cls = "" } = {}) {
+  const svg = document.createElementNS(SVG_NS, "svg");
+  svg.setAttribute("viewBox", "0 0 24 24");
+  svg.setAttribute("width", String(size));
+  svg.setAttribute("height", String(size));
+  svg.setAttribute("fill", "none");
+  svg.setAttribute("stroke", "currentColor");
+  svg.setAttribute("stroke-width", "2");
+  svg.setAttribute("stroke-linecap", "round");
+  svg.setAttribute("stroke-linejoin", "round");
+  svg.setAttribute("aria-hidden", "true");
+  if (cls) svg.setAttribute("class", cls);
+  for (const s of shapes) {
+    const tag = s.d ? "path" : s.tag || "path";
+    const n = document.createElementNS(SVG_NS, tag);
+    for (const [k, v] of Object.entries(s)) if (k !== "tag") n.setAttribute(k, v);
+    svg.appendChild(n);
+  }
+  return svg;
+}
+
+// The two glyphs the Scope search bar needs, as reusable shape sets: a magnifying glass and a
+// descending-bars "sort" mark. Kept here next to svgIcon so any view can reuse them.
+export const ICON_SEARCH = [{ tag: "circle", cx: 11, cy: 11, r: 7 }, { d: "M20 20l-3.6-3.6" }];
+export const ICON_SORT = [{ d: "M4 6h16" }, { d: "M6 12h12" }, { d: "M9 18h6" }];
+
 // Transient toast. Owns the #toast host declared in index.html.
 export function toast(msg) {
   const t = document.getElementById("toast");

--- a/module/webroot/js/ui/field.js
+++ b/module/webroot/js/ui/field.js
@@ -4,15 +4,26 @@
 // renderField(descriptor, value, onChange, context) -> HTMLElement
 //   value    the current value, already read at descriptor.path by the caller
 //   onChange (path, value) => ...  for scalar widgets (text/select/patch/keybox)
-//   context  { id, keyboxFiles, addApp(pkg), removeApp(pkg) }
+//   context  { id, keyboxFiles, addApp(entry), removeApp(entry), openScope(),
+//              labelMap, installedSet, autoInclude, autoTakenBy }
 //            - id           stable element id, so a re-render can restore focus
 //            - keyboxFiles  choices for the 'keybox' widget
-//            - addApp/removeApp  the applist widget's structural callbacks
+//            - addApp/removeApp  the applist/scope widget's structural callbacks
+//            - openScope    the scope widget's "Configure scope" jump (opens the picker)
+//            - labelMap     optional Map(package -> human label) so a scope chip can show
+//                           the app's real name, not just its package
+//            - installedSet optional Set of installed package names, so a scope chip can
+//                           flag a package that is not currently installed on the device
+//            - autoInclude  whether this profile has auto-include on (scope face empty state)
+//            - autoTakenBy  for the auto-include toggle: the OTHER profile that already owns
+//                           auto-include (or null); when set, the switch renders disabled with
+//                           a "(used by <name>)" note, since only one profile may auto-include
 //
 // A new descriptor of an EXISTING type needs no edit here. A new type is one new
 // case below.
 
 import { el } from "./dom.js";
+import { UID_RE } from "../domain/schema.js";
 
 export function renderField(descriptor, value, onChange, context = {}) {
   switch (descriptor.type) {
@@ -24,6 +35,10 @@ export function renderField(descriptor, value, onChange, context = {}) {
       return labelled(descriptor, patchWidget(descriptor, value, onChange, context));
     case "applist":
       return labelled(descriptor, applistWidget(descriptor, value, context));
+    case "scope":
+      return labelled(descriptor, scopeWidget(descriptor, value, context));
+    case "toggle":
+      return toggleField(descriptor, value, onChange, context);
     case "text":
     default:
       return labelled(descriptor, textWidget(descriptor, value, onChange, context));
@@ -39,9 +54,12 @@ export function renderField(descriptor, value, onChange, context = {}) {
 // id rather than the id-less wrapper, otherwise those fields have no programmatic
 // label.
 function labelled(descriptor, control) {
+  // Prefer a real form control; but a compound widget (the scope face) has none — its only id-bearing
+  // focusable is the "Configure scope" <button id=ctx.id>, so fall back to the first element carrying
+  // an id, restoring the label→control association rather than emitting for=null.
   const focusable = control.matches("input, select, textarea")
     ? control
-    : control.querySelector("input, select, textarea");
+    : control.querySelector("input, select, textarea") || control.querySelector("[id]");
   return el("div", { class: "field" }, [
     el("label", { class: "field-label", for: (focusable && focusable.id) || null, text: descriptor.label }),
     control,
@@ -137,4 +155,85 @@ function applistWidget(d, value, ctx) {
   const add = el("button", { type: "button", class: "btn", text: "Add", onclick: submit });
 
   return el("div", {}, [chips, el("div", { class: "add-row" }, [input, add])]);
+}
+
+// A labelled switch: a checkbox styled as an iOS-style toggle. The visible track/thumb is
+// a sibling of the (visually hidden but full-size) checkbox, so a tap anywhere on the track
+// flips it and CSS drives the thumb off `:checked`. onChange gets the boolean, never a string.
+//
+// Auto-include is a whole-device catch-all, so at most one profile may own it: when another
+// profile already does, ctx.autoTakenBy names it and the switch renders disabled with a short
+// "(used by <name>)" note, so the conflict is legible before Save rejects it.
+// A compact settings ROW (not the three-line label/control/help stack): the title and its help sit
+// stacked on the left as a <label for> that also toggles, and the switch sits inline on the right.
+// The help doubles as the "used by <profile>" note when auto-include is locked to another profile.
+function toggleField(d, value, onChange, ctx) {
+  const checked = value === true;
+  const locked = d.key === "autoIncludeNewApps" && !!ctx.autoTakenBy && !checked;
+  const input = el("input", {
+    id: ctx.id, class: "switch-input", type: "checkbox", checked, disabled: locked,
+    role: "switch", "aria-checked": checked ? "true" : "false",
+    onchange: locked ? null : (e) => onChange(d.path, e.target.checked),
+  });
+  const sw = el("span", { class: "switch" + (checked ? " on" : "") + (locked ? " disabled" : "") }, [
+    input,
+    el("span", { class: "switch-track", "aria-hidden": "true" }, [el("span", { class: "switch-thumb" })]),
+  ]);
+  const sub = locked ? "Used by profile “" + ctx.autoTakenBy + "”" : d.help;
+  return el("div", { class: "field toggle-field" }, [
+    el("div", { class: "toggle-row" }, [
+      el("label", { class: "toggle-main", for: ctx.id }, [
+        el("span", { class: "field-label", text: d.label }),
+        sub ? el("span", { class: "field-help", text: sub }) : null,
+      ]),
+      sw,
+    ]),
+  ]);
+}
+
+// The scope field's compact read-only face inside the editor (v2, point 2). Selection happens
+// on the Scope page (ctx.openScope); here we only SUMMARISE it in the fewest words: a header row
+// with the count and a "Configure scope →" button, then a preview of at most a handful of app
+// chips (label only — no package sub-line, no long tally). Extra picks collapse into a "+K more"
+// chip. A not-installed / advanced entry gets a small warn dot, never a paragraph. It stays
+// resilient before the device app list is fetched: labelMap/installedSet are optional, so a chip
+// degrades to its raw package name.
+const SCOPE_PREVIEW_MAX = 6;
+
+function scopeWidget(d, value, ctx) {
+  const apps = Array.isArray(value) ? value : [];
+  const labelMap = ctx.labelMap || null;         // package -> human label
+  const installedSet = ctx.installedSet || null; // installed package names
+
+  const header = el("div", { class: "scope-field-head" }, [
+    el("span", { class: "scope-field-count", text: apps.length ? apps.length + (apps.length === 1 ? " app" : " apps") : "No apps" }),
+    el("button", { id: ctx.id, type: "button", class: "btn primary small", text: "Configure scope →", onclick: () => ctx.openScope && ctx.openScope() }),
+  ]);
+
+  const kids = [header];
+
+  if (apps.length) {
+    const shown = apps.slice(0, SCOPE_PREVIEW_MAX);
+    const chips = shown.map((entry) => {
+      const isUid = UID_RE.test(entry);
+      const missing = !isUid && installedSet && !installedSet.has(entry);
+      const label = isUid ? entry : ((labelMap && labelMap.get && labelMap.get(entry)) || entry);
+      return el("span", {
+        class: "chip scope-chip" + (isUid ? " advanced" : "") + (missing ? " warn" : ""),
+        title: isUid ? "Advanced: targets caller uid " + entry.slice(4)
+          : missing ? entry + " is not installed (a name-match applies if it installs later)" : entry,
+      }, [
+        (isUid || missing) ? el("span", { class: "scope-chip-dot", "aria-hidden": "true" }) : null,
+        el("span", { class: "chip-text" + (isUid ? " mono" : ""), text: label }),
+      ]);
+    });
+    if (apps.length > SCOPE_PREVIEW_MAX) {
+      chips.push(el("span", { class: "chip scope-chip more", text: "+" + (apps.length - SCOPE_PREVIEW_MAX) + " more" }));
+    }
+    kids.push(el("div", { class: "applist scope-preview" }, chips));
+  } else if (ctx.autoInclude) {
+    kids.push(el("span", { class: "muted small", text: "Auto-include on — new apps added automatically." }));
+  }
+
+  return el("div", { class: "scope-field" }, kids);
 }

--- a/module/webroot/js/ui/field.js
+++ b/module/webroot/js/ui/field.js
@@ -191,7 +191,7 @@ function toggleField(d, value, onChange, ctx) {
   ]);
 }
 
-// The scope field's compact read-only face inside the editor (v2, point 2). Selection happens
+// The scope field's compact read-only face inside the editor. Selection happens
 // on the Scope page (ctx.openScope); here we only SUMMARISE it in the fewest words: a header row
 // with the count and a "Configure scope →" button, then a preview of at most a handful of app
 // chips (label only — no package sub-line, no long tally). Extra picks collapse into a "+K more"

--- a/module/webroot/js/ui/scope-view.js
+++ b/module/webroot/js/ui/scope-view.js
@@ -1,0 +1,387 @@
+// The Scope picker (v2): a full-screen drill-in that turns a profile's opaque list of
+// package strings into a browsable, searchable, sortable view of the LIVE device app list.
+// It is the counterpart to config-view's editor drill-in and follows the exact same
+// contract — stateless, rebuilt on every call, no imports from data/* or bridge/*. The
+// controller owns all state (the fetched /packages result, the search text, the filter, the
+// sort, this profile's DRAFT apps array) and hands a fresh snapshot in on every intent; this
+// file only paints it and calls back through `actions`. It never writes into the profile —
+// the controller mutates a draft and asks to save on the way out.
+//
+//   renderScope(host, state, actions)
+//     host    the overlay content node (an .editor-host div)
+//     state   { profileName, apps, packages, claimedByOther, firstAppUid,
+//               search, filter, sort, loading, error, iconUrl }
+//               - apps            the DRAFT entry strings (packages + uid: tokens)
+//               - packages        the keyAdmin("packages") result, or null while loading; each
+//                                 row carries uid/packages/label/system/launchable/enabled plus
+//                                 the v2 usage columns installTime/freq/lastUsed/recent
+//               - claimedByOther  Map(entry -> owning profile name) for entries already claimed
+//                                 by ANOTHER profile (greyed out and inert here)
+//               - firstAppUid     Process.FIRST_APPLICATION_UID; uids below it warn
+//               - filter          "recent" | "user" | "system" | "selected" (Recent is default)
+//               - sort            "freq" | "recent" | "name" | "install"
+//               - iconUrl         fn(pkg) -> a daemon /icon URL string, or null before the admin
+//                                 token is in hand; the row <img> falls back to a letter-avatar
+//     actions { onClose (leave — asks to keep changes if any), onDone (commit + leave),
+//               onToggleApp(entry), onSetSearch(text), onSearchSubmit(),
+//               onSetFilter(id), onOpenSort(), onClearUsage(),
+//               onSelectAllVisible(entries), onClearVisible(entries), onInvertVisible(entries) }
+//
+// Selecting a normal app toggles its PACKAGE-NAME entry (the primary, sorted package), never a
+// uid: token — uid tokens are advanced and only ever added/removed manually, or removed from
+// the pinned "In scope" section here. The three bulk ops act on the CURRENTLY visible rows
+// only: the view computes that set and hands it to the controller as { add, cur } descriptors.
+
+import { el, clear, svgIcon, ICON_SEARCH, ICON_SORT } from "./dom.js";
+import { UID_RE } from "../domain/schema.js";
+
+const SEARCH_ID = "scope-search-input";
+
+// Recent is first and default: the apps that have asked for a key since this boot are what a
+// user most likely wants to target. The rest split into user apps, system, and current picks.
+const FILTERS = [
+  { id: "recent", label: "Recent" },
+  { id: "user", label: "User" },
+  { id: "system", label: "System" },
+  { id: "selected", label: "Selected" },
+];
+
+// A stable, pleasant avatar colour from any string: a tiny rolling hash into a hue, with fixed
+// saturation/lightness so white avatar text always reads. This is the one place a literal colour
+// is computed (an hsl()) rather than read from a token — an avatar tint is inherently per-item
+// and cannot come from the small theme palette.
+function hashColor(str) {
+  let h = 0;
+  const s = String(str || "");
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) >>> 0;
+  return `hsl(${h % 360} 52% 42%)`;
+}
+
+// The avatar glyph: first letter of the label (or package, or "?"), uppercased.
+function avatarLetter(label, pkg) {
+  const src = (label && label.trim()) || pkg || "?";
+  const ch = src.trim().charAt(0);
+  return /[a-z0-9]/i.test(ch) ? ch.toUpperCase() : "#";
+}
+
+export function renderScope(host, state, actions) {
+  const focus = captureFocus(host);
+  clear(host);
+
+  const {
+    profileName, apps = [], packages = null, claimedByOther = new Map(),
+    firstAppUid = 10000, search = "", filter = "recent", sort = "freq",
+    loading = false, error = null,
+  } = state;
+  const iconUrl = typeof state.iconUrl === "function" ? state.iconUrl : () => null;
+
+  const appsSet = new Set(apps);
+
+  // ---- header ----------------------------------------------------------
+  host.appendChild(el("div", { class: "drill-head" }, [
+    el("button", { class: "iconbtn", type: "button", "aria-label": "Back to profile", onclick: () => actions.onClose() }, [
+      el("span", { class: "chevron-left", "aria-hidden": "true" }),
+    ]),
+    el("h1", { class: "drill-title", text: "Scope — " + profileName, tabindex: "-1" }),
+  ]));
+
+  const body = el("div", { class: "drill-body" });
+
+  // ---- search row: a leading search-icon button inside the field, a trailing sort button ----
+  const searchInput = el("input", {
+    id: SEARCH_ID, class: "input scope-search-input", type: "search", value: search,
+    placeholder: "Search apps, packages, or uid…",
+    autocapitalize: "off", autocorrect: "off", spellcheck: "false",
+    oninput: (e) => actions.onSetSearch(e.target.value),
+    onkeydown: (e) => { if (e.key === "Enter") { e.preventDefault(); actions.onSearchSubmit(); } },
+  });
+  body.appendChild(el("div", { class: "scope-search" }, [
+    el("div", { class: "scope-search-field" }, [
+      el("button", { type: "button", class: "scope-search-btn", "aria-label": "Search", onclick: () => actions.onSearchSubmit() }, [
+        svgIcon(ICON_SEARCH, { size: 18 }),
+      ]),
+      searchInput,
+      el("button", { type: "button", class: "scope-sort-btn", "aria-label": "Sort order", onclick: () => actions.onOpenSort() }, [
+        svgIcon(ICON_SORT, { size: 18 }),
+      ]),
+    ]),
+  ]));
+
+  // ---- group filter: full-width segmented, each seg spanning evenly -----
+  body.appendChild(el("div", { class: "segmented scope-filters" },
+    FILTERS.map((f) => el("button", {
+      type: "button", class: "seg" + (filter === f.id ? " on" : ""),
+      "aria-pressed": filter === f.id ? "true" : "false",
+      onclick: () => actions.onSetFilter(f.id),
+    }, f.label))));
+
+  // ---- loading / error short-circuits ---------------------------------
+  if (loading) {
+    body.appendChild(el("div", { class: "scope-status" }, [
+      el("span", { class: "spinner" }), el("span", { class: "muted", text: "Reading installed apps…" }),
+    ]));
+  } else if (error) {
+    body.appendChild(el("div", { class: "banner error" }, [
+      el("div", { text: "Could not read the device app list" }),
+      el("div", { class: "muted small", text: String(error) }),
+    ]));
+  }
+
+  // The installed inventory, for both the pinned "orphan" computation and the main list.
+  const installed = (packages && Array.isArray(packages.apps)) ? packages.apps : [];
+  const installedPkgs = new Set();
+  const installedUids = new Set();
+  for (const row of installed) {
+    installedUids.add(row.uid);
+    (row.packages || []).forEach((p) => installedPkgs.add(p));
+  }
+
+  // The visible rows: search + group filter, then sorted. Computed once so the ops row and the
+  // list share exactly the same set (the ops act only on what the user can see).
+  const q = search.trim().toLowerCase();
+  const rows = installed
+    .filter((row) => matchSearch(row, q))
+    .filter((row) => matchFilter(row, filter, isSelected(row, appsSet)))
+    // Selected rows always float to the top of every group (and of a search result), with the chosen
+    // sort applied within the selected and unselected partitions alike — so what you've picked is
+    // right there, and the rest stays ordered underneath.
+    .sort((a, b) => {
+      const sa = isSelected(a, appsSet) ? 0 : 1;
+      const sb = isSelected(b, appsSet) ? 0 : 1;
+      return sa - sb || compareRows(a, b, sort);
+    });
+
+  // The bulk-op targets: every visible row NOT claimed by another profile AND not a privileged
+  // (system/shell) uid — those are excluded so Select-all/Invert can never add a uid < firstAppUid
+  // without the deliberate per-row confirm that onToggleApp enforces. Each is { add, cur }: the entry
+  // a select would add, and the entry (if any) currently selecting it (to remove).
+  const visibleEntries = rows
+    .filter((row) => !claimOf(row, claimedByOther) && row.uid >= firstAppUid)
+    .map((row) => {
+      const pkgs = row.packages || [];
+      const add = pkgs[0] || ("uid:" + row.uid);
+      const cur = pkgs.find((p) => appsSet.has(p)) || (appsSet.has("uid:" + row.uid) ? "uid:" + row.uid : null);
+      return { add, cur };
+    });
+
+  // ---- ops row: Select all / Clear / Invert (+ Clear usage in Recent) --
+  if (!loading && packages) {
+    const selectedCount = apps.length;
+    const ops = el("div", { class: "scope-ops" }, [
+      el("div", { class: "scope-ops-btns" }, [
+        el("button", { type: "button", class: "linklike", text: "Select all", onclick: () => actions.onSelectAllVisible(visibleEntries) }),
+        el("button", { type: "button", class: "linklike", text: "Clear", onclick: () => actions.onClearVisible(visibleEntries) }),
+        el("button", { type: "button", class: "linklike", text: "Invert", onclick: () => actions.onInvertVisible(visibleEntries) }),
+        filter === "recent"
+          ? el("button", { type: "button", class: "linklike danger", text: "Clear usage", onclick: () => actions.onClearUsage() })
+          : null,
+      ]),
+      el("span", { class: "muted small", text: selectedCount + " selected" }),
+    ]);
+    body.appendChild(ops);
+  }
+
+  // ---- pinned "In scope" section: selected entries with no visible row -
+  // A selected package that is not installed, or a raw uid: token whose uid is not in the live
+  // list, has no row below to show it checked — so pin it at the top, always visible, flagged,
+  // with a remove ✕. (Installed selections just show checked in the list.)
+  const orphans = apps.filter((entry) => {
+    if (UID_RE.test(entry)) return !installedUids.has(Number(entry.slice(4)));
+    return !installedPkgs.has(entry);
+  });
+  if (orphans.length) {
+    body.appendChild(el("div", { class: "scope-pinned" }, [
+      el("div", { class: "scope-section-title", text: "In scope" }),
+      el("div", { class: "applist" }, orphans.map((entry) => {
+        const isUid = UID_RE.test(entry);
+        return el("span", {
+          class: "chip removable scope-chip" + (isUid ? " advanced" : " warn"),
+          title: isUid ? "Advanced: targets caller uid " + entry.slice(4) : entry + " is not installed on this device",
+        }, [
+          isUid ? el("span", { class: "chip-avatar-uid", "aria-hidden": "true", text: "#" }) : null,
+          el("span", { class: "chip-text" + (isUid ? " mono" : ""), text: entry }),
+          el("span", { class: "chip-sub", text: isUid ? "advanced uid" : "not installed" }),
+          el("button", { type: "button", class: "chip-x", "aria-label": "Remove " + entry, text: "✕", onclick: () => actions.onToggleApp(entry) }),
+        ]);
+      })),
+    ]));
+  }
+
+  // ---- the main list ---------------------------------------------------
+  if (!loading && packages) {
+    // Suppress the "nothing here" card when the Selected group's only picks are orphans — they are
+    // already shown, checked, in the pinned "In scope" section right above, so an empty card would
+    // contradict it.
+    const orphansShown = filter === "selected" && !q && orphans.length > 0;
+    if (!rows.length && !orphansShown) {
+      body.appendChild(el("div", { class: "card empty" }, [
+        el("p", { class: "muted", text: emptyText(filter, installed.length, q) }),
+      ]));
+    } else if (rows.length) {
+      const list = el("div", { class: "scope-list" });
+      for (const row of rows) {
+        list.appendChild(scopeRow(row, { appsSet, claimedByOther, firstAppUid, iconUrl }, actions));
+      }
+      body.appendChild(list);
+    }
+  }
+
+  host.appendChild(body);
+
+  // ---- footer: live count + Done --------------------------------------
+  host.appendChild(el("div", { class: "drill-foot" }, [
+    el("span", { class: "status" }, [
+      el("span", { class: "dot ok" }),
+      el("span", { class: "muted small", text: apps.length + " selected" }),
+    ]),
+    el("button", { class: "btn primary", text: "Done", onclick: () => actions.onDone() }),
+  ]));
+
+  restoreFocus(focus);
+}
+
+// The empty-list line, worded for the active group so it never reads as an error.
+function emptyText(filter, total, q) {
+  if (!total) return "No apps found on the device.";
+  if (q) return "No apps match “" + q + "”.";
+  if (filter === "recent") return "No app has requested a key since boot yet.";
+  if (filter === "selected") return "Nothing selected yet — tap an app to add it.";
+  return "No apps match.";
+}
+
+// Is this uid-row currently in scope — by any of its package names, or by a uid: token?
+function isSelected(row, appsSet) {
+  if (appsSet.has("uid:" + row.uid)) return true;
+  return (row.packages || []).some((p) => appsSet.has(p));
+}
+
+function matchSearch(row, q) {
+  if (!q) return true;
+  if (row.label && row.label.toLowerCase().includes(q)) return true;
+  if (String(row.uid).includes(q)) return true;
+  return (row.packages || []).some((p) => p.toLowerCase().includes(q));
+}
+
+function matchFilter(row, filter, selected) {
+  if (filter === "selected") return selected;
+  if (filter === "recent") return row.recent === true;
+  const isUser = row.launchable && !row.system;
+  if (filter === "user") return isUser;
+  if (filter === "system") return row.system || !row.launchable;
+  return true;
+}
+
+// Whom does this row belong to elsewhere? Any of its packages or its uid token; null if free.
+function claimOf(row, claimedByOther) {
+  for (const p of (row.packages || [])) if (claimedByOther.has(p)) return claimedByOther.get(p);
+  if (claimedByOther.has("uid:" + row.uid)) return claimedByOther.get("uid:" + row.uid);
+  return null;
+}
+
+// The list order, per the chosen sort. Frequency and install/recency are numeric with a label
+// tiebreak so equal-usage apps still read alphabetically; Name is a pure locale compare. The
+// Recent GROUP is a filter, not a sort — it can be viewed in any of these orders.
+function compareRows(a, b, sort) {
+  if (sort === "name") return byLabel(a, b);
+  if (sort === "recent") return (b.lastUsed || 0) - (a.lastUsed || 0) || byLabel(a, b);
+  if (sort === "install") return (b.installTime || 0) - (a.installTime || 0) || byLabel(a, b);
+  return (b.freq || 0) - (a.freq || 0) || byLabel(a, b); // "freq" (default)
+}
+
+function byLabel(a, b) {
+  return String(a.label || "").localeCompare(String(b.label || ""));
+}
+
+// One tappable row for a uid. Selecting toggles the primary package-name entry (or, when the row
+// is already selected via a specific package / uid token, that same entry, so a tap truly
+// un-selects). A row already owned by another profile is greyed out and inert.
+function scopeRow(row, ctx, actions) {
+  const { appsSet, claimedByOther, firstAppUid, iconUrl } = ctx;
+  const pkgs = (row.packages || []).slice();
+  const primary = pkgs[0] || ("uid:" + row.uid);
+  const label = row.label || primary;
+
+  const selectedByPkg = pkgs.find((p) => appsSet.has(p));
+  const selectedByUid = appsSet.has("uid:" + row.uid);
+  const selected = !!selectedByPkg || selectedByUid;
+
+  const claimedBy = claimOf(row, claimedByOther);
+  const lowUid = row.uid < firstAppUid;
+
+  // The entry a tap acts on: the package/token that is selected (to remove it) or the primary
+  // package (to add it).
+  const toggleEntry = selectedByPkg || (selectedByUid ? ("uid:" + row.uid) : primary);
+
+  const pkgLine = pkgs.length
+    ? (pkgs.length === 1 ? pkgs[0] : pkgs[0] + " +" + (pkgs.length - 1))
+    : "uid:" + row.uid;
+
+  const pills = [];
+  if (lowUid) pills.push(el("span", { class: "pill warn scope-pill", text: "system uid" }));
+  if (claimedBy) pills.push(el("span", { class: "chip small scope-claimed", text: "in " + claimedBy }));
+  if (row.recent) pills.push(el("span", { class: "scope-recent-dot", title: "Requested a key since boot", "aria-label": "recent" }));
+  if (row.freq > 0) pills.push(el("span", { class: "scope-freq", title: row.freq + " key requests recorded", text: fmtFreq(row.freq) }));
+
+  const cls = "scope-row" + (selected ? " selected" : "") + (claimedBy ? " claimed" : "");
+
+  return el("button", {
+    type: "button", class: cls, disabled: !!claimedBy,
+    "aria-pressed": selected ? "true" : "false",
+    title: claimedBy ? "Already targeted by profile " + claimedBy : label,
+    onclick: claimedBy ? null : () => actions.onToggleApp(toggleEntry),
+  }, [
+    iconEl(row, primary, label, iconUrl),
+    el("span", { class: "scope-meta" }, [
+      el("span", { class: "scope-label" }, [
+        el("span", { class: "scope-name", text: label }),
+        ...pills,
+      ]),
+      el("span", { class: "scope-pkg mono", text: pkgLine + "  ·  uid " + row.uid + (row.enabled === false ? "  ·  disabled" : "") }),
+    ]),
+    el("span", { class: "scope-check" + (selected ? " on" : ""), "aria-hidden": "true" }),
+  ]);
+}
+
+// The lazy app icon: an <img loading="lazy"> pointing at the daemon's /icon route, with a
+// letter-avatar as the fallback both before a URL exists and when the image fails to decode
+// (no such icon, 404). The avatar is swapped in on error so a broken icon never shows.
+function iconEl(row, primary, label, iconUrl) {
+  const wrap = el("span", { class: "scope-ico", "aria-hidden": "true" });
+  const avatar = () => el("span", {
+    class: "scope-avatar", style: "background:" + hashColor(label + "/" + row.uid), text: avatarLetter(row.label, primary),
+  });
+  const pkg = (row.packages || [])[0];
+  const url = pkg ? iconUrl(pkg) : null;
+  if (!url) { wrap.appendChild(avatar()); return wrap; }
+  const img = el("img", {
+    class: "scope-ico-img", loading: "lazy", decoding: "async", alt: "", src: url,
+    onerror: () => { const a = avatar(); if (img.parentNode) img.replaceWith(a); },
+  });
+  wrap.appendChild(img);
+  return wrap;
+}
+
+// A compact frequency label: raw under 1k, else "1.2k" so a busy app's badge stays narrow.
+function fmtFreq(n) {
+  if (n < 1000) return String(n);
+  return (n / 1000).toFixed(n < 10000 ? 1 : 0).replace(/\.0$/, "") + "k";
+}
+
+// ---- focus retention across the stateless rebuild -----------------------
+// Only the search input needs it (typing re-renders the whole page); mirror the config-view
+// pattern so the caret and selection survive.
+function captureFocus(container) {
+  const active = document.activeElement;
+  const id = active && container.contains(active) ? active.id : null;
+  let selStart = null, selEnd = null;
+  try { selStart = active.selectionStart; selEnd = active.selectionEnd; } catch { /* not a text input */ }
+  return { id, selStart, selEnd };
+}
+
+function restoreFocus(f) {
+  if (!f.id) return;
+  const again = document.getElementById(f.id);
+  if (!again) return;
+  again.focus({ preventScroll: true });
+  try { if (f.selStart != null) again.setSelectionRange(f.selStart, f.selEnd); } catch { /* not selectable */ }
+}

--- a/module/webroot/js/ui/scope-view.js
+++ b/module/webroot/js/ui/scope-view.js
@@ -1,4 +1,4 @@
-// The Scope picker (v2): a full-screen drill-in that turns a profile's opaque list of
+// The Scope picker: a full-screen drill-in that turns a profile's opaque list of
 // package strings into a browsable, searchable, sortable view of the LIVE device app list.
 // It is the counterpart to config-view's editor drill-in and follows the exact same
 // contract — stateless, rebuilt on every call, no imports from data/* or bridge/*. The
@@ -14,7 +14,7 @@
 //               - apps            the DRAFT entry strings (packages + uid: tokens)
 //               - packages        the keyAdmin("packages") result, or null while loading; each
 //                                 row carries uid/packages/label/system/launchable/enabled plus
-//                                 the v2 usage columns installTime/freq/lastUsed/recent
+//                                 the usage columns installTime/freq/lastUsed/recent
 //               - claimedByOther  Map(entry -> owning profile name) for entries already claimed
 //                                 by ANOTHER profile (greyed out and inert here)
 //               - firstAppUid     Process.FIRST_APPLICATION_UID; uids below it warn

--- a/module/webroot/tests/domain.test.mjs
+++ b/module/webroot/tests/domain.test.mjs
@@ -8,7 +8,7 @@ import assert from "node:assert/strict";
 
 import {
   emptyProfile, emptyConfig,
-  PKG_RE, PROFILE_RE, KEYBOX_RE, PATCH_RE, OSVER_RE, MODE_RE,
+  PKG_RE, PROFILE_RE, KEYBOX_RE, PATCH_RE, OSVER_RE, MODE_RE, UID_RE, APP_ENTRY_RE,
 } from "../js/domain/schema.js";
 import { validateConfig, validateProfile } from "../js/domain/validate.js";
 
@@ -124,9 +124,57 @@ test("a package listed twice in ONE profile is not a cross-profile duplicate", (
   assert.equal(r.ok, true, JSON.stringify(r.errors));
 });
 
+// --- scope: raw-uid tokens & auto-include --------------------------------
+test("a uid: token is accepted as an app entry", () => {
+  const r = validateConfig(configWith({ p: validProfile(["com.ok", "uid:10123"]) }));
+  assert.equal(r.ok, true, JSON.stringify(r.errors));
+});
+
+test("a malformed uid token is rejected", () => {
+  for (const bad of ["uid:", "uid:x", "uid: 10", "uid:-1", "uid:10.0"]) {
+    const r = validateConfig(configWith({ p: validProfile(["com.ok", bad]) }));
+    assert.equal(r.ok, false, `expected ${bad} to be rejected`);
+    assert.ok(r.errors.some((e) => e.field === "apps"), `expected an apps error for ${bad}`);
+  }
+});
+
+test("autoIncludeNewApps=true makes an empty apps list valid", () => {
+  const p = validProfile([]);
+  p.autoIncludeNewApps = true;
+  const r = validateConfig(configWith({ p }));
+  assert.equal(r.ok, true, JSON.stringify(r.errors));
+});
+
+test("autoIncludeNewApps=false with an empty apps list is still invalid", () => {
+  const p = validProfile([]);
+  p.autoIncludeNewApps = false;
+  const r = validateConfig(configWith({ p }));
+  assert.equal(r.ok, false);
+  assert.ok(r.errors.some((e) => e.profile === "p" && e.field === "apps"));
+});
+
+test("two profiles both auto-including new apps is an error on BOTH", () => {
+  const a = validProfile(["com.a"]); a.autoIncludeNewApps = true;
+  const b = validProfile(["com.b"]); b.autoIncludeNewApps = true;
+  const r = validateConfig(configWith({ a, b }));
+  assert.equal(r.ok, false);
+  const autoErrs = r.errors.filter((e) => e.field === "autoIncludeNewApps");
+  assert.ok(autoErrs.some((e) => e.profile === "a"));
+  assert.ok(autoErrs.some((e) => e.profile === "b"));
+});
+
+test("exactly one profile auto-including new apps is fine", () => {
+  const a = validProfile(["com.a"]); a.autoIncludeNewApps = true;
+  const b = validProfile(["com.b"]);
+  const r = validateConfig(configWith({ a, b }));
+  assert.equal(r.ok, true, JSON.stringify(r.errors));
+});
+
 // --- regex whitelists ----------------------------------------------------
 const cases = [
   [PKG_RE, ["com.foo", "com.foo.bar", "a_b.c", "A9._"], ["", "com foo", "com;rm -rf", "com/foo", "com-foo"]],
+  [UID_RE, ["uid:0", "uid:10123", "uid:2000"], ["", "uid:", "uid:x", "uid: 10", "uid:-1", "uid:10.0", "10123", "com.foo"]],
+  [APP_ENTRY_RE, ["com.foo", "com.foo.bar", "uid:0", "uid:10123"], ["", "uid:", "uid:x", "com foo", "com/foo", "uid:1.0"]],
   [PROFILE_RE, ["pixel", "a-b_c", "x".repeat(32)], ["", "x".repeat(33), "has space", "bad!", "dot.name"]],
   [KEYBOX_RE, ["keybox.xml", "a-b_c.1.xml"], ["keybox", "keybox.XML", "../x.xml", "a b.xml", "keybox.xml.bak"]],
   [PATCH_RE, ["today", "no", "harvested", "system_property", "2024-01", "2024-12", "2024-01-15", "2024-12-31", "YYYY-MM", "YYYY-MM-05", "YYYY-MM-DD"], ["2024", "2024-1", "2024-1-1", "yesterday", "", "2024-00", "2024-13", "2024-01-00", "2024-01-32", "2024-13-01", "MM-05", "YYYY-13-01"]],


### PR DESCRIPTION
A profile's target apps were bare package strings — resolved ad hoc in three drifting places and blind to the device, so a mistyped name silently targeted nothing.

This adds **Scope**, one resolver turning `apps[]` into the interceptor's name- and uid-match arrays (now independent), with advanced `uid:N` tokens and future-only auto-include. The interceptor tallies each key-request caller; the daemon persists a package-keyed frequency and since-boot recency, served over new `/packages`, `/icon`, and `/usage/clear` routes.

The WebUI gains a searchable, grouped, usage-ordered picker with icons, draft-and-confirm selection, and privileged-uid guards.
