### PR TITLE
Intercept KeyMint on legacy Keymaster (km_compat) devices

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up the Android SDK and NDK
         uses: android-actions/setup-android@v3
       - name: Install NDK, CMake and build-tools
-        run: sdkmanager --install "ndk;${NDK_VERSION}" "cmake;3.22.1" "build-tools;34.0.0" "build-tools;36.0.0" "platforms;android-34" "platforms;android-36"
+        run: sdkmanager --install "ndk;${NDK_VERSION}" "cmake;3.22.1" "build-tools;36.0.0" "platforms;android-36"
 
       # The whole build is driven by Gradle via the committed wrapper: AGP produces the control
       # daemon's dex and builds the native interceptors through externalNativeBuild (CMake), whose

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,10 +34,24 @@ target_link_libraries(inject PRIVATE lsplt log)
 target_link_options(inject PRIVATE -static-libstdc++)
 
 # --- KeyMint AIDL, generated with the NDK backend ---------------------------
-find_program(AIDL_BIN aidl)
+# fromBinder's local-binder fallback (checked below) only exists in aidl from build-tools >= 35, so
+# prefer the newest installed build-tools over whatever aidl happens to be first on PATH or first in
+# the (alphabetically sorted) glob -- e.g. a leftover 34.0.0 sorts before 36.0.0 and silently wins.
+# AIDL_BIN is a plain variable, not a find_program cache entry, so it is recomputed on every configure
+# and never sticks to a stale detection; an explicit -DAIDL_BIN=... on the command line still wins.
 if(NOT AIDL_BIN AND DEFINED ENV{ANDROID_HOME})
   file(GLOB _bt $ENV{ANDROID_HOME}/build-tools/*)
-  find_program(AIDL_BIN aidl PATHS ${_bt} NO_DEFAULT_PATH)
+  list(SORT _bt COMPARE NATURAL ORDER DESCENDING)
+  foreach(_d ${_bt})
+    if(EXISTS ${_d}/aidl)
+      set(AIDL_BIN ${_d}/aidl)
+      break()
+    endif()
+  endforeach()
+endif()
+if(NOT AIDL_BIN)
+  find_program(_aidl_on_path aidl)
+  set(AIDL_BIN ${_aidl_on_path})
 endif()
 if(NOT AIDL_BIN)
   message(FATAL_ERROR "aidl not found; set -DAIDL_BIN=/path/to/aidl")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,13 @@ add_compile_definitions(__ANDROID_UNAVAILABLE_SYMBOLS_ARE_WEAK__)
 # resolved at runtime inside keystore2, so only its headers (for the Rust bindings)
 # are needed at build time. The build depends on no device, so any ABI cross-builds.
 set(BORINGSSL_DIR "${CMAKE_SOURCE_DIR}/third_party/boringssl" CACHE PATH "BoringSSL source directory containing include/")
-set(ANDROID_API_LEVEL "34" CACHE STRING "Android platform level for the Rust build")
+# Native API floor for the Rust static lib (cargo ndk --platform). Track the same min-SDK
+# AGP compiles the C++ at (ANDROID_PLATFORM, e.g. android-29) so both halves share one floor.
+if(ANDROID_PLATFORM MATCHES "android-([0-9]+)")
+  set(ANDROID_API_LEVEL "${CMAKE_MATCH_1}")
+else()
+  set(ANDROID_API_LEVEL "29")
+endif()
 
 # --- LSPlt: memory-map scanning and PLT/GOT hooking -------------------------
 set(LSPLT_JNI ${CMAKE_SOURCE_DIR}/third_party/lsplt/lsplt/src/main/jni)
@@ -56,6 +62,20 @@ if(NOT EXISTS ${AIDL_GEN}/.done)
       message(FATAL_ERROR "aidl generation failed for ${pkg}")
     endif()
   endforeach()
+  # The NDK AIDL's fromBinder already handles a LOCAL binder whose AIBinder_Class differs from our
+  # statically-linked copy (a legacy km_compat IKeyMintDevice / IKeyMintOperation): when
+  # AIBinder_associateClass fails it falls back to a descriptor match and builds a Bp, but only under
+  # #if __ANDROID_API__ >= 31. keymint_aidl is compiled at API 31 below to enable that branch; require
+  # the generated code to actually contain it so an aidl too old to emit the fallback fails the build
+  # here rather than silently returning null on legacy devices.
+  if(NOT EXISTS ${AIDL_GEN}/src/android/hardware/security/keymint/IKeyMintDevice.cpp)
+    message(FATAL_ERROR "keymint: aidl did not generate IKeyMintDevice.cpp")
+  endif()
+  file(READ ${AIDL_GEN}/src/android/hardware/security/keymint/IKeyMintDevice.cpp _dev_cpp)
+  if(NOT _dev_cpp MATCHES "AIBinder_Class_getDescriptor")
+    message(FATAL_ERROR "keymint: generated fromBinder lacks the local-binder fallback; "
+                        "build with build-tools >= 35 (36 recommended)")
+  endif()
   file(TOUCH ${AIDL_GEN}/.done)
 endif()
 
@@ -64,6 +84,18 @@ file(GLOB_RECURSE AIDL_SRCS ${AIDL_GEN}/src/*.cpp)
 add_library(keymint_aidl STATIC ${AIDL_SRCS})
 target_include_directories(keymint_aidl PUBLIC
     ${AIDL_GEN}/include ${FN}/include_cpp ${FN}/include_ndk ${FN}/include_platform)
+# keymint_aidl links only into teesim_keymint.so, which is injected into keystore2 (API 31+ only), so
+# compile it at API 31 to enable the AIDL's own local-binder fallback in fromBinder (gated
+# #if __ANDROID_API__ >= 31). The AIBinder_Class_getDescriptor it then calls is left undefined here and
+# resolved at runtime against keystore2's libbinder_ndk (teesim_keymint links with -Wl,-z,undefs). The
+# rest of the module keeps its lower min-SDK floor; only this static lib is raised. The NDK toolchain's
+# compiler target ends in the API level, so bump that suffix to 31.
+if(CMAKE_CXX_COMPILER_TARGET MATCHES "[0-9]+$")
+  string(REGEX REPLACE "[0-9]+$" "31" _km_target "${CMAKE_CXX_COMPILER_TARGET}")
+  target_compile_options(keymint_aidl PRIVATE "--target=${_km_target}")
+else()
+  message(FATAL_ERROR "keymint: cannot derive an API-31 target from '${CMAKE_CXX_COMPILER_TARGET}'")
+endif()
 
 # --- The in-process TA (Rust static library) --------------------------------
 if(ANDROID_ABI STREQUAL "arm64-v8a")

--- a/keymint/README.md
+++ b/keymint/README.md
@@ -28,9 +28,21 @@ the [AIDL method ordinals](https://cs.android.com/android/platform/superproject/
 matching the method declaration order in `IKeyMintDevice.aidl`; the AIDL compiler numbers methods from `1` after the
 reserved metadata slots.) `IsKeyMintProxy(binder)` confirms the target is actually
 the KeyMint proxy and not some other service sharing the `AIBinder_transact` call
-site: it checks `AIBinder_isRemote` and compares the binder's class descriptor
-against `IKeyMintDevice::descriptor`. The descriptor is the interface's fully-qualified
-name string, stamped on every binder of that type, so it's a reliable identity check.
+site: it compares the binder's class descriptor against `IKeyMintDevice::descriptor`
+(it does **not** require `AIBinder_isRemote`). The descriptor is the interface's
+fully-qualified name string, stamped on every binder of that type, so it's a reliable
+identity check.
+
+We match a *local* `IKeyMintDevice` too, which is why the check does not require
+`AIBinder_isRemote`. On a legacy Keymaster (`keymaster@4.x`) backend `keystore2` has no
+native KeyMint, so per security level it holds an in-process `km_compat` `IKeyMintDevice`
+— stored directly (keymaster 4.0/4.1) or behind a native `BacklevelKeyMintWrapper`
+(downlevel) — and the binder that reaches `AIBinder_transact` is that **local** compat
+proxy (`isRemote == false`). The **SOFTWARE** level is a `km_compat` device on *every*
+device (native included) and is deliberately **not** wrapped: `teesim_router_new_device`
+returns `nullptr` for it, so `keystore2`'s software-key path runs untouched. The
+descriptor also matches our own local `TeesimKeyMintDevice`, so `IsKeyMintProxy` excludes
+it (`IsOurDevice`).
 
 ## Re-dispatching the transaction
 
@@ -186,6 +198,13 @@ it (via `teesim_hook_set_forwarding`) around every call into the real HAL, and
 `HookedTransact` bails to `real_transact` immediately when it's set. Thread-local, not
 global, because unrelated KeyMint traffic on other threads must still be intercepted
 while one thread is mid-forward.
+
+Because `IsKeyMintProxy` matches by descriptor alone, `tls_forwarding` is the **only**
+thing keeping a forward from recursing: on a legacy backend the real HAL is a *local*
+`IKeyMintDevice`, so an unguarded `real_->` call would re-match the descriptor and
+re-enter the hook. Every `real_->` call in `keymint_router.cpp` must therefore stay
+`ForwardGuard`-wrapped. `IsOurDevice` is a separate safeguard for our *own* local device,
+not the forwarding guard.
 
 ## Files
 

--- a/keymint/keymint_hook.cpp
+++ b/keymint/keymint_hook.cpp
@@ -42,8 +42,31 @@ binder_status_t (*real_transact)(AIBinder*, transaction_code_t, AParcel**, AParc
 thread_local bool tls_forwarding = false;
 
 std::mutex g_mu;
-// Real KeyMint proxy -> our local device wrapping it.
+// Real KeyMint proxy -> our local device wrapping it. A nullptr value is a NEGATIVE cache ("do not
+// wrap this proxy", i.e. a SOFTWARE-level km_compat device) so we neither re-probe its
+// getHardwareInfo nor rebuild a device on every transact. Keyed on the raw proxy pointer, which is
+// safe because keystore2 caches its per-level KeyMint devices for the process lifetime, so the
+// pointer is stable and never reallocated (the negative cache relies on this too).
 std::map<AIBinder*, AIBinder*> g_local_for_proxy;
+
+// Our own local devices (the non-null values of g_local_for_proxy). IsKeyMintProxy matches any local
+// IKeyMintDevice by descriptor, and our own TeesimKeyMintDevice is one, so IsKeyMintProxy excludes
+// anything in this set. (Redirect dispatches our device through real_transact — the unhooked LSPlt
+// backup — so it never re-enters the hook; forwarding recursion is prevented by tls_forwarding, not
+// this set. This is a guard against any other caller transacting our device through the hooked symbol.)
+//
+// Guarded by a SEPARATE mutex, not g_mu: LocalFor holds g_mu across teesim_router_new_device, which
+// makes a blocking getHardwareInfo IPC into the real HAL, while IsOurDevice runs on the transact hot
+// path — one shared lock would stall every handled transact behind device construction. Lock order is
+// always g_mu -> g_our_mu (IsOurDevice takes g_our_mu alone; LocalFor takes g_mu, then g_our_mu).
+std::mutex g_our_mu;
+std::set<AIBinder*> g_our_devices;
+
+// True if `binder` is a TeesimKeyMintDevice we created.
+bool IsOurDevice(AIBinder* binder) {
+  std::lock_guard<std::mutex> lk(g_our_mu);
+  return g_our_devices.count(binder) != 0;
+}
 
 bool IsHandled(transaction_code_t code) {
   switch (code) {
@@ -61,12 +84,27 @@ bool IsHandled(transaction_code_t code) {
   }
 }
 
+// Identity check for the KeyMint binder keystore2 transacts. We match on the class descriptor alone
+// and do not require AIBinder_isRemote, so we catch KeyMint whether it is remote or in-process:
+//
+//   - Native KeyMint HAL: keystore2's TrustedEnvironment/StrongBox proxy is a remote binder.
+//   - Legacy Keymaster (keymaster@4.x) backend: keystore2 has no native KeyMint, so per security level
+//     it holds an in-process km_compat IKeyMintDevice (getKeyMintDevice) — stored directly (keymaster
+//     4.0/4.1) or behind a BacklevelKeyMintWrapper (downlevel). Either way the binder that reaches
+//     AIBinder_transact is a local proxy (isRemote==false).
+//
+// The SOFTWARE level is excluded by level, not here: keystore2 serves SecurityLevel::SOFTWARE from an
+// in-process km_compat device on every device, and teesim_router_new_device returns nullptr for it
+// (LocalFor caches that), so the software leg is never wrapped. See that function.
+//
+// The descriptor also matches our own local TeesimKeyMintDevice, so we exclude it (IsOurDevice). The
+// descriptor is compared first, so the g_our_mu lookup runs only for actual IKeyMintDevice binders.
 bool IsKeyMintProxy(AIBinder* binder) {
-  if (!AIBinder_isRemote(binder)) return false;
   const AIBinder_Class* clazz = AIBinder_getClass(binder);
   if (!clazz) return false;
   const char* desc = AIBinder_Class_getDescriptor(clazz);
-  return desc && std::strcmp(desc, IKeyMintDevice::descriptor) == 0;
+  if (!desc || std::strcmp(desc, IKeyMintDevice::descriptor) != 0) return false;
+  return !IsOurDevice(binder);
 }
 
 // The framework RKP front-end keystore2 asks for a remote-provisioned attestation key. keystore2
@@ -105,7 +143,14 @@ AIBinder* LocalFor(AIBinder* proxy) {
   // wrapped HAL's getHardwareInfo(); the value passed here is only the fallback
   // used if that query fails.
   AIBinder* local = teesim_router_new_device(1 /* fallback: TRUSTED_ENVIRONMENT */, proxy);
