### PR TITLE
Fix keystore2 injection failure on Android 12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,7 @@ endif()
 # --- The injected interceptor library ---------------------------------------
 add_library(teesim_keymint SHARED
     keymint/keymint_router.cpp keymint/keymint_hook.cpp keymint/keymint_entry.cpp
+    keymint/crypto_compat.c
     common/control.cpp common/json.cpp)
 add_dependencies(teesim_keymint rust_ta)
 target_include_directories(teesim_keymint PRIVATE

--- a/keymint/crypto_compat.c
+++ b/keymint/crypto_compat.c
@@ -1,0 +1,24 @@
+// Compatibility shims for BoringSSL entry points the KeyMint TA references but
+// the host keystore2 process's platform libcrypto does not export.
+//
+// The TA links against a stub libcrypto.so and expects the host's real BoringSSL
+// to supply the symbols at runtime. That holds for everything except the legacy
+// EVP_CipherFinal alias: modern BoringSSL keeps only EVP_CipherFinal_ex in its
+// export map, so resolving EVP_CipherFinal against the host fails and the whole
+// dlopen aborts (see issue #202 on Android 12).
+//
+// Upstream BoringSSL defines EVP_CipherFinal as nothing more than a forwarder to
+// EVP_CipherFinal_ex, so we reproduce that here and let the linker satisfy the
+// TA's reference locally. The definition is hidden and the version script keeps
+// it local, so it is never exported nor interposed by the host. Only the modern
+// EVP_CipherFinal_ex is left to resolve at runtime, which the host does export.
+
+#include <stdint.h>
+
+typedef struct evp_cipher_ctx_st EVP_CIPHER_CTX;
+
+extern int EVP_CipherFinal_ex(EVP_CIPHER_CTX *ctx, uint8_t *out, int *out_len);
+
+__attribute__((visibility("hidden"))) int EVP_CipherFinal(EVP_CIPHER_CTX *ctx, uint8_t *out, int *out_len) {
+    return EVP_CipherFinal_ex(ctx, out, out_len);
+}

--- a/keymint/libcrypto.syms
+++ b/keymint/libcrypto.syms
@@ -33,7 +33,7 @@ EVP_CIPHER_CTX_set_key_length
 EVP_CIPHER_CTX_set_padding
 EVP_CIPHER_iv_length
 EVP_CIPHER_key_length
-EVP_CipherFinal
+EVP_CipherFinal_ex
 EVP_CipherUpdate
 EVP_DecryptInit_ex
 EVP_DigestSign


### PR DESCRIPTION
The KeyMint TA links a stub `libcrypto` and relies on keystore2's platform BoringSSL to supply the symbols at runtime. Every symbol resolves except the legacy `EVP_CipherFinal` alias, which modern BoringSSL replaced with `EVP_CipherFinal_ex`. On Android 12 the remote `dlopen` aborts on the missing symbol, leaving the device unable to unlock after a correct PIN.

This defines `EVP_CipherFinal` inside the injected library as a forwarder to `EVP_CipherFinal_ex`, matching upstream BoringSSL, and depends on the modern symbol from the host. Verified at the ELF level; all remaining crypto references resolve against the host.

Fixes #202.