### PR TITLE
Show revocation and root-authority status in the keybox inspector

### DIFF
--- a/app/src/main/java/org/matrix/teesim/App.kt
+++ b/app/src/main/java/org/matrix/teesim/App.kt
@@ -100,6 +100,10 @@ object App {
             // Key-management endpoint for the WebUI.
             KeyAdmin.start(harvest)
 
+            // Pull Google's attestation revocation list in the background so the keybox inspector's
+            // revoked/Google-signed verdicts are ready before the first inspect.
+            RevocationList.warm()
+
             // Inject the interceptor and keep it injected across keystore restarts.
             Injector(resolveModuleDir(args)).start()
 

--- a/app/src/main/java/org/matrix/teesim/KeyAdmin.kt
+++ b/app/src/main/java/org/matrix/teesim/KeyAdmin.kt
@@ -243,7 +243,10 @@ object KeyAdmin {
                             delete(query["alias"] ?: error("alias required"))
                         method == "GET" && path == "/logs" -> logs(query)
                         method == "GET" && path == "/keybox/inspect" ->
-                            KeyboxInspector.inspect(query["name"] ?: error("name required"))
+                            KeyboxInspector.inspect(
+                                query["name"] ?: error("name required"),
+                                query["refresh"] == "1",
+                            )
                         method == "GET" && path == "/canary" -> Updater.status()
                         method == "POST" && path == "/canary/install" ->
                             Updater.install(

--- a/app/src/main/java/org/matrix/teesim/KeyAdmin.kt
+++ b/app/src/main/java/org/matrix/teesim/KeyAdmin.kt
@@ -50,7 +50,11 @@ import org.json.JSONObject
  * marker- and target-verified) GET /keys/inspect?alias=A -> { ok, alias, attestation{...} | null }
  * POST /keys/delete?alias=A -> { ok, deleted } GET /logs?after=N&max=M
  * -> { ok, lines:[{seq,level,tag,text}], nextAfter } GET /keybox/inspect?name=F -> { ok, name,
- * deviceId, keys:[{algorithm, privateKeyPresent, chainLength, linkage, certs:[{...}]}] } GET /canary ->
+ * deviceId, revocationListAvailable, keys:[{algorithm, privateKeyPresent, chainLength, linkage,
+ * rootAuthority(google|aosp|knox|unknown|none), googleSigned, chainVerified, revoked, revocationChecked,
+ * certs:[{index, subject, issuer, serial, notBefore, notAfter, expired, sigAlg, keyAlgorithm, keySize,
+ * isCa, selfSigned, signatureValid?, revocationChecked?, revoked?, revocationStatus?, revocationReason?,
+ * rootAuthority?}]}] } GET /canary ->
  * { ok, currentCode, latest{...}|null, updateAvailable } POST /canary/install?tag=&variant= -> { ok,
  * message }
  */

--- a/app/src/main/java/org/matrix/teesim/KeyboxInspector.kt
+++ b/app/src/main/java/org/matrix/teesim/KeyboxInspector.kt
@@ -17,6 +17,12 @@ import org.w3c.dom.Element
  * the certificate chain and reports the fields that let a user spot a bad keybox — subject/issuer,
  * validity (with expiry), key type and size, and whether the chain links up — plus whether a private
  * key is present. Read-only: the private key material is never returned, only that it exists.
+ *
+ * It also runs the checks that decide whether a keybox would pass Play Integrity / hardware attestation:
+ * each cert's signature is verified against its parent, [RootPublicKey] classifies the root the chain
+ * terminates in (Google, AOSP software, Knox, or unknown), and every serial is looked up in Google's
+ * revocation list ([RevocationList]). A Google-rooted, cryptographically linked, unrevoked chain is a
+ * genuine live keybox; a revoked or software-rooted one is not.
  */
 object KeyboxInspector {
 
@@ -47,6 +53,7 @@ object KeyboxInspector {
                 .put("ok", true)
                 .put("name", name)
                 .put("deviceId", kb?.getAttribute("DeviceID") ?: "")
+                .put("revocationListAvailable", RevocationList.available())
                 .put("keys", keys)
         } catch (e: Exception) {
             SystemLogger.warning("KeyboxInspector: failed to parse $name", e)
@@ -90,20 +97,76 @@ object KeyboxInspector {
 
         val certParent = firstChild(ke, "CertificateChain") ?: ke
         val certNodes = certParent.getElementsByTagName("Certificate")
+
+        // Parse every slot; a null keeps its position so the signature pairing (cert[i] signed by
+        // cert[i+1], the top cert self-signed) stays aligned even when one cert fails to decode.
+        val parsed = ArrayList<X509Certificate?>()
+        for (i in 0 until certNodes.length) parsed.add(parsePem(certNodes.item(i).textContent))
+        val valid = parsed.filterNotNull()
+
+        val revChecked = RevocationList.available()
         val certs = JSONArray()
-        val parsed = ArrayList<X509Certificate>()
-        for (i in 0 until certNodes.length) {
-            val cert = parsePem(certNodes.item(i).textContent)
+        var anyRevoked = false
+        var chainVerified = valid.isNotEmpty() && valid.size == parsed.size
+        for (i in parsed.indices) {
+            val cert = parsed[i]
             if (cert == null) {
                 certs.put(JSONObject().put("index", i).put("error", "could not parse certificate"))
-            } else {
-                parsed.add(cert)
-                certs.put(certJson(i, cert))
+                chainVerified = false
+                continue
             }
+            val j = certJson(i, cert)
+
+            // Cryptographic linkage: every cert is signed by the next one up; a self-signed root signs
+            // itself. When the top cert is not self-signed the real root is not embedded (the chain ends
+            // at an intermediate) — there is nothing in-chain to check it against, so leave it and let
+            // RootPublicKey.authorityOf decide its trust.
+            val isTop = i == parsed.size - 1
+            val selfSigned = cert.subjectX500Principal == cert.issuerX500Principal
+            val parentKey = when {
+                isTop && !selfSigned -> null
+                isTop -> cert.publicKey
+                else -> parsed[i + 1]?.publicKey
+            }
+            val sigValid = parentKey?.let {
+                try {
+                    cert.verify(it)
+                    true
+                } catch (_: Exception) {
+                    false
+                }
+            }
+            if (sigValid != null) j.put("signatureValid", sigValid)
+            if (sigValid == false) chainVerified = false
+
+            j.put("revocationChecked", revChecked)
+            if (revChecked) {
+                val rev = RevocationList.status(cert.serialNumber)
+                if (rev != null) {
+                    anyRevoked = true
+                    j.put("revoked", true)
+                        .put("revocationStatus", rev.optString("status", "REVOKED"))
+                        .put("revocationReason", rev.optString("reason", ""))
+                } else {
+                    j.put("revoked", false)
+                }
+            }
+            certs.put(j)
         }
+
+        val authority = RootPublicKey.authorityOf(valid)
+        // Tag the top-most parsed cert with the verdict, so the root row can show it.
+        val topIndex = parsed.indexOfLast { it != null }
+        if (topIndex >= 0) certs.optJSONObject(topIndex)?.put("rootAuthority", authority)
+
         out.put("chainLength", certNodes.length)
         out.put("certs", certs)
-        out.put("linkage", linkage(parsed))
+        out.put("linkage", linkage(valid))
+        out.put("rootAuthority", authority)
+        out.put("googleSigned", authority == RootPublicKey.GOOGLE)
+        out.put("chainVerified", chainVerified)
+        out.put("revoked", anyRevoked)
+        out.put("revocationChecked", revChecked)
         return out
     }
 

--- a/app/src/main/java/org/matrix/teesim/KeyboxInspector.kt
+++ b/app/src/main/java/org/matrix/teesim/KeyboxInspector.kt
@@ -35,10 +35,12 @@ object KeyboxInspector {
         return name
     }
 
-    fun inspect(rawName: String): JSONObject {
+    fun inspect(rawName: String, forceRefresh: Boolean = false): JSONObject {
         val name = safeName(rawName) ?: return fail("invalid keybox name")
         val file = File(Const.DATA_DIR, name)
         if (!file.isFile) return fail("no such keybox: $name")
+        // Pull-to-refresh on the detail page re-fetches Google's revocation list before re-checking.
+        if (forceRefresh) RevocationList.forceRefresh()
         return try {
             val doc = newSafeBuilder().parse(file)
             val root = doc.documentElement

--- a/app/src/main/java/org/matrix/teesim/RevocationList.kt
+++ b/app/src/main/java/org/matrix/teesim/RevocationList.kt
@@ -42,6 +42,14 @@ object RevocationList {
     /** True when we hold a revocation list (fresh or stale) to check against. */
     fun available(): Boolean = ensureEntries() != null
 
+    /** Force a fresh fetch straight from the server — bypassing the TTL and any edge cache — then
+     *  report availability. Backs the keybox inspector's pull-to-refresh, so a re-verify sees the
+     *  live list rather than a copy a CDN has been serving for hours. */
+    fun forceRefresh(): Boolean {
+        fetchNow()
+        return entries != null
+    }
+
     /** Kick a load/refresh at daemon start-up so the first inspect already has the list. */
     fun warm() {
         Thread(
@@ -88,7 +96,10 @@ object RevocationList {
     /** Fetch synchronously and adopt the result; leaves any existing copy on failure. */
     private fun fetchNow() {
         try {
-            val raw = httpGet(STATUS_URL)
+            // A unique query defeats any edge/CDN cache — Google serves this list with a one-day
+            // max-age, so a plain GET can return a copy hours stale (a real Age header seen in the
+            // wild). We want the live list here, and the disk copy is our own caching layer.
+            val raw = httpGet("$STATUS_URL?ts=${System.currentTimeMillis()}")
             val parsed = JSONObject(raw).getJSONObject("entries")
             entries = parsed
             loadedAt = System.currentTimeMillis()
@@ -128,7 +139,10 @@ object RevocationList {
         c.connectTimeout = 8000
         c.readTimeout = 8000
         c.instanceFollowRedirects = true
+        c.useCaches = false
         c.setRequestProperty("Accept", "application/json")
+        c.setRequestProperty("Cache-Control", "no-cache")
+        c.setRequestProperty("Pragma", "no-cache")
         c.setRequestProperty("User-Agent", "TEESimulator")
         c.inputStream.use {
             return it.readBytes().toString(Charsets.UTF_8)

--- a/app/src/main/java/org/matrix/teesim/RevocationList.kt
+++ b/app/src/main/java/org/matrix/teesim/RevocationList.kt
@@ -1,0 +1,137 @@
+package org.matrix.teesim
+
+import java.io.File
+import java.math.BigInteger
+import java.net.HttpURLConnection
+import java.net.URL
+import org.json.JSONObject
+
+/**
+ * Google's attestation certificate revocation list — the same one Play Integrity / hardware
+ * attestation consults. It is published as JSON at
+ * https://android.googleapis.com/attestation/status, an object under "entries" keyed by
+ * lowercase-hex certificate serial number, each value carrying a "status" (REVOKED/SUSPENDED) and a
+ * "reason" (KEY_COMPROMISE, SOFTWARE_FLAW, …). A keybox whose chain contains a listed serial is
+ * dead: attestations it signs are rejected.
+ *
+ * The daemon has network, so we fetch the live list and cache it to disk (attestation_status.json),
+ * serving the cached copy immediately and refreshing in the background when stale. Offline, the
+ * last cached copy is used; with no cache at all, one bounded synchronous fetch is attempted. When
+ * nothing is available the lookups report "unknown" rather than a false "not revoked".
+ */
+object RevocationList {
+
+    private const val STATUS_URL = "https://android.googleapis.com/attestation/status"
+    private val cacheFile = File(Const.DATA_DIR, "attestation_status.json")
+    private const val TTL_MS = 12 * 60 * 60 * 1000L // refresh at most twice a day
+
+    @Volatile private var entries: JSONObject? = null
+    @Volatile private var loadedAt = 0L
+    @Volatile private var refreshing = false
+
+    /**
+     * The {status, reason} for a serial, or null if not listed. Null return != "list unavailable" —
+     * pair that with [available] to tell a clean cert from an unknown one.
+     */
+    fun status(serial: BigInteger): JSONObject? {
+        val e = ensureEntries() ?: return null
+        val key = serial.toString(16).lowercase()
+        return e.optJSONObject(key)
+    }
+
+    /** True when we hold a revocation list (fresh or stale) to check against. */
+    fun available(): Boolean = ensureEntries() != null
+
+    /** Kick a load/refresh at daemon start-up so the first inspect already has the list. */
+    fun warm() {
+        Thread(
+                {
+                    try {
+                        ensureEntries()
+                    } catch (e: Exception) {
+                        SystemLogger.warning("RevocationList: warm failed", e)
+                    }
+                },
+                "teesim-revocation-warm",
+            )
+            .apply {
+                isDaemon = true
+                start()
+            }
+    }
+
+    private fun ensureEntries(): JSONObject? {
+        val now = System.currentTimeMillis()
+        entries?.let { if (now - loadedAt < TTL_MS) return it }
+
+        // Nothing in memory yet — try the disk cache, adopting its file mtime as the fetch time.
+        if (entries == null && cacheFile.isFile) {
+            try {
+                val parsed = JSONObject(cacheFile.readText()).getJSONObject("entries")
+                entries = parsed
+                loadedAt = cacheFile.lastModified()
+                SystemLogger.info("RevocationList: loaded ${parsed.length()} entries from cache")
+            } catch (e: Exception) {
+                SystemLogger.warning("RevocationList: bad cache, ignoring", e)
+            }
+        }
+
+        val have = entries
+        val fresh = have != null && now - loadedAt < TTL_MS
+        if (!fresh) {
+            if (have == null) fetchNow() // no data at all — block once (bounded)
+            else refreshAsync() // stale — serve what we have, refresh behind the scenes
+        }
+        return entries
+    }
+
+    /** Fetch synchronously and adopt the result; leaves any existing copy on failure. */
+    private fun fetchNow() {
+        try {
+            val raw = httpGet(STATUS_URL)
+            val parsed = JSONObject(raw).getJSONObject("entries")
+            entries = parsed
+            loadedAt = System.currentTimeMillis()
+            try {
+                cacheFile.parentFile?.mkdirs()
+                cacheFile.writeText(raw)
+            } catch (e: Exception) {
+                SystemLogger.warning("RevocationList: could not write cache", e)
+            }
+            SystemLogger.info("RevocationList: fetched ${parsed.length()} entries from $STATUS_URL")
+        } catch (e: Exception) {
+            SystemLogger.warning("RevocationList: fetch failed (offline?)", e)
+        }
+    }
+
+    private fun refreshAsync() {
+        if (refreshing) return
+        refreshing = true
+        Thread(
+                {
+                    try {
+                        fetchNow()
+                    } finally {
+                        refreshing = false
+                    }
+                },
+                "teesim-revocation-refresh",
+            )
+            .apply {
+                isDaemon = true
+                start()
+            }
+    }
+
+    private fun httpGet(url: String): String {
+        val c = URL(url).openConnection() as HttpURLConnection
+        c.connectTimeout = 8000
+        c.readTimeout = 8000
+        c.instanceFollowRedirects = true
+        c.setRequestProperty("Accept", "application/json")
+        c.setRequestProperty("User-Agent", "TEESimulator")
+        c.inputStream.use {
+            return it.readBytes().toString(Charsets.UTF_8)
+        }
+    }
+}

--- a/app/src/main/java/org/matrix/teesim/RootPublicKey.kt
+++ b/app/src/main/java/org/matrix/teesim/RootPublicKey.kt
@@ -1,0 +1,171 @@
+package org.matrix.teesim
+
+import java.io.ByteArrayInputStream
+import java.security.KeyFactory
+import java.security.PublicKey
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+import java.security.spec.X509EncodedKeySpec
+import java.util.Base64
+
+/**
+ * Classifies the root a keybox certificate chain terminates in, so the WebUI can tell a genuine
+ * Google-signed keybox from an AOSP software root or a Samsung Knox one. The trust anchors are the
+ * public keys Google publishes for hardware key attestation; we pin the *public key* (not a whole
+ * cert) so every re-issued root with the same key collapses to one anchor.
+ *
+ * The authoritative machine-readable set is served at
+ * https://android.googleapis.com/attestation/root (documented at
+ * https://developer.android.com/privacy-and-security/security-key-attestation). It currently
+ * publishes two roots, both pinned below: the long-standing RSA-4096 root (subject serial
+ * f92009e853b6b045, valid 2022-2042) and the EC P-384 "Key Attestation CA1" root that signs Remote
+ * Key Provisioning chains — live since 2026-02-01 and, since 2026-04-10, the exclusive root for
+ * RKP-enabled devices (i.e. most modern hardware). Trust anchors are pinned in-binary on purpose:
+ * fetching a root you then trust would be circular. The AOSP and Knox keys mirror the vvb2060
+ * KeyAttestation reference.
+ */
+object RootPublicKey {
+
+    /** RSA-4096 Google hardware-attestation root SubjectPublicKeyInfo (base64 DER). */
+    private const val GOOGLE_ROOT_RSA =
+        "MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAr7bHgiuxpwHsK7Qui8xU" +
+            "FmOr75gvMsd/dTEDDJdSSxtf6An7xyqpRR90PL2abxM1dEqlXnf2tqw1Ne4Xwl5j" +
+            "lRfdnJLmN0pTy/4lj4/7tv0Sk3iiKkypnEUtR6WfMgH0QZfKHM1+di+y9TFRtv6y" +
+            "//0rb+T+W8a9nsNL/ggjnar86461qO0rOs2cXjp3kOG1FEJ5MVmFmBGtnrKpa73X" +
+            "pXyTqRxB/M0n1n/W9nGqC4FSYa04T6N5RIZGBN2z2MT5IKGbFlbC8UrW0DxW7AYI" +
+            "mQQcHtGl/m00QLVWutHQoVJYnFPlXTcHYvASLu+RhhsbDmxMgJJ0mcDpvsC4PjvB" +
+            "+TxywElgS70vE0XmLD+OJtvsBslHZvPBKCOdT0MS+tgSOIfga+z1Z1g7+DVagf7q" +
+            "uvmag8jfPioyKvxnK/EgsTUVi2ghzq8wm27ud/mIM7AY2qEORR8Go3TVB4HzWQgp" +
+            "Zrt3i5MIlCaY504LzSRiigHCzAPlHws+W0rB5N+er5/2pJKnfBSDiCiFAVtCLOZ7" +
+            "gLiMm0jhO2B6tUXHI/+MRPjy02i59lINMRRev56GKtcd9qO/0kUJWdZTdA2XoS82" +
+            "ixPvZtXQpUpuL12ab+9EaDK8Z4RHJYYfCT3Q5vNAXaiWQ+8PTWm2QgBR/bkwSWc+" +
+            "NpUFgNPN9PvQi8WEg5UmAGMCAwEAAQ=="
+
+    /** EC P-384 Google root, effective 2026-02-01 (full cert; its key is derived at load). */
+    private const val GOOGLE_ROOT_EC_CERT =
+        "-----BEGIN CERTIFICATE-----\n" +
+            "MIICIjCCAaigAwIBAgIRAISp0Cl7DrWK5/8OgN52BgUwCgYIKoZIzj0EAwMwUjEc\n" +
+            "MBoGA1UEAwwTS2V5IEF0dGVzdGF0aW9uIENBMTEQMA4GA1UECwwHQW5kcm9pZDET\n" +
+            "MBEGA1UECgwKR29vZ2xlIExMQzELMAkGA1UEBhMCVVMwHhcNMjUwNzE3MjIzMjE4\n" +
+            "WhcNMzUwNzE1MjIzMjE4WjBSMRwwGgYDVQQDDBNLZXkgQXR0ZXN0YXRpb24gQ0Ex\n" +
+            "MRAwDgYDVQQLDAdBbmRyb2lkMRMwEQYDVQQKDApHb29nbGUgTExDMQswCQYDVQQG\n" +
+            "EwJVUzB2MBAGByqGSM49AgEGBSuBBAAiA2IABCPaI3FO3z5bBQo8cuiEas4HjqCt\n" +
+            "G/mLFfRT0MsIssPBEEU5Cfbt6sH5yOAxqEi5QagpU1yX4HwnGb7OtBYpDTB57uH5\n" +
+            "Eczm34A5FNijV3s0/f0UPl7zbJcTx6xwqMIRq6NCMEAwDwYDVR0TAQH/BAUwAwEB\n" +
+            "/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFFIyuyz7RkOb3NaBqQ5lZuA0QepA\n" +
+            "MAoGCCqGSM49BAMDA2gAMGUCMETfjPO/HwqReR2CS7p0ZWoD/LHs6hDi422opifH\n" +
+            "EUaYLxwGlT9SLdjkVpz0UUOR5wIxAIoGyxGKRHVTpqpGRFiJtQEOOTp/+s1GcxeY\n" +
+            "uR2zh/80lQyu9vAFCj6E4AXc+osmRg==\n" +
+            "-----END CERTIFICATE-----\n"
+
+    /** AOSP software roots — a chain rooted here is a software keybox, not hardware-attested. */
+    private const val AOSP_ROOT_EC =
+        "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE7l1ex+HA220Dpn7mthvsTWpdamgu" +
+            "D/9/SQ59dx9EIm29sa/6FsvHrcV30lacqrewLVQBXT5DKyqO107sSHVBpA=="
+    private const val AOSP_ROOT_RSA =
+        "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCia63rbi5EYe/VDoLmt5TRdSMf" +
+            "d5tjkWP/96r/C3JHTsAsQ+wzfNes7UA+jCigZtX3hwszl94OuE4TQKuvpSe/lWmg" +
+            "MdsGUmX4RFlXYfC78hdLt0GAZMAoDo9Sd47b0ke2RekZyOmLw9vCkT/X11DEHTVm" +
+            "+Vfkl5YLCazOkjWFmwIDAQAB"
+
+    /** Samsung Knox attestation roots (SAKV1/SAKV2/SAKMV1). */
+    private const val KNOX_SAKV1 =
+        "MIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBs9Qjr//REhkXW7jUqjY9KNwWac4r" +
+            "5+kdUGk+TZjRo1YEa47Axwj6AJsbOjo4QsHiYRiWTELvFeiuBsKqyuF0xyAAKvDo" +
+            "fBqrEq1/Ckxo2mz7Q4NQes3g4ahSjtgUSh0k85fYwwHjCeLyZ5kEqgHG9OpOH526" +
+            "FFAK3slSUgC8RObbxys="
+    private const val KNOX_SAKV2 =
+        "MIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBhbGuLrpql5I2WJmrE5kEVZOo+dgA" +
+            "46mKrVJf/sgzfzs2u7M9c1Y9ZkCEiiYkhTFE9vPbasmUfXybwgZ2EM30A1ABPd12" +
+            "4n3JbEDfsB/wnMH1AcgsJyJFPbETZiy42Fhwi+2BCA5bcHe7SrdkRIYSsdBRaKBo" +
+            "ZsapxB0gAOs0jSPRX5M="
+    private const val KNOX_SAKMV1 =
+        "MIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQB9XeEN8lg6p5xvMVWG42P2Qi/aRKX" +
+            "2rPRNgK92UlO9O/TIFCKHC1AWCLFitPVEow5W+yEgC2wOiYxgepY85TOoH0AuEkL" +
+            "oiC6ldbF2uNVU3rYYSytWAJg3GFKd1l9VLDmxox58Hyw2Jmdd5VSObGiTFQ/SgKs" +
+            "n2fbQPtpGlNxgEfd6Y8="
+
+    /** Chain-root classification, as reported to the WebUI. */
+    const val GOOGLE = "google"
+    const val AOSP = "aosp"
+    const val KNOX = "knox"
+    const val UNKNOWN = "unknown"
+    const val NONE = "none"
+
+    private val googleKeys: List<PublicKey> = buildList {
+        spkiToKey(GOOGLE_ROOT_RSA)?.let { add(it) }
+        certToKey(GOOGLE_ROOT_EC_CERT)?.let { add(it) }
+    }
+    private val aospKeys: List<PublicKey> =
+        listOfNotNull(spkiToKey(AOSP_ROOT_EC), spkiToKey(AOSP_ROOT_RSA))
+    private val knoxKeys: List<PublicKey> =
+        listOfNotNull(spkiToKey(KNOX_SAKV1), spkiToKey(KNOX_SAKV2), spkiToKey(KNOX_SAKMV1))
+
+    init {
+        SystemLogger.info(
+            "RootPublicKey: pinned ${googleKeys.size} Google, ${aospKeys.size} AOSP, ${knoxKeys.size} Knox anchors"
+        )
+    }
+
+    /**
+     * The authority the chain terminates in. Prefers an exact key match on the top cert (a
+     * self-signed root that IS a known anchor); if the top cert is not itself an anchor, tries to
+     * verify it against each anchor key, so a chain whose Google root is present as issuer-only
+     * (not embedded) still reads as Google. Returns [NONE] for an empty chain.
+     */
+    fun authorityOf(chain: List<X509Certificate>): String {
+        val top = chain.lastOrNull() ?: return NONE
+        val enc = top.publicKey.encoded
+        when {
+            matches(enc, googleKeys) -> return GOOGLE
+            matches(enc, aospKeys) -> return AOSP
+            matches(enc, knoxKeys) -> return KNOX
+        }
+        // Root not embedded: does a pinned anchor sign the top cert?
+        if (signedByAny(top, googleKeys)) return GOOGLE
+        if (signedByAny(top, aospKeys)) return AOSP
+        if (signedByAny(top, knoxKeys)) return KNOX
+        return UNKNOWN
+    }
+
+    private fun matches(encoded: ByteArray, keys: List<PublicKey>): Boolean = keys.any {
+        it.encoded.contentEquals(encoded)
+    }
+
+    private fun signedByAny(cert: X509Certificate, keys: List<PublicKey>): Boolean = keys.any {
+        try {
+            cert.verify(it)
+            true
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    private fun spkiToKey(base64: String): PublicKey? {
+        val der =
+            try {
+                Base64.getDecoder().decode(base64)
+            } catch (e: Exception) {
+                SystemLogger.warning("RootPublicKey: bad SPKI base64", e)
+                return null
+            }
+        val spec = X509EncodedKeySpec(der)
+        for (algo in listOf("EC", "RSA")) {
+            try {
+                return KeyFactory.getInstance(algo).generatePublic(spec)
+            } catch (_: Exception) {}
+        }
+        SystemLogger.warning("RootPublicKey: SPKI matched neither EC nor RSA")
+        return null
+    }
+
+    private fun certToKey(pem: String): PublicKey? =
+        try {
+            CertificateFactory.getInstance("X.509")
+                .generateCertificate(ByteArrayInputStream(pem.toByteArray()))
+                .publicKey
+        } catch (e: Exception) {
+            SystemLogger.warning("RootPublicKey: could not parse pinned root cert", e)
+            null
+        }
+}

--- a/module/webroot/css/app.css
+++ b/module/webroot/css/app.css
@@ -439,6 +439,25 @@ html, body { overscroll-behavior-y: contain; }
 .kbi-cert { border-top: 1px solid var(--line); padding-top: 12px; display: flex; flex-direction: column; gap: 6px; }
 .kbi-key .kbi-cert:first-of-type { border-top: 0; padding-top: 0; }
 
+/* Chain verdict banner — the headline "is this keybox genuine / revoked" status. */
+.kbi-verdict { display: flex; gap: 12px; align-items: flex-start; padding: 12px 14px; border-radius: var(--radius-sm); background: var(--chip); border: 1px solid var(--line); border-left: 4px solid var(--muted); }
+.kbi-verdict--good { border-left-color: var(--ok); }
+.kbi-verdict--warn { border-left-color: var(--warn); }
+.kbi-verdict--bad { border-left-color: var(--danger); }
+.kbi-verdict-icon { flex: none; width: 24px; height: 24px; border-radius: 50%; display: inline-flex; align-items: center; justify-content: center; font-size: 14px; font-weight: 800; line-height: 1; color: #fff; background: var(--muted); }
+.kbi-verdict--good .kbi-verdict-icon { background: var(--ok); }
+.kbi-verdict--warn .kbi-verdict-icon { background: var(--warn); }
+.kbi-verdict--bad .kbi-verdict-icon { background: var(--danger); }
+.kbi-verdict-text { min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+.kbi-verdict-title { font-weight: 700; font-size: 14px; }
+.kbi-verdict--good .kbi-verdict-title { color: var(--ok); }
+.kbi-verdict--warn .kbi-verdict-title { color: var(--warn); }
+.kbi-verdict--bad .kbi-verdict-title { color: var(--danger); }
+.kbi-verdict-sub { color: var(--muted); font-size: 12px; line-height: 1.4; }
+
+/* A revoked cert deserves a stronger signal than the amber warn chips. */
+.chip.danger { color: var(--danger); font-weight: 700; }
+
 /* --- stored-key provenance lines ---------------------------------------- */
 .kmeta { color: var(--muted); font-size: 12px; word-break: break-word; }
 .kmeta b { color: var(--fg); font-weight: 600; }

--- a/module/webroot/js/controllers/keybox-controller.js
+++ b/module/webroot/js/controllers/keybox-controller.js
@@ -5,7 +5,7 @@
 
 import { listKeyboxes, importKeybox, renameKeybox, deleteKeybox } from "../data/keybox-io.js";
 import { keyAdmin } from "../data/keyadmin.js";
-import { renderKeyboxes, renderKeyboxImport, renderKeyboxInspect } from "../ui/keybox-view.js";
+import { renderKeyboxes, renderKeyboxImport, renderKeyboxInspect, fillKeyboxInspect } from "../ui/keybox-view.js";
 import { toast, confirmDialog, promptDialog, openSheet, openOverlay } from "../ui/dom.js";
 import { attachPullToRefresh } from "../ui/pull-refresh.js";
 
@@ -57,9 +57,29 @@ export function create(mount) {
       return;
     }
     const content = renderKeyboxInspect({ name, data }, { close: () => closeInspect() });
-    inspectOverlay = openOverlay(content, { variant: "panel", label: "Keybox", onClose: () => { inspectOverlay = null; } });
+    const body = content.querySelector(".drill-body");
+    let detachPtr = null;
+    inspectOverlay = openOverlay(content, {
+      variant: "panel", label: "Keybox",
+      onClose: () => { if (detachPtr) detachPtr(); detachPtr = null; inspectOverlay = null; },
+    });
+    // Pull down on the detail page to re-fetch Google's revocation list and re-verify in place.
+    // The spinner must clear the overlay (z-index 40), and detachPtr removes the fixed dot on close.
+    detachPtr = attachPullToRefresh(body, () => refreshInspect(name, body), { scroller: body, zIndex: 41 });
     const title = content.querySelector(".drill-title");
     if (title) title.focus();
+  }
+
+  // Re-inspect with a forced, cache-busted revocation-list refresh, then refill the same body node.
+  async function refreshInspect(name, body) {
+    let data;
+    try {
+      data = await keyAdmin("keyboxInspect", { name, refresh: true });
+    } catch (e) {
+      toast("Refresh failed: " + (e && e.message ? e.message : String(e)));
+      return;
+    }
+    fillKeyboxInspect(body, { name, data });
   }
 
   function closeInspect() {

--- a/module/webroot/js/data/keyadmin.js
+++ b/module/webroot/js/data/keyadmin.js
@@ -45,11 +45,18 @@
 //   keyAdmin("logsWrite", { dir, name, text }) -> { ok, path } | { ok:false, error }
 //       the daemon (root) writes `text` to <dir>/<safe(name)>, creating dir; it names and
 //       places the file since the WebView ignores download filenames and Content-Disposition.
-//   keyAdmin("keyboxInspect", { name }) -> { ok, name, deviceId,
-//                                          keys:[{ algorithm, privateKeyPresent, chainLength,
-//                                                  linkage, certs:[{ index, subject, issuer,
-//                                                  serial, notBefore, notAfter, expired,
-//                                                  keyAlgorithm, keySize, isCa, ... }] }] }
+//   keyAdmin("keyboxInspect", { name }) -> { ok, name, deviceId, revocationListAvailable,
+//                                          keys:[{ algorithm, privateKeyPresent, chainLength, linkage,
+//                                                  rootAuthority, googleSigned, chainVerified, revoked,
+//                                                  revocationChecked,
+//                                                  certs:[{ index, subject, issuer, serial, notBefore,
+//                                                  notAfter, expired, sigAlg, keyAlgorithm, keySize, isCa,
+//                                                  selfSigned, signatureValid, revoked, revocationChecked,
+//                                                  revocationStatus, revocationReason, rootAuthority }] }] }
+//       rootAuthority: which trust anchor the chain roots in — "google" (genuine hardware keybox),
+//       "aosp" (software root), "knox", "unknown", or "none". googleSigned/chainVerified/revoked are the
+//       chain-level verdicts the inspector's status banner is built from; revocationChecked is false when
+//       Google's revocation list could not be fetched (so revoked is not authoritative).
 //   keyAdmin("canary")               -> { ok, currentCode, latest:{ code, tag, name,
 //                                          notes, htmlUrl, assets:[{ name, size }] }|null,
 //                                          updateAvailable }

--- a/module/webroot/js/data/keyadmin.js
+++ b/module/webroot/js/data/keyadmin.js
@@ -45,7 +45,9 @@
 //   keyAdmin("logsWrite", { dir, name, text }) -> { ok, path } | { ok:false, error }
 //       the daemon (root) writes `text` to <dir>/<safe(name)>, creating dir; it names and
 //       places the file since the WebView ignores download filenames and Content-Disposition.
-//   keyAdmin("keyboxInspect", { name }) -> { ok, name, deviceId, revocationListAvailable,
+//   keyAdmin("keyboxInspect", { name, refresh? }) -> { ok, name, deviceId, revocationListAvailable,
+//       refresh:true forces the daemon to re-fetch Google's revocation list (fresh, cache-busted)
+//       before re-checking — the inspector's pull-to-refresh sets it.
 //                                          keys:[{ algorithm, privateKeyPresent, chainLength, linkage,
 //                                                  rootAuthority, googleSigned, chainVerified, revoked,
 //                                                  revocationChecked,
@@ -192,7 +194,9 @@ export async function keyAdmin(action, args = {}) {
     case "logsWrite":
       return request("POST", "/logs/write" + logsWriteQuery(args), args.text);
     case "keyboxInspect":
-      return request("GET", "/keybox/inspect" + nameQuery(args));
+      // refresh:true has the daemon re-fetch Google's revocation list (fresh, cache-busted) before
+      // re-checking — the keybox inspector's pull-to-refresh sets it.
+      return request("GET", "/keybox/inspect" + nameQuery(args) + (args.refresh ? "&refresh=1" : ""));
     case "canary":
       return request("GET", "/canary");
     case "canaryInstall":

--- a/module/webroot/js/ui/keybox-view.js
+++ b/module/webroot/js/ui/keybox-view.js
@@ -137,16 +137,60 @@ function keyBlock(k) {
       : el("span", { class: "chip warn", text: "no private key" }),
   ]);
   const certs = Array.isArray(k.certs) ? k.certs : [];
-  return el("div", { class: "card kbi-key" }, [head, ...certs.map(certBlock)]);
+  return el("div", { class: "card kbi-key" }, [verdictBanner(k), head, ...certs.map(certBlock)]);
+}
+
+// The headline verdict for a chain: is this a genuine, live keybox that would pass hardware
+// attestation, or a revoked / software / broken one? Built from the daemon's chain-level fields.
+function verdictOf(k) {
+  const unchecked = k.revocationChecked === false;
+  if (k.revoked) {
+    return { tier: "bad", icon: "✕", title: "Revoked by Google",
+      sub: "A certificate in this chain is on Google's revocation list — attestations it signs are rejected by Play Integrity." };
+  }
+  if (k.chainVerified === false) {
+    return { tier: "bad", icon: "✕", title: "Chain does not verify",
+      sub: "A certificate signature in this chain is invalid, so it is not a usable attestation chain." };
+  }
+  const revNote = unchecked ? " · revocation list unavailable" : " · not revoked";
+  switch (k.rootAuthority) {
+    case "google":
+      return { tier: "good", icon: "✓", title: "Signed by Google",
+        sub: "Roots in the Google Hardware Attestation key" + revNote + "." };
+    case "knox":
+      return { tier: "good", icon: "✓", title: "Samsung Knox root",
+        sub: "Roots in a Samsung Knox attestation key" + revNote + "." };
+    case "aosp":
+      return { tier: "warn", icon: "!", title: "AOSP software root",
+        sub: "Rooted in the AOSP software test key — not a hardware-backed keybox; fails hardware attestation." };
+    default:
+      return { tier: "warn", icon: "?", title: "Unknown root",
+        sub: "Chain does not root in a recognized attestation authority" + (unchecked ? " · revocation list unavailable" : "") + "." };
+  }
+}
+
+function verdictBanner(k) {
+  const v = verdictOf(k);
+  return el("div", { class: "kbi-verdict kbi-verdict--" + v.tier }, [
+    el("span", { class: "kbi-verdict-icon", "aria-hidden": "true", text: v.icon }),
+    el("div", { class: "kbi-verdict-text" }, [
+      el("div", { class: "kbi-verdict-title", text: v.title }),
+      el("div", { class: "kbi-verdict-sub", text: v.sub }),
+    ]),
+  ]);
 }
 
 function certBlock(c) {
   if (c.error) {
     return el("div", { class: "kbi-cert" }, [el("div", { class: "err", text: "cert " + c.index + ": " + c.error })]);
   }
+  const authTier = c.rootAuthority === "google" || c.rootAuthority === "knox" ? "good" : "warn";
   const badges = el("div", { class: "chips" }, [
     el("span", { class: "chip", text: roleOf(c) }),
     el("span", { class: "chip mono", text: (c.keyAlgorithm || "?") + (c.keySize ? " " + c.keySize : "") }),
+    c.rootAuthority ? el("span", { class: "chip " + authTier, text: authorityLabel(c.rootAuthority) }) : null,
+    c.revoked ? el("span", { class: "chip danger", text: "revoked" }) : null,
+    c.signatureValid === false ? el("span", { class: "chip warn", text: "bad signature" }) : null,
     c.expired ? el("span", { class: "chip warn", text: "expired" }) : null,
     c.notYetValid ? el("span", { class: "chip warn", text: "not yet valid" }) : null,
   ]);
@@ -155,9 +199,20 @@ function certBlock(c) {
     kv("subject", c.subject),
     kv("issuer", c.issuer),
     kv("serial", c.serial),
+    c.revoked ? kv("revocation", (c.revocationStatus || "REVOKED") + (c.revocationReason ? " · " + c.revocationReason : "")) : null,
     kv("valid", fmtDate(c.notBefore) + "  →  " + fmtDate(c.notAfter)),
     kv("sigAlg", c.sigAlg),
   ]);
+}
+
+function authorityLabel(a) {
+  switch (a) {
+    case "google": return "Google root";
+    case "aosp": return "AOSP root";
+    case "knox": return "Knox root";
+    case "none": return "no root";
+    default: return "unknown root";
+  }
 }
 
 function roleOf(c) {

--- a/module/webroot/js/ui/keybox-view.js
+++ b/module/webroot/js/ui/keybox-view.js
@@ -92,23 +92,28 @@ export function renderKeyboxImport(state, actions) {
 }
 
 // ---- inspect drill-in ---------------------------------------------------
-export function renderKeyboxInspect(state, actions) {
+// The body is filled by fillKeyboxInspect so the controller can refill the SAME .drill-body element
+// on pull-to-refresh — keeping the scroll container (and its pull-to-refresh binding) in place.
+export function fillKeyboxInspect(body, state) {
   const { name = "", data = null } = state;
-
-  const body = el("div", { class: "drill-body" }, [
-    el("div", { class: "keyalias" }, [el("span", { class: "mono", text: name })]),
-  ]);
+  clear(body);
+  body.appendChild(el("div", { class: "keyalias" }, [el("span", { class: "mono", text: name })]));
 
   if (!data || data.ok === false) {
     body.appendChild(el("div", { class: "banner error" }, [
       el("div", { text: (data && data.error) || "Could not inspect this keybox." }),
     ]));
-  } else {
-    if (data.deviceId) body.appendChild(el("div", { class: "muted small", text: "DeviceID: " + data.deviceId }));
-    const keys = Array.isArray(data.keys) ? data.keys : [];
-    if (!keys.length) body.appendChild(el("p", { class: "muted", text: "No <Key> blocks found in this keybox." }));
-    for (const k of keys) body.appendChild(keyBlock(k));
+    return;
   }
+  if (data.deviceId) body.appendChild(el("div", { class: "muted small", text: "DeviceID: " + data.deviceId }));
+  const keys = Array.isArray(data.keys) ? data.keys : [];
+  if (!keys.length) body.appendChild(el("p", { class: "muted", text: "No <Key> blocks found in this keybox." }));
+  for (const k of keys) body.appendChild(keyBlock(k));
+}
+
+export function renderKeyboxInspect(state, actions) {
+  const body = el("div", { class: "drill-body" });
+  fillKeyboxInspect(body, state);
 
   return el("div", {}, [
     el("div", { class: "drill-head" }, [

--- a/module/webroot/js/ui/pull-refresh.js
+++ b/module/webroot/js/ui/pull-refresh.js
@@ -1,22 +1,29 @@
-// Pull-to-refresh for a document-scrolled screen: drag down from the very top past a threshold to
-// run onRefresh(). Vanilla touch events, no library. It only claims the gesture while genuinely
-// pulling from scrollTop 0, so ordinary scrolling is untouched; the host also sets
+// Pull-to-refresh for a scrolled surface: drag down from the very top past a threshold to run
+// onRefresh(). Vanilla touch events, no library. It only claims the gesture while genuinely pulling
+// from scrollTop 0, so ordinary scrolling is untouched; the host also sets
 // `overscroll-behavior-y: contain` so the browser's own pull-to-refresh never competes.
 //
+// By default it watches the document scroller (the resting screens are document-scrolled). Pass
+// opts.scroller to bind an inner overflow container instead (e.g. the keybox inspector's .drill-body,
+// which scrolls inside a fixed overlay). opts.zIndex lifts the spinner above that overlay.
+//
 // The spinner is a fixed element (added once), so a screen re-render — which replaces the mount's
-// children — never removes it. Listeners live on the persistent <section> mount, which stays put.
+// children — never removes it. attachPullToRefresh returns a detach() that removes the spinner and
+// listeners; call it when the surface goes away (an overlay close) so the fixed dot doesn't leak.
 
 const THRESHOLD = 64; // px of pull (after resistance) that commits a refresh
 const MAX = 92; // clamp the pull travel
 const RESIST = 0.5; // the drag feels heavier than 1:1
 
-export function attachPullToRefresh(screen, onRefresh) {
+export function attachPullToRefresh(screen, onRefresh, opts = {}) {
   const dot = document.createElement("div");
   dot.className = "ptr";
   dot.appendChild(document.createElement("div")).className = "ptr-spin";
+  if (opts.zIndex) dot.style.zIndex = String(opts.zIndex);
   document.body.appendChild(dot);
 
-  const scroller = () => document.scrollingElement || document.documentElement;
+  const scrollTop = () =>
+    opts.scroller ? opts.scroller.scrollTop : (document.scrollingElement || document.documentElement).scrollTop;
   const place = (d, op) => {
     dot.style.transform = `translateX(-50%) translateY(${d}px)`;
     dot.style.opacity = String(op);
@@ -35,37 +42,29 @@ export function attachPullToRefresh(screen, onRefresh) {
     place(0, 0);
   };
 
-  screen.addEventListener(
-    "touchstart",
-    (e) => {
-      pulling = false;
-      if (busy || e.touches.length !== 1 || scroller().scrollTop > 0) return;
-      startY = e.touches[0].clientY;
-      pulling = true;
-      dist = 0;
-      dot.style.transition = "none"; // follow the finger without lag
-    },
-    { passive: true },
-  );
+  const onStart = (e) => {
+    pulling = false;
+    if (busy || e.touches.length !== 1 || scrollTop() > 0) return;
+    startY = e.touches[0].clientY;
+    pulling = true;
+    dist = 0;
+    dot.style.transition = "none"; // follow the finger without lag
+  };
 
-  screen.addEventListener(
-    "touchmove",
-    (e) => {
-      if (!pulling) return;
-      const dy = e.touches[0].clientY - startY;
-      if (dy <= 0 || scroller().scrollTop > 0) {
-        relax();
-        return;
-      }
-      e.preventDefault(); // we own this drag now — suppress native scroll/refresh
-      dist = Math.min(dy * RESIST, MAX);
-      place(dist, Math.min(dist / THRESHOLD, 1));
-      dot.classList.toggle("ready", dist >= THRESHOLD);
-    },
-    { passive: false },
-  );
+  const onMove = (e) => {
+    if (!pulling) return;
+    const dy = e.touches[0].clientY - startY;
+    if (dy <= 0 || scrollTop() > 0) {
+      relax();
+      return;
+    }
+    e.preventDefault(); // we own this drag now — suppress native scroll/refresh
+    dist = Math.min(dy * RESIST, MAX);
+    place(dist, Math.min(dist / THRESHOLD, 1));
+    dot.classList.toggle("ready", dist >= THRESHOLD);
+  };
 
-  const end = () => {
+  const onEnd = () => {
     if (!pulling) return;
     pulling = false;
     dot.style.transition = "";
@@ -87,6 +86,16 @@ export function attachPullToRefresh(screen, onRefresh) {
       });
   };
 
-  screen.addEventListener("touchend", end, { passive: true });
+  screen.addEventListener("touchstart", onStart, { passive: true });
+  screen.addEventListener("touchmove", onMove, { passive: false });
+  screen.addEventListener("touchend", onEnd, { passive: true });
   screen.addEventListener("touchcancel", relax, { passive: true });
+
+  return () => {
+    screen.removeEventListener("touchstart", onStart);
+    screen.removeEventListener("touchmove", onMove);
+    screen.removeEventListener("touchend", onEnd);
+    screen.removeEventListener("touchcancel", relax);
+    dot.remove();
+  };
 }


### PR DESCRIPTION
The inspector reported a chain's shape — subject/issuer, validity, DN linkage — but not whether the keybox is usable, so a genuine live keybox, a revoked one, and an AOSP software keybox all looked alike. Those are the properties that decide whether attestations pass [Android key attestation](https://developer.android.com/privacy-and-security/security-key-attestation) / Play Integrity.

This adds a per-`<Key>` verdict. `RootPublicKey` pins the [Google attestation roots](https://android.googleapis.com/attestation/root) (RSA-4096 and the 2026 EC P-384 RKP root) plus AOSP and Knox anchors and classifies where a chain terminates. `RevocationList` fetches and caches Google's [revocation status list](https://android.googleapis.com/attestation/status), serving it offline. `KeyboxInspector` now verifies each cert's signature against its parent, looks up every serial, and reports `googleSigned`, `rootAuthority`, `chainVerified`, and `revoked`. The detail page shows a status banner and flags the revoked cert with its reason. The pinned keys mirror the [vvb2060/KeyAttestation](https://github.com/vvb2060/KeyAttestation) reference, with the 2026 EC root added.

Roots cross-checked against `attestation/root` by SPKI hash; builds clean. On-device verification still to run.
