### PR TITLE
Encode unsigned KeyMint tags as non-negative CBOR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,16 @@ jobs:
             rust/target
           key: cargo-${{ hashFiles('rust/**/Cargo.toml') }}
 
+      # Enforce the TA's cast lints on the shipped target before building: capi's
+      # KeyParameter conversion denies lossy integer casts (see #205), so a new
+      # unguarded cast fails here rather than silently mis-encoding a tag.
+      - name: Lint the KeyMint TA (clippy)
+        env:
+          ANDROID_NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/${{ env.NDK_VERSION }}
+        run: |
+          rustup component add clippy
+          ./rust/build.sh clippy
+
       - name: Build the module
         env:
           ANDROID_NDK_HOME: ${{ env.ANDROID_HOME }}/ndk/${{ env.NDK_VERSION }}

--- a/keymint/README.md
+++ b/keymint/README.md
@@ -105,9 +105,11 @@ Each method decides for itself whether to simulate or forward:
   just relays them to the real HAL; they're intercepted for uniformity, not simulated.
 
 The method bodies translate between the AIDL types and the TA's flat C ABI
-([`teesim_km.h`](../rust/teesim-km/include/teesim_km.h)): `ToKm`/`FromKm` convert a `KeyParameter` to/from a `KmParam`, using the
-tag's top nibble (`kTagBool`, `kTagBytes`, `kTagUlong`, …) to pick the active union
-member. `TeesimKeyMintOperation` wraps a TA operation handle and aborts it in the
+([`teesim_km.h`](../rust/teesim-km/include/teesim_km.h)): `ToKm`/`FromKm` convert a `KeyParameter` to/from a `KmParam`. `FromKm` asks
+the TA how a tag's value is represented via `teesim_km_tag_value_kind` (returning a
+`KmValueKind`) rather than reading the tag's nibble itself, so the signed/unsigned/width
+choice lives only in the Rust side and can't drift (e.g. `USER_AUTH_TYPE` is ENUM-typed
+but decoded as an unsigned 32-bit value). `TeesimKeyMintOperation` wraps a TA operation handle and aborts it in the
 destructor if `finish` never ran, so a dropped operation doesn't leak state in the TA.
 
 ### Patch and generation modes