-  g_local_for_proxy[proxy] = local;
+  g_local_for_proxy[proxy] = local;  // may be nullptr (SOFTWARE): negative cache, do not re-probe
+  if (local) {
+    // Record our device so the relaxed IsKeyMintProxy never re-wraps it. We already hold g_mu; lock
+    // order is g_mu -> g_our_mu. Never insert nullptr (a SOFTWARE proxy yields local==nullptr): the
+    // "g_our_devices == our real devices" invariant must hold.
+    std::lock_guard<std::mutex> lk(g_our_mu);
+    g_our_devices.insert(local);
+  }
   return local;
 }
 
@@ -147,6 +192,8 @@ binder_status_t HookedTransact(AIBinder* binder, transaction_code_t code, AParce
     if (IsHandled(code) && IsKeyMintProxy(binder)) {
       AIBinder* local = LocalFor(binder);
       if (local) return Redirect(local, code, in, out, flags, binder);
+      // local == nullptr: a SOFTWARE-level proxy we deliberately do not wrap; fall through to
+      // real_transact so keystore2's own software-key path runs untouched.
     }
   }
   return real_transact(binder, code, in, out, flags);
@@ -195,8 +242,13 @@ extern "C" bool teesim_hook_install() {
   // on some build do we widen to a full ELF scan, so coverage is never lost.
   if (!exe.empty()) {
     register_and_commit(/*exe_only=*/true);
-    if (real_transact != nullptr) return true;
+    if (real_transact != nullptr) {
+      LOGI("hook: AIBinder_transact patched in the main executable (%s)", exe.c_str());
+      return true;
+    }
   }
   register_and_commit(/*exe_only=*/false);
+  LOGI("hook: AIBinder_transact %s after full ELF scan",
+       real_transact != nullptr ? "patched" : "not found (no importer)");
   return real_transact != nullptr;
 }

