### PR TITLE
keymint, harvester: fix generation on rkp_only / broken-TEE devices

### DIFF
--- a/app/src/main/java/org/matrix/teesim/Harvester.kt
+++ b/app/src/main/java/org/matrix/teesim/Harvester.kt
@@ -949,7 +949,7 @@ object Harvester {
     // --- fallback (no working TEE) ---------------------------------------------
 
     private fun fallback(): Record {
-        SystemLogger.warning("Harvest failed; using fixed non-zero boot key + Build.VERSION props")
+        SystemLogger.warning("Harvest failed; using vbmeta props (or stable fallback) + Build.VERSION props")
         val osVersion = DeviceProps.deviceOsVersion()
         val osPatchLevel = DeviceProps.toYyyymm(DeviceProps.systemSecurityPatch())
         val vendorPatchLevel = DeviceProps.toYyyymmdd(DeviceProps.vendorSecurityPatch())
@@ -957,7 +957,15 @@ object Harvester {
         // Harvest failed: nothing was captured, so every field is raw-empty (all-zero boot bytes, null
         // moduleHash) and every attestation-critical value we present lives in `overrides`. The WebUI
         // hides the Captured group entirely when harvestFailed, so only these synthesized values show.
+        //
+        // Boot key/hash must still match the live ro.boot.vbmeta.* props when those hold a real
+        // digest — Duck (and similar) compare attested verifiedBootHash to ro.boot.vbmeta.digest as
+        // hard evidence. Prefer the props the same way a successful harvest's defaultBootOverride
+        // does; only then fall back to the stable synthetic digests.
         val zero = ByteArray(32)
+        val bootKeyHex =
+            defaultBootOverride("ro.boot.vbmeta.public_key_digest", ::fallbackBootKey, zero)!!
+        val bootHashHex = defaultBootOverride("ro.boot.vbmeta.digest", ::fallbackBootHash, zero)!!
         return Record(
             harvestFailed = true,
             verifiedBootKey = zero,
@@ -984,14 +992,13 @@ object Harvester {
             imei = "",
             meid = "",
             imei2 = "",
-            // No working TEE: every attestation-critical value is synthesized (machine form values).
             overrides =
                 typedOverrides(
                     mapOf(
                         "deviceLocked" to "true",
                         "verifiedBootState" to "0",
-                        "verifiedBootKey" to fallbackBootKey().toHex(),
-                        "verifiedBootHash" to fallbackBootHash().toHex(),
+                        "verifiedBootKey" to bootKeyHex,
+                        "verifiedBootHash" to bootHashHex,
                         "osVersion" to osVersion.toString(),
                         "osPatchLevel" to osPatchLevel.toString(),
                         "vendorPatchLevel" to vendorPatchLevel.toString(),

--- a/keymint/README.md
+++ b/keymint/README.md
@@ -163,8 +163,11 @@ it is also ours — as does StrongBox:
   transact for a target uid, so on a hybrid device keystore2 falls back to *no* attest key and
   appends nothing, leaving the TA's keybox-rooted chain intact. It is scoped to target uids
   (`teesim_is_target_uid`, and the resolution runs on the app's binder thread so `getCallingUid`
-  is the app's) and gated on `remote_provisioning.tee.rkp_only`, which is only *read*, never
-  written — a global property change would be an obvious detection point.
+  is the app's). On an *rkp_only* device a real RKP miss is fatal (`OUT_OF_KEYS`) and attested
+  generateKey never reaches KeyMint — so inside keystore2 only we PLT-mask
+  `remote_provisioning.*.rkp_only` as unset (never a global resetprop) and keystore2 takes the
+  hybrid fallback into our TA. The properties are only *read* elsewhere; writing them globally
+  would be an obvious detection point.
 - **A foreign attest key on a leaf** — one an app made before we covered it — is forwarded to the
   real HAL (its leaf keeps the real root of trust). The durable fix is that attest keys are now
   ours, so once regenerated the app takes the "ours" path; the startup purge deletes any
@@ -209,7 +212,8 @@ not the forwarding guard.
 ## Files
 
 - [`keymint_hook.cpp`](keymint_hook.cpp) — the `AIBinder_transact` hook, the KeyMint redirect, the
-  remote-provisioning denial for target apps (`IsRkpProvisioning` / `RkpOnlyTee`), and
+  remote-provisioning denial for target apps (`IsRkpProvisioning`), the in-process `rkp_only`
+  property mask (`__system_property_get` / `__system_property_find`), and
   `teesim_hook_install`,
   which uses LSPlt to patch the caller's PLT slot for the symbol. It scans `/proc/self/maps`
   and probes only the main executable first — the binder client that issues the KeyMint call

--- a/keymint/keymint_hook.cpp
+++ b/keymint/keymint_hook.cpp
@@ -119,19 +119,30 @@ bool IsRkpProvisioning(AIBinder* binder) {
   return desc && std::strcmp(desc, "android.security.rkp.IRemoteProvisioning") == 0;
 }
 
-// Whether TEE is RKP-only. We must NEVER write this property (a global change is an obvious detection
-// point) — we only read it, once, to gate the denial: on an rkp-only device, denying RKP would fail
-// key generation outright, so there we let it through. Default (unset) is hybrid == safe to deny.
-bool RkpOnlyTee() {
-  static const bool value = [] {
-    char buf[PROP_VALUE_MAX] = {0};
-    int n = __system_property_get("remote_provisioning.tee.rkp_only", buf);
-    bool only = n > 0 && (std::strcmp(buf, "true") == 0 || std::strcmp(buf, "1") == 0);
-    LOGI("RKP: remote_provisioning.tee.rkp_only=%s; target-app RKP denial %s", n > 0 ? buf : "<unset>",
-         only ? "DISABLED (rkp-only device; would break generation)" : "enabled");
-    return only;
-  }();
-  return value;
+bool IsRkpOnlyProp(const char* name) {
+  return name && (std::strcmp(name, "remote_provisioning.tee.rkp_only") == 0 ||
+                  std::strcmp(name, "remote_provisioning.strongbox.rkp_only") == 0);
+}
+
+// keystore2 treats remote_provisioning.*.rkp_only=true as "RKP failure is fatal" — so on a
+// broken-TEE / OUT_OF_KEYS unit the attested generateKey never reaches KeyMint (Duck: "Failed to
+// generate key pair", chain length 0). We must NEVER resetprop those globally (detection). Instead
+// PLT-hook the libc property readers inside this process only and report them unset, so keystore2
+// uses hybrid fallback (RKP miss -> Ok(None) -> our KeyMint path). Installed before any RKP read.
+int (*real_system_property_get)(const char*, char*) = nullptr;
+const prop_info* (*real_system_property_find)(const char*) = nullptr;
+
+int HookedSystemPropertyGet(const char* name, char* value) {
+  if (IsRkpOnlyProp(name)) {
+    if (value) value[0] = '\0';
+    return 0;
+  }
+  return real_system_property_get ? real_system_property_get(name, value) : 0;
+}
+
+const prop_info* HookedSystemPropertyFind(const char* name) {
+  if (IsRkpOnlyProp(name)) return nullptr;
+  return real_system_property_find ? real_system_property_find(name) : nullptr;
 }
 
 // Return (creating if needed) the local device that wraps `proxy`.
@@ -178,7 +189,9 @@ binder_status_t HookedTransact(AIBinder* binder, transaction_code_t code, AParce
     // Deny a target app's remote-provisioning lookup so keystore2 attaches no real attest key. The
     // RKP resolution runs on this same binder thread (a current-thread tokio runtime block_on),
     // while keystore2 is still serving the app's generateKey, so getCallingUid is the app's uid.
-    if (IsRkpProvisioning(binder) && !RkpOnlyTee()) {
+    // Safe on rkp_only hardware too: HookedSystemProperty* makes keystore2 treat the device as
+    // hybrid, so this failure becomes Ok(None) rather than OUT_OF_KEYS.
+    if (IsRkpProvisioning(binder)) {
       int32_t uid = static_cast<int32_t>(AIBinder_getCallingUid());
       if (teesim_is_target_uid(uid)) {
         LOGI("RKP: denying IRemoteProvisioning transact code=%u for target uid=%d "
@@ -218,22 +231,37 @@ extern "C" bool teesim_hook_install() {
 
   const auto maps = lsplt::MapInfo::Scan();
 
-  // Register the AIBinder_transact hook across a chosen set of modules and commit. `exe_only`
-  // limits it to the main executable; otherwise every ELF module (main exe + .so) is probed.
-  auto register_and_commit = [&](bool exe_only) {
+  // Register hooks across a chosen set of modules and commit. `exe_only` limits it to the main
+  // executable; otherwise every ELF module (main exe + .so) is probed.
+  auto register_and_commit = [&](bool exe_only, const char* sym, void* hook, void** backup) {
     std::set<std::pair<dev_t, ino_t>> seen;
     for (const auto& m : maps) {
       if (m.path.empty() || m.inode == 0) continue;
       if (exe_only ? (m.path != exe) : !IsHookableElf(m.path, exe)) continue;
       if (!seen.insert({m.dev, m.inode}).second) continue;
-      lsplt::RegisterHook(m.dev, m.inode, "AIBinder_transact",
-                          reinterpret_cast<void*>(HookedTransact),
-                          reinterpret_cast<void**>(&real_transact));
+      lsplt::RegisterHook(m.dev, m.inode, sym, hook, backup);
     }
     // CommitHook returns false when a probed module doesn't import the symbol, which is
     // expected; success is that the caller's slot was patched (backup set).
     lsplt::CommitHook();
   };
+
+  // Mask rkp_only inside this process before keystore2 caches it (see HookedSystemProperty*).
+  // libc is the usual importer; also try the main executable. Failure is non-fatal: hybrid
+  // devices already work, and rkp_only+working-RKP still needs the binder denial below.
+  auto install_prop = [&](const char* sym, void* hook, void** backup) {
+    *backup = nullptr;
+    register_and_commit(/*exe_only=*/false, sym, hook, backup);
+    if (*backup) {
+      LOGI("hook: %s patched (rkp_only masked in-process)", sym);
+      return;
+    }
+    LOGI("hook: %s not found (rkp_only mask skipped)", sym);
+  };
+  install_prop("__system_property_get", reinterpret_cast<void*>(HookedSystemPropertyGet),
+               reinterpret_cast<void**>(&real_system_property_get));
+  install_prop("__system_property_find", reinterpret_cast<void*>(HookedSystemPropertyFind),
+               reinterpret_cast<void**>(&real_system_property_find));
 
   // The transaction we intercept — keystore2 forwarding to the real KeyMint — is issued from
   // the main executable, which is where AIBinder_transact is imported (keystore2's binder client
@@ -241,13 +269,16 @@ extern "C" bool teesim_hook_install() {
   // (and having LSPlt warn about) every unrelated .so. Only if the importer isn't the executable
   // on some build do we widen to a full ELF scan, so coverage is never lost.
   if (!exe.empty()) {
-    register_and_commit(/*exe_only=*/true);
+    register_and_commit(/*exe_only=*/true, "AIBinder_transact",
+                        reinterpret_cast<void*>(HookedTransact),
+                        reinterpret_cast<void**>(&real_transact));
     if (real_transact != nullptr) {
       LOGI("hook: AIBinder_transact patched in the main executable (%s)", exe.c_str());
       return true;
     }
   }
-  register_and_commit(/*exe_only=*/false);
+  register_and_commit(/*exe_only=*/false, "AIBinder_transact", reinterpret_cast<void*>(HookedTransact),
+                      reinterpret_cast<void**>(&real_transact));
   LOGI("hook: AIBinder_transact %s after full ELF scan",
        real_transact != nullptr ? "patched" : "not found (no importer)");
   return real_transact != nullptr;

--- a/rust/teesim-km/src/lib.rs
+++ b/rust/teesim-km/src/lib.rs
@@ -195,8 +195,12 @@ impl Ta {
             keys: Box::new(device::Keys),
             sign_info: Some(Box::new(sign_info.clone())),
             attest_ids,
-            // Rollback-resistant keys are declined (no secure-deletion store).
-            sdd_mgr: None,
+            // In-memory secure-deletion slots so UsageCountLimit(1) / RollbackResistance are
+            // KeyMint-enforced. Without this, UsageCountLimit is left to keystore2 (often a no-op
+            // for our blobs) and Duck's single-use EC probe sees a second use succeed. Slots are
+            // lost on process restart — fine for an in-process TA; single-use keys are deleted on
+            // first finish anyway.
+            sdd_mgr: Some(Box::new(kmr_common::keyblob::sdd_mem::InMemorySlotManager::<256>::default())),
             bootloader: Box::new(BootloaderDone),
             sk_wrapper: None,
             tup: Box::new(TrustedPresenceUnsupported),

--- a/rust/teesim-km/src/lib.rs
+++ b/rust/teesim-km/src/lib.rs
@@ -195,12 +195,8 @@ impl Ta {
             keys: Box::new(device::Keys),
             sign_info: Some(Box::new(sign_info.clone())),
             attest_ids,
-            // In-memory secure-deletion slots so UsageCountLimit(1) / RollbackResistance are
-            // KeyMint-enforced. Without this, UsageCountLimit is left to keystore2 (often a no-op
-            // for our blobs) and Duck's single-use EC probe sees a second use succeed. Slots are
-            // lost on process restart — fine for an in-process TA; single-use keys are deleted on
-            // first finish anyway.
-            sdd_mgr: Some(Box::new(kmr_common::keyblob::sdd_mem::InMemorySlotManager::<256>::default())),
+            // Rollback-resistant keys are declined (no secure-deletion store).
+            sdd_mgr: None,
             bootloader: Box::new(BootloaderDone),
             sk_wrapper: None,
             tup: Box::new(TrustedPresenceUnsupported),


### PR DESCRIPTION
## Summary
- Mask `remote_provisioning.*.rkp_only` in-process (never global resetprop) so keystore2 takes hybrid RKP fallback and attested `generateKey` reaches our TA instead of dying with `OUT_OF_KEYS` / empty chains.
- Prefer live `ro.boot.vbmeta.*` digests in the harvest-failed path so attested `verifiedBootHash` matches what Duck (and similar) compare against.
- Enable in-memory secure-deletion slots so `UsageCountLimit(1)` is KeyMint-enforced (Duck single-use EC no longer succeeds on a second use).

## Single-use EC / SDD (withdrawn)
`a7ea286` (in-memory SDD slots) was reverted: it fixed Duck Single-use EC but regressed AES-GCM round-trip and lifecycle delete/regenerate. Left out of this PR until a teesim-safe fix exists; Single-use EC will fail on Duck again for now.