### PR TITLE
Select keystore1 transaction codes by Android release

### DIFF
--- a/common/control.cpp
+++ b/common/control.cpp
@@ -402,6 +402,8 @@ void *ServerThread(void *) {
 
 }  // namespace
 
+extern "C" int teesim_android_api(void) { return AndroidApi(); }
+
 extern "C" void teesim_control_start(void) {
   static bool started = false;
   if (started) return;

--- a/common/control.h
+++ b/common/control.h
@@ -89,6 +89,11 @@ const char *teesim_hook_name(void);
 // The daemon polls it via the control channel's getUsage request.
 char *teesim_usage_json_alloc(void);
 
+// The device Android API level (ro.build.version.sdk), or 0 if unknown. Shared so
+// hooks can select release-specific wire formats — the legacy keystore1 interface
+// shifted its transaction ordinals and grew finish()'s signature between 10 and 11.
+int teesim_android_api(void);
+
 // --- control server, implemented in common/control.cpp -----------------------
 
 // Bind the abstract socket @teesim, listen, and serve config pushes on a

--- a/keystore/keystore_entry.cpp
+++ b/keystore/keystore_entry.cpp
@@ -24,7 +24,9 @@ bool teesim_install_binder_hook();
 extern "C" bool teesim_ks_handle(uint32_t code, const Parcel& data, Parcel* reply, status_t& result);
 
 extern "C" [[gnu::visibility("default")]] bool entry(void* /*handle*/) {
-  LOGI("keystore interceptor loading");
+  int api = teesim_android_api();
+  LOGI("keystore interceptor loading (api=%d, %s transaction codes)", api,
+       api >= 30 ? "Android 11" : "Android 10");
   teesim_control_start();
 
   if (!teesim_install_binder_hook()) {

--- a/keystore/keystore_router.cpp
+++ b/keystore/keystore_router.cpp
@@ -39,17 +39,29 @@
 
 using namespace android;
 
-// IKeystoreService transaction codes (Android 10/11).
-enum {
-  TX_generateKey = 18,
-  TX_getKeyCharacteristics = 19,
-  TX_begin = 22,
-  TX_update = 23,
-  TX_finish = 24,
-  TX_abort = 25,
-  TX_exportKey = 21,
-  TX_attestKey = 29,
+// IKeystoreService transaction codes. The interface is otherwise identical across
+// Android 10 and 11, but R dropped reset() (ordinal 7 on Q) from the AIDL, so every
+// later method — all the ones we intercept — shifts down by one. Picking the wrong
+// table silently hijacks the neighbouring method: on an R device the Q codes make us
+// answer getKeyCharacteristics as if it were generateKey while the real generateKey
+// (one ordinal lower) runs untouched in keystore. Selected from the API level below.
+struct TxCodes {
+  uint32_t generateKey, getKeyCharacteristics, exportKey, attestKey, begin, update, finish, abort;
 };
+constexpr TxCodes kTxQ = {18, 19, 21, 29, 22, 23, 24, 25};  // Android 10 (API 29)
+constexpr TxCodes kTxR = {17, 18, 20, 28, 21, 22, 23, 24};  // Android 11 (API 30)
+
+// True on Android 11+. Besides the ordinal shift, R inserted a `byte[] input` before
+// `signature` in finish(), so the two releases also parse that request differently.
+bool IsAndroidR() {
+  static const bool is_r = teesim_android_api() >= 30;
+  return is_r;
+}
+
+const TxCodes& Codes() {
+  static const TxCodes& codes = IsAndroidR() ? kTxR : kTxQ;
+  return codes;
+}
 
 // KeyMint/Keymaster tag values (shared) and enum constants we need.
 enum {
@@ -735,7 +747,11 @@ bool HandleFinish(int /*uid*/, Parcel& in, Parcel* reply) {
   sp<IBinder> token = in.readStrongBinder();
   std::vector<std::vector<uint8_t>> blobs;
   if (in.readInt32() == 1) ReadKeymasterArguments(in, blobs);  // op params (unused)
-  std::vector<uint8_t> signature = ReadByteArray(in);          // supplied for verify
+  // R added a leading `byte[] input` (single-shot finish) ahead of the signature; Q
+  // has only the signature. Read input first on R so `signature` lands on the right field.
+  std::vector<uint8_t> input;
+  if (IsAndroidR()) input = ReadByteArray(in);
+  std::vector<uint8_t> signature = ReadByteArray(in);  // supplied for verify
 
   int64_t op_handle = 0;
   TaPtr ta;
@@ -743,7 +759,8 @@ bool HandleFinish(int /*uid*/, Parcel& in, Parcel* reply) {
 
   uint8_t* out = nullptr;
   size_t out_len = 0;
-  int32_t rc = teesim_km_finish(ta.get(), op_handle, nullptr, 0, signature.data(), signature.size(),
+  int32_t rc = teesim_km_finish(ta.get(), op_handle, input.data(), input.size(), signature.data(),
+                                signature.size(),
                                 /*auth_token=*/nullptr, /*timestamp_token=*/nullptr,
                                 /*confirmation_token=*/nullptr, 0, &out, &out_len);
   std::vector<uint8_t> output;
@@ -755,7 +772,7 @@ bool HandleFinish(int /*uid*/, Parcel& in, Parcel* reply) {
   }
   LOGI("keystore: finish output=%zu", output.size());
 
-  DeliverOperationResult(cb, rc, token, 0, output);
+  DeliverOperationResult(cb, rc, token, static_cast<int32_t>(input.size()), output);
   ReplyStatus(reply, KS_NO_ERROR);
   return true;
 }
@@ -837,35 +854,27 @@ extern "C" bool teesim_cfg_resign(const char* /*profile_id*/, const uint8_t* /*l
 // The interception handler installed for the keystore service binder.
 extern "C" bool teesim_ks_handle(uint32_t code, const Parcel& data, Parcel* reply,
                                   status_t& result) {
-  switch (code) {
-    case TX_generateKey:
-    case TX_getKeyCharacteristics:
-    case TX_exportKey:
-    case TX_attestKey:
-    case TX_begin:
-    case TX_update:
-    case TX_finish:
-    case TX_abort:
-      break;
-    default:
-      return false;
-  }
+  // The ordinals are release-specific, so this dispatch runs against the resolved table
+  // rather than a compile-time switch (see TxCodes).
+  const TxCodes& tx = Codes();
+  if (code != tx.generateKey && code != tx.getKeyCharacteristics && code != tx.exportKey &&
+      code != tx.attestKey && code != tx.begin && code != tx.update && code != tx.finish &&
+      code != tx.abort)
+    return false;
   int uid = IPCThreadState::self()->getCallingUid();
   if (!IsTarget(uid)) return false;
   Reader r(data);
   if (!r.p.enforceInterface(kServiceDescriptor)) return false;
 
   bool done = false;
-  switch (code) {
-    case TX_generateKey:           done = HandleGenerateKey(uid, r.p, reply); break;
-    case TX_getKeyCharacteristics: done = HandleGetKeyCharacteristics(uid, r.p, reply); break;
-    case TX_exportKey:             done = HandleExportKey(uid, r.p, reply); break;
-    case TX_attestKey:             done = HandleAttestKey(uid, r.p, reply); break;
-    case TX_begin:                 done = HandleBegin(uid, r.p, reply); break;
-    case TX_update:                done = HandleUpdate(uid, r.p, reply); break;
-    case TX_finish:                done = HandleFinish(uid, r.p, reply); break;
-    case TX_abort:                 done = HandleAbort(uid, r.p, reply); break;
-  }
+  if (code == tx.generateKey)                done = HandleGenerateKey(uid, r.p, reply);
+  else if (code == tx.getKeyCharacteristics) done = HandleGetKeyCharacteristics(uid, r.p, reply);
+  else if (code == tx.exportKey)             done = HandleExportKey(uid, r.p, reply);
+  else if (code == tx.attestKey)             done = HandleAttestKey(uid, r.p, reply);
+  else if (code == tx.begin)                 done = HandleBegin(uid, r.p, reply);
+  else if (code == tx.update)                done = HandleUpdate(uid, r.p, reply);
+  else if (code == tx.finish)                done = HandleFinish(uid, r.p, reply);
+  else if (code == tx.abort)                 done = HandleAbort(uid, r.p, reply);
   if (done) result = OK;
   return done;
 }


### PR DESCRIPTION
The legacy keystore1 hook hardcoded Android 10's `IKeystoreService` ordinals, breaking key attestation on Android 11 (reproduced on ColorOS). Android 11 removed `reset()` from the AIDL, shifting every later method down by one — `generateKey` 18→17, `finish` 24→23, `attestKey` 29→28, and so on. With the Android 10 table, an Android 11 device answered `getKeyCharacteristics` as if it were `generateKey` while the real `generateKey` ran untouched, corrupting the reply parcel and trapping callers in a generate-fail-retry loop.

The ordinals are now resolved from `ro.build.version.sdk` and dispatched against the selected table. Android 11 also added a `byte[] input` argument to `finish()`, which is now read on 11+ and forwarded to the TA. Request layouts are otherwise identical across the two releases. Verified against the AOSP `r47`/`r48` AIDL; native build passes for both ABIs.