--- a/keymint/keymint_router.cpp
+++ b/keymint/keymint_router.cpp
@@ -1000,13 +1000,35 @@ extern "C" AIBinder* teesim_router_new_device(int32_t security_level, AIBinder* 
     KeyMintHardwareInfo hw;
     if (real->getHardwareInfo(&hw).isOk()) {
       security_level = static_cast<int32_t>(hw.securityLevel);
+    } else {
+      // The level probe failed, so we keep the passed fallback (TEE). This is the one path that could
+      // mis-level a SOFTWARE km_compat leg as TEE and wrap it — the SOFTWARE exclusion below keys off
+      // this value. getHardwareInfo is an in-process call returning static info, so a failure is not
+      // expected; log it so a mis-levelled leg is visible rather than silently assumed TEE.
+      LOGW("teesim_router_new_device: getHardwareInfo failed; keeping fallback security_level=%d "
+           "(real=%p, remote=%d)", security_level, real_binder,
+           real_binder ? AIBinder_isRemote(real_binder) : -1);
     }
   }
-  // Confirms which KeyMint HALs we intercept: keystore2 resolves a distinct IKeyMintDevice for
-  // TrustedEnvironment (level 1) and, when present, StrongBox (level 2) — both are hooked, each
-  // wrapped by its own local device at its real level.
-  LOGI("teesim_router_new_device: local KeyMint device at security_level=%d (real=%p)",
-       security_level, real_binder);
+  // Never wrap a SOFTWARE-level KeyMint. keystore2 serves SecurityLevel::SOFTWARE from an in-process
+  // km_compat device on every device — native TEE devices included (only TrustedEnvironment and
+  // StrongBox resolve to a native HAL; SOFTWARE always takes the compat fallback). We only simulate the
+  // hardware levels; wrapping the software leg would route a target uid's ordinary software keys (via
+  // ProfileForRequest's uid fallback) into the TA, so we bail here: LocalFor caches this nullptr and
+  // HookedTransact falls through to real_transact, leaving the software path untouched. The early
+  // return is ref-balanced — `real` releases its fromBinder reference as it goes out of scope,
+  // restoring real_binder to exactly the count keystore2 holds; adding a decStrong here would
+  // under-reference it.
+  if (static_cast<SecurityLevel>(security_level) == SecurityLevel::SOFTWARE) {
+    LOGI("teesim_router_new_device: SOFTWARE-level KeyMint (real=%p, remote=%d); NOT wrapping",
+         real_binder, real_binder ? AIBinder_isRemote(real_binder) : -1);
+    return nullptr;
+  }
+  // keystore2 resolves a distinct IKeyMintDevice for TrustedEnvironment (level 1) and, when present,
+  // StrongBox (level 2); each is wrapped by its own local device at its real level. remote=0 marks a
+  // legacy km_compat leg, remote=1 a native HAL.
+  LOGI("teesim_router_new_device: local KeyMint device at security_level=%d (real=%p, remote=%d)",
+       security_level, real_binder, real_binder ? AIBinder_isRemote(real_binder) : -1);
   auto dev = ndk::SharedRefBase::make<TeesimKeyMintDevice>(
       static_cast<SecurityLevel>(security_level), std::move(real));
   ndk::SpAIBinder b = dev->asBinder();