--- a/keymint/keymint_router.cpp
+++ b/keymint/keymint_router.cpp
@@ -32,14 +32,6 @@ extern "C" void teesim_hook_set_forwarding(bool forwarding);
 
 namespace {
 
-constexpr uint32_t kTagTypeMask = 0xF0000000u;
-constexpr uint32_t kTagUlong = 0x50000000u;
-constexpr uint32_t kTagDate = 0x60000000u;
-constexpr uint32_t kTagBool = 0x70000000u;
-constexpr uint32_t kTagBignum = 0x80000000u;
-constexpr uint32_t kTagBytes = 0x90000000u;
-constexpr uint32_t kTagUlongRep = 0xA0000000u;
-
 // A TA is reference-counted so an in-flight operation keeps its profile's TA
 // alive even if a config reload swaps or drops that profile underneath it.
 using TaPtr = std::shared_ptr<::Ta>;
@@ -230,22 +222,24 @@ KeyParameter FromKm(const KmParam& k) {
     default:
       break;
   }
-  switch (k.tag & kTagTypeMask) {
-    case kTagBool:
+  // The remaining tags map by their flat value kind (the classifier the Rust TA
+  // owns), so the width/signedness table lives in one place. The specific ENUM
+  // tags handled above keep their dedicated union fields; everything else is a
+  // bool, a byte array, a date, a long, or a plain 32-bit integer.
+  switch (teesim_km_tag_value_kind(k.tag)) {
+    case KM_VALUE_BOOL:
       kp.value.set<KeyParameterValue::boolValue>(true);
       break;
-    case kTagBytes:
-    case kTagBignum:
+    case KM_VALUE_BYTES:
       kp.value.set<KeyParameterValue::blob>(std::vector<uint8_t>(k.blob, k.blob + k.blob_len));
       break;
-    case kTagDate:
+    case KM_VALUE_INT64:  // DATE
       kp.value.set<KeyParameterValue::dateTime>(k.int_value);
       break;
-    case kTagUlong:
-    case kTagUlongRep:
+    case KM_VALUE_UINT64:  // ULONG/ULONG_REP
       kp.value.set<KeyParameterValue::longInteger>(k.int_value);
       break;
-    default:
+    default:  // INT32/UINT32 enums and integers
       kp.value.set<KeyParameterValue::integer>(static_cast<int32_t>(k.int_value));
       break;
   }

--- a/keystore/keystore_router.cpp
+++ b/keystore/keystore_router.cpp
@@ -90,8 +90,7 @@ struct PendingKey {
   void RebindParamBlobs() {
     size_t k = 0;
     for (auto& kp : params) {
-      const uint32_t type = kp.tag & 0xf0000000u;
-      if (type != 0x80000000u && type != 0x90000000u) continue;  // not a BIGNUM/BYTES param
+      if (teesim_km_tag_value_kind(kp.tag) != KM_VALUE_BYTES) continue;  // not a BIGNUM/BYTES param
       if (k >= param_blobs.size()) {
         kp.blob = nullptr;
         kp.blob_len = 0;
@@ -250,23 +249,19 @@ std::vector<KmParam> ReadKeymasterArguments(Parcel& p,
     if (p.readInt32() == 0) continue;  // typed-list element presence marker
     KmParam kp{};
     kp.tag = static_cast<uint32_t>(p.readInt32());
-    switch (kp.tag & 0xf0000000u) {
-      case 0x10000000:  // ENUM
-      case 0x20000000:  // ENUM_REP
-      case 0x30000000:  // UINT
-      case 0x40000000:  // UINT_REP
+    switch (teesim_km_tag_value_kind(kp.tag)) {
+      case KM_VALUE_INT32:   // ENUM/ENUM_REP
+      case KM_VALUE_UINT32:  // UINT/UINT_REP, USER_AUTH_TYPE
         kp.int_value = p.readInt32();
         break;
-      case 0x50000000:  // ULONG
-      case 0x60000000:  // DATE
-      case 0xa0000000:  // ULONG_REP
+      case KM_VALUE_INT64:   // DATE
+      case KM_VALUE_UINT64:  // ULONG/ULONG_REP
         kp.int_value = p.readInt64();
         break;
-      case 0x70000000:  // BOOL
+      case KM_VALUE_BOOL:
         kp.int_value = 1;
         break;
-      case 0x80000000:  // BIGNUM
-      case 0x90000000:  // BYTES
+      case KM_VALUE_BYTES:  // BIGNUM/BYTES
         blob_store.push_back(ReadByteArray(p));
         kp.blob = blob_store.back().data();
         kp.blob_len = blob_store.back().size();
@@ -304,23 +299,21 @@ void WriteKeymasterArguments(Parcel& p, const std::vector<KmParam>& params) {
   for (const auto& kp : params) {
     p.writeInt32(1);  // typed-list element presence marker
     p.writeInt32(static_cast<int32_t>(kp.tag));
-    switch (kp.tag & 0xf0000000u) {
-      case 0x10000000:
-      case 0x20000000:
-      case 0x30000000:
-      case 0x40000000:
+    switch (teesim_km_tag_value_kind(kp.tag)) {
+      case KM_VALUE_INT32:
+      case KM_VALUE_UINT32:
         p.writeInt32(static_cast<int32_t>(kp.int_value));
         break;
-      case 0x50000000:
-      case 0x60000000:
-      case 0xa0000000:
+      case KM_VALUE_INT64:
+      case KM_VALUE_UINT64:
         p.writeInt64(kp.int_value);
         break;
-      case 0x70000000:
+      case KM_VALUE_BOOL:
         break;  // bool: presence only
-      case 0x80000000:
-      case 0x90000000:
+      case KM_VALUE_BYTES:
         p.writeByteArray(kp.blob_len, kp.blob);
+        break;
+      default:
         break;
     }
   }

--- a/rust/build.sh
+++ b/rust/build.sh
@@ -71,6 +71,14 @@ cd "$HERE"
 # see those args either way — detect which cargo-ndk is installed and pass the flag only when it exists.
 BINDGEN=()
 if cargo ndk --help 2>/dev/null | grep -q -- '--bindgen'; then BINDGEN=(--bindgen); fi
-cargo ndk -t "$ABI" --platform "$API" "${BINDGEN[@]}" build --release -p teesim-km
 
-echo "Output: $HERE/target/$TRIPLE/release/libteesim_km.a"
+# `build.sh clippy` type-checks the crate with clippy instead of building the .a,
+# enforcing its cast lints (capi's conversion functions deny them). It runs under
+# the same NDK/BoringSSL env as a build, so it checks the exact target the
+# interceptor ships for. Any other/absent argument builds the static library.
+CARGO_CMD="${1:-build}"
+cargo ndk -t "$ABI" --platform "$API" "${BINDGEN[@]}" "$CARGO_CMD" --release -p teesim-km
+
+if [ "$CARGO_CMD" = build ]; then
+  echo "Output: $HERE/target/$TRIPLE/release/libteesim_km.a"
+fi

--- a/rust/teesim-km/README.md
+++ b/rust/teesim-km/README.md
@@ -154,8 +154,11 @@ encoding:
 - Handles it holds but can't inspect: `Ta` (the boxed TA), `TsCreationResult`
   (generate/import output), `TsBeginResult`, `TsCharacteristics`.
 - `KmParam` — a KeyMint `KeyParameter` flattened to `{ tag, int_value, blob,
-  blob_len }`. The tag's top-nibble type bits decide which field is live, so C++
-  copies one union arm without knowing the tag catalog.
+  blob_len }`. `teesim_km_tag_value_kind(tag)` returns a `KmValueKind` saying how
+  `int_value` is represented (bool / bytes / signed or unsigned 32- or 64-bit), so
+  C++ copies one union arm without knowing the tag catalog and both sides share one
+  signed/unsigned/width table (it mirrors `kmr_wire`'s per-tag decoder — the source
+  of the `USER_SECURE_ID` sign bug this replaced).
 - Per-method entry points (`teesim_km_generate_key`, `teesim_km_begin`,
   `teesim_km_update`, `teesim_km_finish`, …), each returning `0` or a negative
   KeyMint error code, plus accessor functions to walk the result handles field by

--- a/rust/teesim-km/include/teesim_km.h
+++ b/rust/teesim-km/include/teesim_km.h
@@ -30,6 +30,23 @@ typedef struct {
   size_t blob_len;
 } KmParam;
 
+// How a KeyMint tag's scalar value is represented in KmParam::int_value. Returned by
+// teesim_km_tag_value_kind so the native marshallers share one signed/unsigned/width table with the
+// Rust side (which mirrors kmr_wire's per-tag decoder). Never derive this from the tag's type nibble
+// directly: USER_AUTH_TYPE is ENUM-typed but decoded as an unsigned 32-bit value.
+typedef enum {
+  KM_VALUE_INVALID = 0,  // no scalar value / unknown tag
+  KM_VALUE_BOOL = 1,     // BOOL: presence means true
+  KM_VALUE_BYTES = 2,    // BYTES/BIGNUM: a byte array
+  KM_VALUE_INT32 = 3,    // signed 32-bit: ENUM/ENUM_REP
+  KM_VALUE_UINT32 = 4,   // unsigned 32-bit: UINT/UINT_REP and USER_AUTH_TYPE
+  KM_VALUE_INT64 = 5,    // signed 64-bit: DATE
+  KM_VALUE_UINT64 = 6,   // unsigned 64-bit: ULONG/ULONG_REP
+} KmValueKind;
+
+// Classify a tag's flat value representation (see KmValueKind). Pure function of `tag`.
+KmValueKind teesim_km_tag_value_kind(uint32_t tag);
+
 // Device-ID values a profile vouches for; each is a byte span (NULL/0 = unset).
 // Passed to teesim_km_init_ex. If every field is unset, device-ID attestation is
 // declined, exactly as on a device that was never provisioned with IDs.

--- a/rust/teesim-km/src/capi.rs
+++ b/rust/teesim-km/src/capi.rs
@@ -89,18 +89,103 @@ unsafe fn timestamp_token(tok: *const TsTimestampToken) -> Option<TimeStampToken
 
 // KeyMint TagType bits (top nibble of a tag).
 const TAG_TYPE_MASK: u32 = 0xF000_0000;
+const TAG_ENUM: u32 = 0x1000_0000;
+const TAG_ENUM_REP: u32 = 0x2000_0000;
 const TAG_UINT: u32 = 0x3000_0000;
 const TAG_UINT_REP: u32 = 0x4000_0000;
 const TAG_ULONG: u32 = 0x5000_0000;
+const TAG_DATE: u32 = 0x6000_0000;
 const TAG_BOOL: u32 = 0x7000_0000;
 const TAG_BIGNUM: u32 = 0x8000_0000;
 const TAG_BYTES: u32 = 0x9000_0000;
 const TAG_ULONG_REP: u32 = 0xA000_0000;
 
-// USER_AUTH_TYPE is ENUM-typed (top nibble 0x1) yet kmr_wire decodes it as a
-// u32, and its ANY value is 0xFFFFFFFF, so it needs the same unsigned handling
-// as the UINT tags rather than the signed enum path.
-const TAG_USER_AUTH_TYPE: u32 = 0x1000_0000 | 504;
+// USER_AUTH_TYPE is ENUM-typed (top nibble 0x1) yet kmr_wire decodes it as a u32,
+// and its ANY value is 0xFFFFFFFF, so it is classified as unsigned 32-bit rather
+// than a signed enum. It is the one tag whose representation does not follow from
+// its type nibble, so `tag_value_kind` handles it explicitly.
+const TAG_USER_AUTH_TYPE: u32 = TAG_ENUM | 504;
+
+/// How a KeyMint tag's scalar value is represented once flattened into the signed
+/// `KmParam::int_value` carrier. This is the single source of truth for the
+/// signed/unsigned/width decision every marshaller needs: the width and signedness
+/// match kmr_wire's own decoder for each tag (a u32/u64 decoder rejects a negative
+/// CBOR integer with OutOfRangeIntegerValue). The C++ routers read it through
+/// `teesim_km_tag_value_kind`, so their parcel/AIDL widths cannot drift from here.
+#[repr(i32)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum KmValueKind {
+    /// No scalar value / unknown tag.
+    Invalid = 0,
+    /// BOOL: presence means true.
+    Bool = 1,
+    /// BYTES/BIGNUM: a byte array.
+    Bytes = 2,
+    /// Signed 32-bit: the ENUM/ENUM_REP tags (a defined enumerant).
+    Int32 = 3,
+    /// Unsigned 32-bit: the UINT/UINT_REP tags and USER_AUTH_TYPE.
+    Uint32 = 4,
+    /// Signed 64-bit: the DATE tags (milliseconds since epoch).
+    Int64 = 5,
+    /// Unsigned 64-bit: the ULONG/ULONG_REP tags.
+    Uint64 = 6,
+}
+
+/// Classify a tag's flat value representation. The only tag whose kind does not
+/// follow from its type nibble is USER_AUTH_TYPE (see the constant above).
+fn tag_value_kind(tag: u32) -> KmValueKind {
+    if tag == TAG_USER_AUTH_TYPE {
+        return KmValueKind::Uint32;
+    }
+    match tag & TAG_TYPE_MASK {
+        TAG_BOOL => KmValueKind::Bool,
+        TAG_BYTES | TAG_BIGNUM => KmValueKind::Bytes,
+        TAG_ENUM | TAG_ENUM_REP => KmValueKind::Int32,
+        TAG_UINT | TAG_UINT_REP => KmValueKind::Uint32,
+        TAG_ULONG | TAG_ULONG_REP => KmValueKind::Uint64,
+        TAG_DATE => KmValueKind::Int64,
+        _ => KmValueKind::Invalid,
+    }
+}
+
+/// Classify a KeyMint tag for the native marshallers (the keymint/keystore
+/// routers), so the signed/unsigned/width choice lives only in `tag_value_kind`.
+/// Returns a `KmValueKind` discriminant. Pure function of `tag`; safe for any input.
+#[no_mangle]
+pub extern "C" fn teesim_km_tag_value_kind(tag: u32) -> i32 {
+    tag_value_kind(tag) as i32
+}
+
+// The C ABI packs every scalar KeyParameter value into one signed i64 carrier
+// (`KmParam::int_value`), so moving a value across it is a deliberate,
+// bit-preserving reinterpretation. These helpers are the *only* place the cast
+// lints are relaxed; `to_keyparam` and `owned_param` route every conversion
+// through them and are themselves `deny`-ed, so a new raw `as` at the boundary
+// fails clippy instead of silently repeating the USER_SECURE_ID sign bug.
+#[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+fn carrier_low_u32(v: i64) -> u32 {
+    v as u32
+}
+#[allow(clippy::cast_sign_loss)]
+fn carrier_u64(v: i64) -> u64 {
+    v as u64
+}
+#[allow(clippy::cast_possible_truncation)]
+fn carrier_i32(v: i64) -> i32 {
+    v as i32
+}
+#[allow(clippy::cast_possible_wrap)]
+fn tag_bits_i32(tag: u32) -> i32 {
+    tag as i32
+}
+#[allow(clippy::cast_possible_truncation)]
+fn cbor_int_to_carrier(v: i128) -> i64 {
+    v as i64
+}
+#[allow(clippy::cast_sign_loss)]
+fn tag_enum_bits(tag: kmr_wire::keymint::Tag) -> u32 {
+    tag as u32
+}
 
 fn call<T>(f: impl FnOnce() -> Result<T, OpError>) -> Result<T, i32> {
     match catch_unwind(AssertUnwindSafe(f)) {
@@ -114,38 +199,34 @@ fn call<T>(f: impl FnOnce() -> Result<T, OpError>) -> Result<T, i32> {
 }
 
 /// Convert a flat `KmParam` into a kmr_wire `KeyParam`, reusing kmr_wire's own
-/// tag-keyed decoding.
+/// tag-keyed decoding. The value is encoded at the width and signedness kmr_wire's
+/// decoder expects (via `tag_value_kind`); a mismatch would make kmr_wire reject
+/// the parameter with OutOfRangeIntegerValue. Denies raw casts so every carrier
+/// reinterpretation stays in the audited helpers above.
+#[deny(clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_possible_wrap)]
 fn to_keyparam(p: &KmParam) -> Result<KeyParam, OpError> {
-    // Unsigned tag values cross the ABI in the signed `int_value` carrier, so a
-    // value with its top bit set arrives as a negative i64. kmr_wire decodes these
-    // tags with u32/u64 decoders that reject a negative CBOR integer with
-    // OutOfRangeIntegerValue, so the bits must be reinterpreted to a non-negative
-    // integer of the decoder's width. Enum and DATE tags stay on the signed path:
-    // their values are a defined (small, non-negative) enumerant or an epoch time.
-    let value = if p.tag == TAG_USER_AUTH_TYPE {
-        // ENUM-typed but u32-decoded; ANY == 0xFFFFFFFF must stay non-negative.
-        Value::Integer(Integer::from(p.int_value as u32 as u64))
-    } else {
-        match p.tag & TAG_TYPE_MASK {
-            TAG_BOOL => Value::Bool(true),
-            TAG_BYTES | TAG_BIGNUM => {
-                let bytes = if p.blob.is_null() || p.blob_len == 0 {
-                    Vec::new()
-                } else {
-                    // Safety: the caller guarantees blob/blob_len are valid for the call.
-                    unsafe { slice::from_raw_parts(p.blob, p.blob_len) }.to_vec()
-                };
-                Value::Bytes(bytes)
-            }
-            // 32-bit unsigned tags (KEY_SIZE, patchlevels, ...): drop the sign
-            // extension so the low word decodes as the intended u32.
-            TAG_UINT | TAG_UINT_REP => Value::Integer(Integer::from(p.int_value as u32 as u64)),
-            // 64-bit unsigned tags (USER_SECURE_ID, RSA_PUBLIC_EXPONENT).
-            TAG_ULONG | TAG_ULONG_REP => Value::Integer(Integer::from(p.int_value as u64)),
-            _ => Value::Integer(Integer::from(p.int_value)),
+    let value = match tag_value_kind(p.tag) {
+        KmValueKind::Bool => Value::Bool(true),
+        KmValueKind::Bytes => {
+            let bytes = if p.blob.is_null() || p.blob_len == 0 {
+                Vec::new()
+            } else {
+                // Safety: the caller guarantees blob/blob_len are valid for the call.
+                unsafe { slice::from_raw_parts(p.blob, p.blob_len) }.to_vec()
+            };
+            Value::Bytes(bytes)
         }
+        // Unsigned tags: reinterpret the carrier's bits at the decoder's width so a
+        // top-bit-set value stays a non-negative CBOR integer (USER_SECURE_ID,
+        // RSA_PUBLIC_EXPONENT, USER_AUTH_TYPE=ANY, ...).
+        KmValueKind::Uint32 => Value::Integer(Integer::from(carrier_low_u32(p.int_value))),
+        KmValueKind::Uint64 => Value::Integer(Integer::from(carrier_u64(p.int_value))),
+        // Signed tags: an enumerant (Int32) or an epoch time (Int64); an unknown
+        // tag falls through as the raw carrier so kmr_wire can report it.
+        KmValueKind::Int32 => Value::Integer(Integer::from(carrier_i32(p.int_value))),
+        KmValueKind::Int64 | KmValueKind::Invalid => Value::Integer(Integer::from(p.int_value)),
     };
-    let tag = Value::Integer(Integer::from((p.tag as i32) as i64));
+    let tag = Value::Integer(Integer::from(tag_bits_i32(p.tag)));
     KeyParam::from_cbor_value(Value::Array(vec![tag, value])).map_err(|e| OpError {
         code: ERR_UNKNOWN,
         msg: format!("bad key param tag {:#x}: {e:?}", p.tag),
@@ -168,14 +249,17 @@ struct OwnedParam {
     blob: Vec<u8>,
 }
 
+#[deny(clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_possible_wrap)]
 fn owned_param(kp: &KeyParam) -> OwnedParam {
-    let mut o = OwnedParam { tag: kp.tag() as u32, int_value: 0, blob: Vec::new() };
+    let mut o = OwnedParam { tag: tag_enum_bits(kp.tag()), int_value: 0, blob: Vec::new() };
     if let Ok(Value::Array(mut a)) = kp.clone().to_cbor_value() {
         if a.len() == 2 {
             match a.remove(1) {
-                Value::Integer(i) => o.int_value = i128::from(i) as i64,
+                // Store the value's bits back in the signed carrier; the C++ side
+                // reinterprets them by tag kind, the mirror of `to_keyparam`.
+                Value::Integer(i) => o.int_value = cbor_int_to_carrier(i128::from(i)),
                 Value::Bytes(b) => o.blob = b,
-                Value::Bool(b) => o.int_value = b as i64,
+                Value::Bool(b) => o.int_value = i64::from(b),
                 _ => {}
             }
         }

--- a/rust/teesim-km/src/capi.rs
+++ b/rust/teesim-km/src/capi.rs
@@ -89,9 +89,18 @@ unsafe fn timestamp_token(tok: *const TsTimestampToken) -> Option<TimeStampToken
 
 // KeyMint TagType bits (top nibble of a tag).
 const TAG_TYPE_MASK: u32 = 0xF000_0000;
+const TAG_UINT: u32 = 0x3000_0000;
+const TAG_UINT_REP: u32 = 0x4000_0000;
+const TAG_ULONG: u32 = 0x5000_0000;
 const TAG_BOOL: u32 = 0x7000_0000;
 const TAG_BIGNUM: u32 = 0x8000_0000;
 const TAG_BYTES: u32 = 0x9000_0000;
+const TAG_ULONG_REP: u32 = 0xA000_0000;
+
+// USER_AUTH_TYPE is ENUM-typed (top nibble 0x1) yet kmr_wire decodes it as a
+// u32, and its ANY value is 0xFFFFFFFF, so it needs the same unsigned handling
+// as the UINT tags rather than the signed enum path.
+const TAG_USER_AUTH_TYPE: u32 = 0x1000_0000 | 504;
 
 fn call<T>(f: impl FnOnce() -> Result<T, OpError>) -> Result<T, i32> {
     match catch_unwind(AssertUnwindSafe(f)) {
@@ -107,18 +116,34 @@ fn call<T>(f: impl FnOnce() -> Result<T, OpError>) -> Result<T, i32> {
 /// Convert a flat `KmParam` into a kmr_wire `KeyParam`, reusing kmr_wire's own
 /// tag-keyed decoding.
 fn to_keyparam(p: &KmParam) -> Result<KeyParam, OpError> {
-    let value = match p.tag & TAG_TYPE_MASK {
-        TAG_BOOL => Value::Bool(true),
-        TAG_BYTES | TAG_BIGNUM => {
-            let bytes = if p.blob.is_null() || p.blob_len == 0 {
-                Vec::new()
-            } else {
-                // Safety: the caller guarantees blob/blob_len are valid for the call.
-                unsafe { slice::from_raw_parts(p.blob, p.blob_len) }.to_vec()
-            };
-            Value::Bytes(bytes)
+    // Unsigned tag values cross the ABI in the signed `int_value` carrier, so a
+    // value with its top bit set arrives as a negative i64. kmr_wire decodes these
+    // tags with u32/u64 decoders that reject a negative CBOR integer with
+    // OutOfRangeIntegerValue, so the bits must be reinterpreted to a non-negative
+    // integer of the decoder's width. Enum and DATE tags stay on the signed path:
+    // their values are a defined (small, non-negative) enumerant or an epoch time.
+    let value = if p.tag == TAG_USER_AUTH_TYPE {
+        // ENUM-typed but u32-decoded; ANY == 0xFFFFFFFF must stay non-negative.
+        Value::Integer(Integer::from(p.int_value as u32 as u64))
+    } else {
+        match p.tag & TAG_TYPE_MASK {
+            TAG_BOOL => Value::Bool(true),
+            TAG_BYTES | TAG_BIGNUM => {
+                let bytes = if p.blob.is_null() || p.blob_len == 0 {
+                    Vec::new()
+                } else {
+                    // Safety: the caller guarantees blob/blob_len are valid for the call.
+                    unsafe { slice::from_raw_parts(p.blob, p.blob_len) }.to_vec()
+                };
+                Value::Bytes(bytes)
+            }
+            // 32-bit unsigned tags (KEY_SIZE, patchlevels, ...): drop the sign
+            // extension so the low word decodes as the intended u32.
+            TAG_UINT | TAG_UINT_REP => Value::Integer(Integer::from(p.int_value as u32 as u64)),
+            // 64-bit unsigned tags (USER_SECURE_ID, RSA_PUBLIC_EXPONENT).
+            TAG_ULONG | TAG_ULONG_REP => Value::Integer(Integer::from(p.int_value as u64)),
+            _ => Value::Integer(Integer::from(p.int_value)),
         }
-        _ => Value::Integer(Integer::from(p.int_value)),
     };
     let tag = Value::Integer(Integer::from((p.tag as i32) as i64));
     KeyParam::from_cbor_value(Value::Array(vec![tag, value])).map_err(|e| OpError {

--- a/rust/teesim-km/src/lib.rs
+++ b/rust/teesim-km/src/lib.rs
@@ -6,6 +6,12 @@
 // transaction into a kmr_wire request, calls `Ta::process`, and re-encodes the
 // reply.
 
+// Surface lossy integer casts crate-wide. The USER_SECURE_ID bug (#205) was a
+// signed carrier sign-extending into a negative CBOR integer that kmr_wire then
+// rejected; these lints (off by default) flag that shape. The value-marshaling
+// boundary in `capi` upgrades them to `deny` on its conversion functions.
+#![warn(clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_possible_wrap)]
+
 extern crate alloc;
 
 mod attest;

--- a/rust/teesim-km/src/resign.rs
+++ b/rust/teesim-km/src/resign.rs
@@ -142,6 +142,9 @@ impl Ta {
 /// verifiedBootState ENUMERATED, verifiedBootHash OCTET STRING }` from the profile's boot info. This
 /// is the value generation emits (see kmr-ta's `RootOfTrust::from(&BootInfo)`), so patch and
 /// generation report an identical root of trust.
+// `state & 0xff` is a single ENUMERATED byte (VerifiedBootState is 0..=3); the mask makes the u8 cast
+// exact, so the sign-loss lint does not apply.
+#[allow(clippy::cast_sign_loss)]
 pub(crate) fn build_root_of_trust(vb_key: &[u8], locked: bool, state: i32, vb_hash: &[u8]) -> Vec<u8> {
     // kmr-ta hashes an over-long verified-boot key (boot_info_hashed_key); mirror it.
     let key_bytes = if vb_key.len() > 32 {
@@ -263,6 +266,9 @@ fn split_elems(mut content: &[u8]) -> Result<Vec<&[u8]>, OpError> {
 }
 
 /// Encode DER length octets for a value of length `n`.
+// Each `as u8` writes one length octet from a value already reduced to 0..=255 (guarded `n < 0x80`,
+// masked `v & 0xff`, or a byte count that never reaches 256), so the truncation lint does not apply.
+#[allow(clippy::cast_possible_truncation)]
 fn der_len(n: usize) -> Vec<u8> {
     if n < 0x80 {
         return vec![n as u8];


### PR DESCRIPTION
A KeyMint `KeyParameter` carries a tag whose top nibble is its [`TagType`](https://cs.android.com/android/platform/superproject/main/+/main:hardware/interfaces/security/keymint/aidl/android/hardware/security/keymint/TagType.aidl), and the interceptor flattens every scalar value into one signed `int_value` (`i64`) as it crosses the C ABI into the reference TA. That flattening discards the value's signedness: an unsigned tag whose value sets its top bit arrives as a negative `i64`, and `to_keyparam` re-encoded it verbatim as a negative CBOR integer. The reference implementation decodes such tags through unsigned decoders — for `USER_SECURE_ID`, [`<u64>::from_cbor_value`](https://cs.android.com/android/platform/superproject/main/+/main:system/keymint/wire/src/keymint.rs) — whose `try_into` rejects a negative with `OutOfRangeIntegerValue`, so generate/import/begin failed with "bad key param tag" and the key was unusable. #201 forwarded the `HardwareAuthToken`; this is the encoding half of the same report.

`USER_SECURE_ID` ([`ULONG_REP | 502`](https://cs.android.com/android/platform/superproject/main/+/main:hardware/interfaces/security/keymint/aidl/android/hardware/security/keymint/Tag.aidl)) is the reported case: a Gatekeeper secure id routinely sets bit 63, so an auth-bound key used through BiometricPrompt/CryptoObject was refused as the TA decoded its parameters. Two further tags share the defect. `USER_AUTH_TYPE` is declared `ENUM` yet the reference decodes it as a `u32`, and [`HardwareAuthenticatorType.ANY`](https://cs.android.com/android/platform/superproject/main/+/main:hardware/interfaces/security/keymint/aidl/android/hardware/security/keymint/HardwareAuthenticatorType.aidl) is `0xFFFFFFFF`, so any key accepting an unspecified authenticator meets the same rejection; the `UINT`/`UINT_REP` family is u32-decoded as well and is latent should a value ever reach bit 31. The fix reinterprets the carrier's bits to a non-negative integer of the decoder's width — `u32` for the UINT tags and `USER_AUTH_TYPE`, `u64` for the ULONG tags — while `DATE` and the genuine enumerations keep the signed path, their values being an epoch time or a defined enumerant.

The report was possible because the tag-to-representation mapping was restated independently in four places — the Rust encode and decode, and the keymint and keystore routers' nibble switches — so any one could diverge from the decoder that ultimately validates the CBOR. This change gives that mapping a single definition, `tag_value_kind`, mirroring the reference decoder and exported as `teesim_km_tag_value_kind`; the routers consult it rather than reading the nibble, and the duplicated masks are removed. Because the original error was an `as` cast, which is lossy in silence by construction, the crate now warns on `cast_possible_truncation`, `cast_sign_loss` and `cast_possible_wrap`, and the marshaling boundary denies them, confining every carrier reinterpretation to a small set of audited helpers checked by clippy over the shipped target in CI. Behaviour is otherwise unchanged: the width chosen per kind reproduces the previous nibble switches exactly.

@Harry8472 confirmed on a Nothing Phone (3) running Android 16 that this conversion together with #201 restores ID Austria, including its BiometricPrompt flow, and MeineSV. A release build of the TA and clippy pass locally.

Closes #205.