--- a/rust/build.sh
+++ b/rust/build.sh
@@ -6,14 +6,14 @@
 # FFI from them) — no libcrypto.so of any ABI. Configure via environment:
 #   NDK_HOME   Android NDK (default: newest under $ANDROID_HOME/ndk)
 #   ABI        Android ABI (default: arm64-v8a)
-#   API        platform level (default: 34)
+#   API        platform level (default: 29)
 #   BORINGSSL  BoringSSL source dir with include/ (cloned if unset/missing)
 set -euo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 ROOT="$(cd "$HERE/.." && pwd)"
 ABI="${ABI:-arm64-v8a}"
-API="${API:-34}"
+API="${API:-29}"
 
 case "$ABI" in
   arm64-v8a)   TRIPLE=aarch64-linux-android ;;


### PR DESCRIPTION
On a device whose secure hardware still speaks Keymaster (keymaster@4.x HIDL), keystore2 has no native KeyMint, so per security level it wraps the HAL in-process with [km_compat](https://cs.android.com/android/platform/superproject/main/+/main:system/security/keystore2/src/km_compat/km_compat.rs) and hands out a *local* `IKeyMintDevice`. The hook only matched *remote* KeyMint, so these devices ran with no interception at all — the root of #216 (and the confusion in #198/#212).

The hook now matches the KeyMint descriptor whether the binder is remote or in-process, inserts the reference TA in front of it, and excludes the SOFTWARE `km_compat` device that exists on every device (including native-TEE ones).

The one subtlety: `IKeyMintDevice::fromBinder` returns null for such a local binder, because its `AIBinder_Class` was created by keystore2's own AIDL copy and `AIBinder_associateClass` rejects our statically-linked copy's class object. The generated `fromBinder` already handles exactly this (descriptor match → build a `Bp`), but only under `#if __ANDROID_API__ >= 31`. Since `keymint_aidl` only ever loads inside keystore2 (API 31+), we compile that one static lib at API 31 to switch the fallback on — no generated-code edits. A configure check fails the build if the aidl is too old to emit it.

Also: generate the AIDL with a single current build-tools (36) so its output is stable, and derive the Rust lib's native floor from `minSdk` instead of a hardcoded 34.