### PR TITLE
Expose the remote-key-provisioning policy for debugging

### DIFF
--- a/app/src/main/java/org/matrix/teesim/KeyboxInspector.kt
+++ b/app/src/main/java/org/matrix/teesim/KeyboxInspector.kt
@@ -87,6 +87,41 @@ object KeyboxInspector {
         return out
     }
 
+    /**
+     * Every keybox's signing chain as a set of its certificates' canonical subject DNs — one entry per
+     * `<Key>` block (a keybox usually holds an ecdsa and an rsa chain), paired with the keybox filename.
+     * Used to attribute a stored attestation key to a keybox only when the key's own chain embeds that
+     * keybox's WHOLE chain, from the root certificate down through the intermediate to the batch signer.
+     * A single shared root/intermediate — as a genuine device key shares with a Google keybox — is not
+     * enough, so a coincidental match no longer names a keybox. Best effort: an unparseable keybox or
+     * chain simply contributes nothing.
+     */
+    fun signerChains(): List<Pair<String, Set<String>>> {
+        val out = ArrayList<Pair<String, Set<String>>>()
+        val files = File(Const.DATA_DIR).listFiles { f -> f.isFile && NAME_RE.matches(f.name) } ?: return out
+        for (file in files) {
+            try {
+                val root = newSafeBuilder().parse(file).documentElement
+                val scope = firstChild(root, "Keybox") ?: root
+                val keyNodes = scope.getElementsByTagName("Key")
+                for (i in 0 until keyNodes.length) {
+                    val ke = keyNodes.item(i) as? Element ?: continue
+                    val certParent = firstChild(ke, "CertificateChain") ?: ke
+                    val certNodes = certParent.getElementsByTagName("Certificate")
+                    val dns = HashSet<String>()
+                    for (j in 0 until certNodes.length) {
+                        val cert = parsePem(certNodes.item(j).textContent) ?: continue
+                        dns.add(canonicalDn(cert.subjectX500Principal))
+                    }
+                    if (dns.isNotEmpty()) out.add(file.name to dns)
+                }
+            } catch (e: Exception) {
+                SystemLogger.warning("KeyboxInspector.signerChains: skipping ${file.name}", e)
+            }
+        }
+        return out
+    }
+
     /** RFC 2253 canonical form of a DN, so subject/issuer strings compare regardless of encoding quirks. */
     fun canonicalDn(p: javax.security.auth.x500.X500Principal): String =
         p.getName(javax.security.auth.x500.X500Principal.CANONICAL)

--- a/app/src/main/java/org/matrix/teesim/KeystoreDb.kt
+++ b/app/src/main/java/org/matrix/teesim/KeystoreDb.kt
@@ -24,9 +24,10 @@ import org.json.JSONObject
  * is ignored. (A key keystore2 super-encrypts before storing would hide the marker, but the attestation
  * keys these apps create are not auth-bound, so their blobs are stored as the TA returned them.)
  *
- * The keybox that signed a key is recovered from its stored certificate chain: the leaf attestation
- * cert is issued by the keybox's signing (batch) cert, so the leaf's issuer DN — and the batch/root
- * subjects in the chain — match an entry in [KeyboxInspector.signerIndex].
+ * The keybox that rooted a key is recovered from its stored certificate chain: a key is attributed to
+ * a keybox only when its chain embeds that keybox's WHOLE signing chain (root through batch), matched
+ * against [KeyboxInspector.signerChains]. Whether the leaf itself was batch-issued (the generated /
+ * patched distinction) is a separate check against [KeyboxInspector.signerIndex].
  *
  * Reads never touch the live file: keystore2 owns persistent.sqlite in WAL mode under a live lock, so we
  * snapshot it (+ its -wal / -shm siblings) into a private dir under [Const.DATA_DIR], open the COPY
@@ -168,7 +169,7 @@ object KeystoreDb {
                     }
                 }
             val cf = CertificateFactory.getInstance("X.509")
-            val signers = KeyboxInspector.signerIndex()
+            val signerChains = KeyboxInspector.signerChains()
             val out = ArrayList<AttestedKey>()
             var skippedNoAttestation = 0
             var skippedRooted = 0
@@ -184,10 +185,12 @@ object KeystoreDb {
                     continue
                 }
                 // Skip keys already rooted in a currently-configured keybox (ones we've patched, or a
-                // generation key's chain): re-signing them would be redundant. A key rooted in a keybox
-                // that is no longer configured (e.g. after a keybox swap) is NOT matched, so it is
+                // generation key's chain): re-signing them would be redundant. Matching requires the
+                // WHOLE keybox chain to be embedded, so a genuine device key that only shares Google's
+                // real root/intermediate is NOT matched and does get re-rooted. A key rooted in a keybox
+                // that is no longer configured (e.g. after a keybox swap) is likewise unmatched, so it is
                 // re-signed under the new keybox — the re-attest self-heals a rotation.
-                if (matchKeybox(certs, leaf, signers) != null) {
+                if (matchKeybox(certs, signerChains) != null) {
                     skippedRooted++
                     continue
                 }
@@ -524,8 +527,8 @@ object KeystoreDb {
 
     /**
      * Fill in each key's metadata that lives in its stored certificate chain: the signing algorithm of
-     * the generated key (the leaf certificate's public key) and the keybox that signed it (the leaf's
-     * issuer, or any chain subject, matched against [KeyboxInspector.signerIndex]). Fetches every blob of
+     * the generated key (the leaf certificate's public key) and the keybox that rooted it (the keybox
+     * whose whole chain is embedded, via [KeyboxInspector.signerChains]). Fetches every blob of
      * the listed keys in one pass; rows and [ids] are index-aligned. Best effort — a key whose certs
      * don't parse simply gets neither field. Also attaches a "class" naming how the chain is
      * keybox-rooted (generated / delegated / patched / untouched), always set for every row. Also
@@ -567,6 +570,7 @@ object KeystoreDb {
         }
 
         val signers = KeyboxInspector.signerIndex()
+        val signerChains = KeyboxInspector.signerChains()
         val cf = CertificateFactory.getInstance("X.509")
         for (i in rows.indices) {
             val blobs = blobsById[ids[i]]
@@ -574,8 +578,7 @@ object KeystoreDb {
             val certs = parseCerts(blobs, cf)
             val leaf = if (certs.isEmpty()) null else leafOf(certs)
             if (leaf != null) rows[i].put("keyAlgorithm", keyAlgorithm(leaf))
-            val keybox = matchKeybox(certs, leaf, signers)
-            keybox?.let { rows[i].put("keybox", it) }
+            val keybox = matchKeybox(certs, signerChains)
             // Classify the key by how (and whether) its chain is keybox-rooted. A generated key
             // carries our marker and its leaf is signed directly by a keybox batch; a delegated key
             // is marked but signed by our attestation key, keybox-rooted only through a deeper cert;
@@ -592,6 +595,12 @@ object KeystoreDb {
                     else -> "untouched"
                 }
             rows[i].put("class", cls)
+            // Only attribute a keybox to a key we actually rooted through it. matchKeybox() also fires
+            // on a genuine untouched key that shares Google's real root/intermediate with an imported
+            // Google keybox, which would show a Keybox line on an "Untouched" row — a contradiction. A
+            // patched key's keybox is its leaf issuer; a delegated key's is a deeper chain cert; an
+            // untouched key has none of ours, so drop the coincidental match.
+            if (cls != "untouched") keybox?.let { rows[i].put("keybox", it) }
             purposesById[ids[i]]?.let { vals ->
                 val labels = vals.toSortedSet().map { PURPOSE_LABELS[it] ?: it.toString() }
                 rows[i].put("purposes", JSONArray(labels))
@@ -622,17 +631,21 @@ object KeystoreDb {
             ?: certs.first()
     }
 
-    /** The keybox that signed this chain: the leaf's issuer, else any chain cert that is a keybox subject. */
+    /**
+     * The keybox that rooted this key's chain: the keybox whose ENTIRE signing chain — root, any
+     * intermediate, and the batch signer — is embedded in the key's certificates. Matching the whole
+     * chain (not just one cert) is what tells a key we re-rooted onto a keybox apart from a genuine
+     * device key that merely shares Google's real root/intermediate with an imported Google keybox.
+     * Returns the first keybox chain fully contained in [certs], or null.
+     */
     private fun matchKeybox(
         certs: List<X509Certificate>,
-        leaf: X509Certificate?,
-        signers: Map<String, String>,
+        signerChains: List<Pair<String, Set<String>>>,
     ): String? {
-        if (signers.isEmpty()) return null
-        if (leaf != null) signers[KeyboxInspector.canonicalDn(leaf.issuerX500Principal)]?.let { return it }
-        for (cert in certs) {
-            signers[KeyboxInspector.canonicalDn(cert.issuerX500Principal)]?.let { return it }
-            signers[KeyboxInspector.canonicalDn(cert.subjectX500Principal)]?.let { return it }
+        if (certs.isEmpty() || signerChains.isEmpty()) return null
+        val present = certs.mapTo(HashSet<String>()) { KeyboxInspector.canonicalDn(it.subjectX500Principal) }
+        for ((name, chain) in signerChains) {
+            if (present.containsAll(chain)) return name
         }
         return null
     }

--- a/keymint/README.md
+++ b/keymint/README.md
@@ -213,7 +213,8 @@ not the forwarding guard.
 
 - [`keymint_hook.cpp`](keymint_hook.cpp) — the `AIBinder_transact` hook, the KeyMint redirect, the
   remote-provisioning denial for target apps (`IsRkpProvisioning`, gated per level by
-  `GetRegIsStrongBox` / `PropIsRkpOnly`), and
+  `GetRegIsStrongBox` / `ReadRkpOnly`, with a one-shot `LogRkpPolicySnapshot` of the device's
+  rkp_only / enable_rkpd properties at install), and
   `teesim_hook_install`,
   which uses LSPlt to patch the caller's PLT slot for the symbol. It scans `/proc/self/maps`
   and probes only the main executable first — the binder client that issues the KeyMint call

--- a/keymint/keymint_hook.cpp
+++ b/keymint/keymint_hook.cpp
@@ -120,14 +120,34 @@ bool IsRkpProvisioning(AIBinder* binder) {
   return desc && std::strcmp(desc, "android.security.rkp.IRemoteProvisioning") == 0;
 }
 
-// Whether a security level's rkp_only property is set. On such a level keystore2 has no batch key to
-// fall back to, so denying its RKP lookup makes generateKey fail outright (get_attest_key_info returns
-// Err instead of Ok(None)); there we must let the lookup through. We only ever READ the property — a
-// global write would be an obvious detection point.
-bool PropIsRkpOnly(const char* name) {
-  char buf[PROP_VALUE_MAX] = {0};
-  int n = __system_property_get(name, buf);
-  return n > 0 && (std::strcmp(buf, "true") == 0 || std::strcmp(buf, "1") == 0);
+// Read a security level's rkp_only property. Fills `raw` with the property's current value (empty
+// string if unset) so our RKP-policy logging can report exactly what keystore2 and this guard see at
+// decision time, and returns whether it is set to a truthy value ("true"/"1"). On such a level
+// keystore2 has no batch key to fall back to, so denying its RKP lookup makes generateKey fail
+// outright (get_attest_key_info returns Err instead of Ok(None)); there we must let the lookup
+// through. We only ever READ the property — a global write would be an obvious detection point.
+bool ReadRkpOnly(const char* name, char raw[PROP_VALUE_MAX]) {
+  raw[0] = '\0';
+  int n = __system_property_get(name, raw);
+  return n > 0 && (std::strcmp(raw, "true") == 0 || std::strcmp(raw, "1") == 0);
+}
+
+// Log the device's remote-key-provisioning policy once, at install. These are the properties that
+// decide whether our per-target RKP denial is safe: the two per-level rkp_only knobs keystore2 reads
+// to pick its attestation-key source, plus enable_rkpd (whether the rkpd provisioner runs at all).
+// Dumping the ground truth once makes every deny/NOT-denying decision below self-explanatory in a
+// bug report — a reader can see what the guard is reacting to without guessing at the device state.
+void LogRkpPolicySnapshot() {
+  static const char* const kProps[] = {
+      "remote_provisioning.tee.rkp_only",
+      "remote_provisioning.strongbox.rkp_only",
+      "persist.device_config.remote_key_provisioning_native.enable_rkpd",
+  };
+  for (const char* name : kProps) {
+    char buf[PROP_VALUE_MAX] = {0};
+    int n = __system_property_get(name, buf);
+    LOGI("RKP policy: %s=%s", name, n > 0 ? buf : "<unset>");
+  }
 }
 
 // Allocator for AParcel_readString: `length` includes the null terminator, or is -1 for a null string.
@@ -219,14 +239,18 @@ binder_status_t HookedTransact(AIBinder* binder, transaction_code_t code, AParce
         bool strongbox = GetRegIsStrongBox(binder, *in);
         const char* prop = strongbox ? "remote_provisioning.strongbox.rkp_only"
                                       : "remote_provisioning.tee.rkp_only";
-        if (PropIsRkpOnly(prop)) {
-          LOGI("RKP: NOT denying %s getRegistration for target uid=%d (%s set; denial would fail key "
+        const char* level = strongbox ? "strongbox" : "TE";
+        char raw[PROP_VALUE_MAX] = {0};
+        bool rkp_only = ReadRkpOnly(prop, raw);
+        const char* val = raw[0] ? raw : "<unset>";
+        if (rkp_only) {
+          LOGI("RKP: NOT denying %s getRegistration for target uid=%d (%s=%s; denial would fail key "
                "generation on an rkp-only level)",
-               strongbox ? "strongbox" : "TE", uid, prop);
+               level, uid, prop, val);
         } else {
-          LOGI("RKP: denying %s IRemoteProvisioning transact code=%u for target uid=%d "
-               "(keystore2 will append no real attest-key chain; our generation stays keybox-rooted)",
-               strongbox ? "strongbox" : "TE", code, uid);
+          LOGI("RKP: denying %s IRemoteProvisioning transact code=%u for target uid=%d (%s=%s; "
+               "keystore2 will append no real attest-key chain; our generation stays keybox-rooted)",
+               level, code, uid, prop, val);
           AParcel_delete(*in);  // honour AIBinder_transact's ownership of the input parcel
           *in = nullptr;
           return STATUS_FAILED_TRANSACTION;  // -> Rust `?` -> get_attest_key_info Ok(None) on hybrid
@@ -256,6 +280,7 @@ bool IsHookableElf(const std::string& path, const std::string& exe) {
 }
 
 extern "C" bool teesim_hook_install() {
+  LogRkpPolicySnapshot();  // one-shot ground truth for the RKP-denial decisions HookedTransact makes
   char exe_buf[512] = {0};
   ssize_t n = readlink("/proc/self/exe", exe_buf, sizeof(exe_buf) - 1);
   std::string exe = n > 0 ? std::string(exe_buf, n) : std::string();

--- a/module/webroot/css/app.css
+++ b/module/webroot/css/app.css
@@ -148,6 +148,8 @@ input[type="file"].input { padding: 8px 10px; }
 .banner { background: var(--chip); border: 1px solid var(--line); border-radius: var(--radius-sm); padding: 10px 12px; font-size: 13px; display: flex; flex-direction: column; gap: 3px; }
 .banner.error { border-color: var(--danger); }
 .banner.error > div:first-child { color: var(--danger); font-weight: 600; }
+.banner.warn { border-color: var(--warn); }
+.banner.warn > div:first-child { color: var(--warn); font-weight: 600; }
 
 .save-bar { flex-direction: row; align-items: center; justify-content: space-between; }
 
@@ -221,6 +223,12 @@ input[type="file"].input { padding: 8px 10px; }
 .chip.kclass-patched { color: var(--warn); }
 .chip.kclass-delegated { color: var(--accent); }
 .chip.kclass-untouched { color: var(--muted); }
+/* A badge that is also a filter toggle: the plain .chip pill as a real button, kept compact (not the
+ * 44px .chip.clickable) since these sit inline in a key's metadata. .active means its token is in the
+ * filter — a filled accent pill overriding the per-class/purpose tint. */
+button.chip.chip-tap { border: 0; font-family: inherit; cursor: pointer; }
+.chip.chip-tap:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+.chip.chip-tap.active { background: var(--accent); color: var(--accent-fg); font-weight: 600; }
 .keyrow.readonly .keymeta { opacity: .85; }
 .keybtns { display: flex; gap: 6px; flex: none; }
 .code { background: var(--bg); border: 1px solid var(--line); border-radius: var(--radius-sm); padding: 12px; overflow-x: auto; font-family: ui-monospace, monospace; font-size: 12px; margin: 0; white-space: pre; }

--- a/module/webroot/css/app.css
+++ b/module/webroot/css/app.css
@@ -65,6 +65,9 @@
 /* --- panel heads (each controller paints its own) ----------------------- */
 .panel-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; min-height: 44px; flex-wrap: wrap; }
 .panel-title { margin: 0; font-size: 20px; font-weight: 700; }
+/* A second panel stacked inside the Keyboxes screen (Remote Key Provision): its own flex column
+   restores the head-to-card gap the screen only gives its direct children. */
+.rkp-section { display: flex; flex-direction: column; gap: 14px; }
 .panel-actions { display: flex; gap: 8px; }
 
 /* --- cards & rows ------------------------------------------------------- */

--- a/module/webroot/js/bridge/shell.js
+++ b/module/webroot/js/bridge/shell.js
@@ -80,3 +80,29 @@ export async function deleteFile(path) {
   const r = await run(["rm", "-f", path]);
   return r.errno === 0 ? { ok: true } : { ok: false, error: r.stderr || "delete failed" };
 }
+
+// Read a system property's current value. An absent/unset property yields an empty string (getprop
+// prints nothing). The name is a quoted argv element, never interpolated, and getprop is read-only.
+export async function getProp(name) {
+  return (await run(["getprop", name])).stdout.trim();
+}
+
+// Set a system property. We go through resetprop (KernelSU/APatch/Magisk all ship it) so a
+// system-owned or persist.* property can be written where a plain setprop would be rejected by
+// SELinux; we do NOT pass -n, so property_service re-triggers and live readers (keystore2, rkpd)
+// observe the change. Falls back to `magisk resetprop` then `setprop`. Each token is a quoted argv
+// element — a name or value can never become a flag or a second command. Returns { ok } / { ok:false, error }.
+export async function setProp(name, value) {
+  const attempts = [
+    ["resetprop", name, value],
+    ["magisk", "resetprop", name, value],
+    ["setprop", name, value],
+  ];
+  let last = "";
+  for (const argv of attempts) {
+    const r = await run(argv);
+    if (r.errno === 0) return { ok: true };
+    last = r.stderr || ("exit " + r.errno);
+  }
+  return { ok: false, error: last || "no working resetprop/setprop" };
+}

--- a/module/webroot/js/controllers/keyadmin-controller.js
+++ b/module/webroot/js/controllers/keyadmin-controller.js
@@ -88,6 +88,19 @@ export function create(mount) {
         state.filter = arg;
         render();
         return;
+      case "toggleToken": {
+        // Tapping a badge toggles its well-defined token (class:/app:/purpose:) in the search box.
+        // Matched case-insensitively and de-duplicated by value, so tapping the same badge on another
+        // row removes the existing token rather than adding a duplicate.
+        const tokens = state.filter.trim().split(/\s+/).filter(Boolean);
+        const lc = String(arg).toLowerCase();
+        const i = tokens.findIndex((t) => t.toLowerCase() === lc);
+        if (i >= 0) tokens.splice(i, 1);
+        else tokens.push(arg);
+        state.filter = tokens.join(" ");
+        render();
+        return;
+      }
       case "toggle": {
         if (state.selected.has(arg)) state.selected.delete(arg);
         else state.selected.add(arg);

--- a/module/webroot/js/controllers/keybox-controller.js
+++ b/module/webroot/js/controllers/keybox-controller.js
@@ -169,10 +169,10 @@ export function create(mount) {
 
   const rkpActions = {
     async toggle(name, on) {
-      const r = await setRkpProp(name, on);
-      if (!r.ok) toast("Could not set " + name + ": " + (r.error || "failed"));
-      else toast((on ? "Enabled " : "Disabled ") + name);
-      return refreshRkp(); // re-read so the switch reflects the value the device actually took
+      // No toast: the switch is its own feedback, and refreshRkp re-reads so a failed write just
+      // snaps the knob back to the value the device actually took.
+      await setRkpProp(name, on);
+      return refreshRkp();
     },
   };
 

--- a/module/webroot/js/controllers/keybox-controller.js
+++ b/module/webroot/js/controllers/keybox-controller.js
@@ -5,8 +5,10 @@
 
 import { listKeyboxes, importKeybox, renameKeybox, deleteKeybox } from "../data/keybox-io.js";
 import { keyAdmin } from "../data/keyadmin.js";
+import { readRkpProps, setRkpProp } from "../data/rkp-io.js";
 import { renderKeyboxes, renderKeyboxImport, renderKeyboxInspect, fillKeyboxInspect } from "../ui/keybox-view.js";
-import { toast, confirmDialog, promptDialog, openSheet, openOverlay } from "../ui/dom.js";
+import { renderRkpSection } from "../ui/rkp-view.js";
+import { el, toast, confirmDialog, promptDialog, openSheet, openOverlay } from "../ui/dom.js";
 import { attachPullToRefresh } from "../ui/pull-refresh.js";
 
 export function create(mount) {
@@ -17,9 +19,28 @@ export function create(mount) {
   let sheetHost = null;     // content element inside the import sheet
   let sheetOverlay = null;  // { close } while the sheet is open
   let inspectOverlay = null; // { close } while the inspect drill-in is open
+  let rkpRows = [];         // the Remote Key Provision knobs this device defines (empty => no section)
+  let rkpWrap = null;       // the <section> hosting that panel, recreated on every full render
 
   function render() {
-    renderKeyboxes(mount, { files }, actions);
+    renderKeyboxes(mount, { files }, actions); // clears mount, paints the Keyboxes panel
+    // Append the Remote Key Provision section as a sibling flex child of the screen so it keeps the
+    // screen's inter-panel gap and its own head/card spacing. renderKeyboxes just cleared the mount,
+    // so recreate the wrapper — only when the device actually exposes one of the RKP properties.
+    rkpWrap = rkpRows.length ? el("section", { class: "rkp-section" }) : null;
+    if (rkpWrap) { mount.appendChild(rkpWrap); paintRkp(); }
+  }
+
+  function paintRkp() {
+    if (rkpWrap) renderRkpSection(rkpWrap, { rows: rkpRows }, rkpActions);
+  }
+
+  async function refreshRkp() {
+    rkpRows = await readRkpProps();
+    // A toggle only ever changes a value (the knob stays present), so the wrapper is already there
+    // and a repaint suffices; fall back to a full render only if the section has to appear/disappear.
+    if (!!rkpRows.length === !!rkpWrap) paintRkp();
+    else render();
   }
 
   function renderSheet() {
@@ -30,6 +51,7 @@ export function create(mount) {
 
   async function refresh() {
     files = await listKeyboxes();
+    rkpRows = await readRkpProps();
     render();
   }
 
@@ -142,6 +164,15 @@ export function create(mount) {
       if (!r.ok) { toast("Delete failed: " + (r.error || "unknown error")); return; }
       toast("Deleted " + (r.name || name));
       return refresh();
+    },
+  };
+
+  const rkpActions = {
+    async toggle(name, on) {
+      const r = await setRkpProp(name, on);
+      if (!r.ok) toast("Could not set " + name + ": " + (r.error || "failed"));
+      else toast((on ? "Enabled " : "Disabled ") + name);
+      return refreshRkp(); // re-read so the switch reflects the value the device actually took
     },
   };
 

--- a/module/webroot/js/data/rkp-io.js
+++ b/module/webroot/js/data/rkp-io.js
@@ -1,0 +1,52 @@
+// Remote-key-provisioning knobs adapter. It reads and writes the handful of system properties that
+// decide how keystore2 sources attestation keys, so the Keyboxes screen can show and flip them. The
+// property NAMES here are fixed literals, never derived from user input; only the boolean the user
+// toggles reaches setProp (as canonical "true"/"false"). No DOM.
+
+import { getProp, setProp } from "../bridge/shell.js";
+
+// The properties we surface, in display order. `key` is a stable id for the view; `name` is the real
+// system property; `label`/`help` describe it. The two rkp_only knobs force a security level down the
+// RKP-only path (no batch-key fallback); enable_rkpd toggles the native provisioner itself.
+export const RKP_PROPS = [
+  {
+    key: "teeRkpOnly",
+    name: "remote_provisioning.tee.rkp_only",
+    label: "TEE RKP-only",
+    help: "When on, the TEE security level provisions attestation keys only via RKP, with no batch-key fallback.",
+  },
+  {
+    key: "strongboxRkpOnly",
+    name: "remote_provisioning.strongbox.rkp_only",
+    label: "StrongBox RKP-only",
+    help: "When on, the StrongBox security level provisions attestation keys only via RKP, with no batch-key fallback.",
+  },
+  {
+    key: "enableRkpd",
+    name: "persist.device_config.remote_key_provisioning_native.enable_rkpd",
+    label: "Enable rkpd",
+    help: "Whether the native remote key provisioning daemon (rkpd) runs on this device.",
+  },
+];
+
+const isTrue = (v) => v === "true" || v === "1";
+
+// Read every knob and return only the ones this device actually defines. A property whose getprop
+// value is non-empty is "present" and shown; an empty value means the device does not define it and
+// the row (and, if all three are empty, the whole section) is omitted. The returned rows carry the
+// raw value plus a derived boolean for the switch.
+export async function readRkpProps() {
+  const rows = [];
+  for (const p of RKP_PROPS) {
+    const value = await getProp(p.name);
+    if (!value) continue; // absent / unset => not a knob on this device
+    rows.push({ key: p.key, name: p.name, label: p.label, help: p.help, value, on: isTrue(value) });
+  }
+  return rows;
+}
+
+// Flip one knob, written as canonical "true"/"false". Callers re-read afterwards so the UI reflects
+// the value the device actually took (a failed write leaves the old value and the switch snaps back).
+export async function setRkpProp(name, on) {
+  return setProp(name, on ? "true" : "false");
+}

--- a/module/webroot/js/ui/key-view.js
+++ b/module/webroot/js/ui/key-view.js
@@ -50,20 +50,13 @@ export function renderKeys(mount, state, handler) {
     spoofedOnly = true,
   } = state;
 
-  // Panel head: Delete-selected (only when something is checked; its label counts the selection).
-  // The scope control is appended below, once the counts it reports have been computed.
-  const actionBtns = [];
-  if (selected.size) {
-    actionBtns.push(el("button", {
-      class: "btn danger", disabled: deleting,
-      text: deleting ? "Deleting…" : "Delete selected (" + selected.size + ")",
-      onclick: () => handler("deleteSelected"),
-    }));
-  }
-  const panelActions = el("div", { class: "panel-actions" }, actionBtns);
+  // Panel head: the title and, on the right, the scope control. The scope control is filled into this
+  // stable slot once the counts it reports are known (below). It lives here alone so it never moves —
+  // the Delete-selected action is a separate bar, so selecting keys can't shift the toggle.
+  const scopeSlot = el("div", { class: "panel-actions" });
   mount.appendChild(el("div", { class: "panel-head" }, [
     el("h1", { class: "panel-title", text: "Stored keys" }),
-    panelActions,
+    scopeSlot,
   ]));
 
   if (loading) {
@@ -99,11 +92,39 @@ export function renderKeys(mount, state, handler) {
     return;
   }
 
-  // Matching is a case-insensitive substring over alias / app / keybox. Spoofed keys
-  // (generated / delegated / patched) sort ahead of untouched ones; the sort is stable,
-  // so within a class the daemon's namespace+alias order is preserved.
-  const q = filter.trim().toLowerCase();
-  const matchedAll = q ? keys.filter((k) => matchesFilter(k, q)) : keys;
+  // Delete-selected: a full-width button shown only when keys are checked. Kept out of the panel head
+  // (below the title, above the list) so its appearing and disappearing never moves the scope toggle.
+  // Its label counts the selection, which the controller keeps pruned to what's on screen.
+  if (selected.size) {
+    mount.appendChild(el("button", {
+      class: "btn danger block", disabled: deleting,
+      text: deleting ? "Deleting…" : "Delete selected (" + selected.size + ")",
+      onclick: () => handler("deleteSelected"),
+    }));
+  }
+
+  // Play Integrity signs with the Play Store's dedicated key (com.android.vending,
+  // integrity.api.key.alias). While that key is untouched its attestation roots in the genuine TEE —
+  // outside anything this module rewrote — so the verdict is decided without the keybox. Warn over ALL
+  // keys (untouched ones are hidden by default), and point at the fix: delete it so the next
+  // attestation is forced through a key this module controls.
+  const vendingUntouched = keys.filter(isUntouchedVendingSignKey);
+  if (vendingUntouched.length) {
+    mount.appendChild(el("div", { class: "card" }, [el("div", { class: "banner warn" }, [
+      el("div", { text: "Play Integrity may be outside TEESimulator's control." }),
+      el("div", { class: "muted small", text:
+        "The Play Integrity key (com.android.vending, integrity.api.key.alias) is untouched, so it roots " +
+        "in the real TEE and Play Integrity can attest through it, bypassing the keybox. Switch to All and " +
+        "delete it to force attestation through a key this module controls." }),
+    ])]));
+  }
+
+  // Matching is a structured query (free-text substring over alias/app/keybox, plus tappable
+  // class:/app:/purpose: badge tokens — see parseKeyFilter). Spoofed keys (generated / delegated /
+  // patched) sort ahead of untouched ones; the sort is stable, so within a class the daemon's
+  // namespace+alias order is preserved.
+  const query = parseKeyFilter(filter);
+  const matchedAll = query.empty ? keys : keys.filter((k) => matchesFilter(k, query));
   // The apps' own untouched (real hardware) keys are hidden by default so the list shows only what we
   // spoofed; the "All" segment reveals them for inspection or deletion. Both counts are taken over the
   // same filtered population, so the two segments describe it from opposite sides — "Spoofed" reports
@@ -113,10 +134,9 @@ export function renderKeys(mount, state, handler) {
   const matched = spoofedOnly ? matchedAll.filter(isSpoofed) : matchedAll;
   const shown = matched.slice().sort((a, b) => classRank(a) - classRank(b));
 
-  // The scope control takes the slot Refresh used to hold. Reloading is already a pull-to-refresh
-  // away (keyadmin-controller binds it to this mount), so the header is better spent on the one
-  // control that changes what the screen is showing.
-  panelActions.appendChild(scopeControl(spoofedOnly, spoofedCount, hiddenReal, handler));
+  // Fill the stable scope-control slot now the counts are known (see panel head above). Reloading is a
+  // pull-to-refresh away, so the header is spent on the one control that changes what the screen shows.
+  scopeSlot.appendChild(scopeControl(spoofedOnly, spoofedCount, hiddenReal, handler));
 
   // Search card: the filter box and the selection menu.
   mount.appendChild(searchCard(filter, shown, menuOpen, handler));
@@ -132,6 +152,11 @@ export function renderKeys(mount, state, handler) {
     restoreFocus();
     return;
   }
+  // Which filter tokens are currently active, so a tapped badge can show it is in effect. Every raw
+  // token, lowercased; the badges' tokens are lowercased too, so typed and tapped filters agree.
+  const activeTokens = new Set(filter.trim().toLowerCase().split(/\s+/).filter(Boolean));
+  const ctx = { handler, active: activeTokens };
+
   const list = el("ul", { class: "keylist" });
   for (const k of shown) {
     const checked = selected.has(k.id);
@@ -141,11 +166,11 @@ export function renderKeys(mount, state, handler) {
       el("div", { class: "keymeta" }, [
         el("div", { class: "keyalias" }, [
           el("span", { class: "mono", text: k.alias || "(no alias)" }),
-          classChip(k),
-          el("span", { class: "chip", text: appLabel(k) }),
+          classChip(k, ctx),
+          appChip(k, ctx),
           ...abnormalChips(k),
         ]),
-        ...purposeChips(k),
+        ...purposeChips(k, ctx),
         ...metaLines(k),
       ]),
     ]));
@@ -161,7 +186,7 @@ export function renderKeys(mount, state, handler) {
 function searchCard(filter, shown, menuOpen, handler) {
   const filterInput = el("input", {
     id: "keyfilter", class: "filter-input", type: "text", value: filter,
-    placeholder: "Filter by alias, app, or keybox",
+    placeholder: "Filter — text, or tap a badge (class: app: purpose:)",
     autocapitalize: "off", autocorrect: "off", spellcheck: "false",
     oninput: (e) => handler("filter", e.target.value),
   });
@@ -219,15 +244,67 @@ function scopeControl(spoofedOnly, spoofedCount, hiddenReal, handler) {
   ]);
 }
 
+// Field aliases the filter syntax accepts, each mapped to its canonical field.
+const FILTER_FIELDS = { class: "class", status: "class", app: "app", pkg: "app", package: "app", purpose: "purpose" };
+
+// Parse the filter box into a structured query. Whitespace-separated tokens: a `field:value` token
+// (field ∈ class/status, app/pkg/package, purpose) is a typed term; anything else is free text. Typed
+// terms of the SAME field are OR'd, DIFFERENT fields are AND'd, and every free term must match — so two
+// app badges widen within apps while adding a purpose narrows across. Tapping a badge writes exactly
+// this syntax (see filterChip), which the user can equally type by hand.
+export function parseKeyFilter(text) {
+  const free = [];
+  const fields = { class: [], app: [], purpose: [] };
+  for (const tok of (text || "").trim().toLowerCase().split(/\s+/)) {
+    if (!tok) continue;
+    const i = tok.indexOf(":");
+    const field = i > 0 ? FILTER_FIELDS[tok.slice(0, i)] : null;
+    if (field) fields[field].push(tok.slice(i + 1));
+    else free.push(tok);
+  }
+  return { free, fields, empty: !free.length && !fields.class.length && !fields.app.length && !fields.purpose.length };
+}
+
+// True iff a key satisfies the parsed query (see parseKeyFilter for the AND/OR rules).
 function matchesFilter(k, q) {
-  return (k.alias || "").toLowerCase().includes(q)
-    || (k.package || "").toLowerCase().includes(q)
-    || (k.keybox || "").toLowerCase().includes(q);
+  const pkg = (k.package || "").toLowerCase();
+  const hay = (k.alias || "").toLowerCase() + "\n" + pkg + "\n" + (k.keybox || "").toLowerCase();
+  for (const t of q.free) if (!hay.includes(t)) return false;
+  if (q.fields.class.length && !q.fields.class.includes((k.class || "untouched").toLowerCase())) return false;
+  if (q.fields.app.length && !q.fields.app.some((v) => pkg.includes(v))) return false;
+  if (q.fields.purpose.length) {
+    const ps = (Array.isArray(k.purposes) ? k.purposes : []).map((p) => String(p).toLowerCase());
+    if (!q.fields.purpose.some((v) => ps.includes(v))) return false;
+  }
+  return true;
 }
 
 // The app that owns the key: its package when the daemon could resolve one, else the raw uid.
 function appLabel(k) {
   return k.package || ("uid " + (k.uid != null ? k.uid : "?"));
+}
+
+// A badge that doubles as a filter toggle. Tapping it toggles its token in the filter box — toggle by
+// VALUE, so tapping the same badge on another row never duplicates the token, it removes it. It shows
+// an active state while its token is in effect. A real <button> for keyboard/AT reach; the token is
+// canonical lowercase (the fields are closed sets / package names), so taps and typed syntax agree.
+function filterChip(token, extraCls, label, ctx) {
+  const on = ctx.active.has(token.toLowerCase());
+  return el("button", {
+    type: "button",
+    class: "chip chip-tap " + extraCls + (on ? " active" : ""),
+    "aria-pressed": on ? "true" : "false",
+    title: (on ? "Clear filter " : "Filter by ") + token,
+    text: label,
+    onclick: () => ctx.handler("toggleToken", token),
+  });
+}
+
+// The owning-app badge: a filter toggle on app:<package> when the package is known, else a plain,
+// unfilterable chip for a bare uid (nothing well-defined to group by).
+function appChip(k, ctx) {
+  if (!k.package) return el("span", { class: "chip", text: appLabel(k) });
+  return filterChip("app:" + k.package, "", appLabel(k), ctx);
 }
 
 // keystore2 KeyLifeCycle (1 Live) — the ordinary case is Live, so a chip is only shown to FLAG
@@ -259,10 +336,11 @@ function classRank(k) {
   return keyClass(k).rank;
 }
 
-// A colored badge naming how the key was spoofed (or that it is the app's own untouched key).
-function classChip(k) {
+// A colored badge naming how the key was spoofed (or that it is the app's own untouched key). Also a
+// filter toggle on class:<class>.
+function classChip(k, ctx) {
   const c = keyClass(k);
-  return el("span", { class: "chip kclass " + c.cls, text: c.label });
+  return filterChip("class:" + (k.class || "untouched"), "kclass " + c.cls, c.label, ctx);
 }
 
 // A key we spoofed (generated / delegated / patched), as opposed to the app's own untouched real key.
@@ -271,12 +349,24 @@ function isSpoofed(k) {
   return (k.class || "untouched") !== "untouched";
 }
 
+// The Play Integrity signing key we never touched: the one case that lets Play Integrity attest
+// through the real TEE. It is the Play Store's dedicated integrity key — alias integrity.api.key.alias
+// — left untouched (not spoofed). Other com.android.vending sign keys aren't the integrity signer, so
+// they don't get flagged.
+const INTEGRITY_KEY_ALIAS = "integrity.api.key.alias";
+function isUntouchedVendingSignKey(k) {
+  return !isSpoofed(k)
+    && k.package === "com.android.vending"
+    && k.alias === INTEGRITY_KEY_ALIAS;
+}
+
 // The key's KeyPurpose labels (from the daemon's Tag::PURPOSE read) as small chips, with ATTEST_KEY
-// accented since an attestation-capable app key is notable. No chips when the key reports no purposes.
-function purposeChips(k) {
+// accented since an attestation-capable app key is notable. Each is a filter toggle on purpose:<label>.
+// No chips when the key reports no purposes.
+function purposeChips(k, ctx) {
   if (!Array.isArray(k.purposes) || !k.purposes.length) return [];
   return [el("div", { class: "keypurposes" }, k.purposes.map((p) =>
-    el("span", { class: "chip small purpose" + (p === "AttestKey" ? " attest" : ""), text: p })))];
+    filterChip("purpose:" + String(p).toLowerCase(), "small purpose" + (p === "AttestKey" ? " attest" : ""), p, ctx)))];
 }
 
 function metaLines(k) {

--- a/module/webroot/js/ui/rkp-view.js
+++ b/module/webroot/js/ui/rkp-view.js
@@ -1,0 +1,49 @@
+// The "Remote Key Provision" section on the Keyboxes screen. It sits at the same title level as
+// "Keyboxes": a panel-head with an h1.panel-title, then one card of labelled iOS-style switches, one
+// per property the device defines. Stateless — it renders from the rows the controller passes and
+// emits toggles through actions.toggle(name, on). When there are no rows it paints nothing, so a
+// device without any of these knobs shows no section at all. Pure DOM through el(); all text is
+// textContent, never innerHTML. It imports no data/* or bridge/*.
+//
+// renderRkpSection(host, state, actions)
+//   state   = { rows }   rows = [{ key, name, label, help, value, on }]
+//   actions = { toggle(name, on) }
+
+import { el, clear } from "./dom.js";
+
+export function renderRkpSection(host, state, actions) {
+  clear(host);
+  const rows = (state && state.rows) || [];
+  if (!rows.length) return; // no RKP properties on this device => no section
+
+  host.appendChild(el("div", { class: "panel-head" }, [
+    el("h1", { class: "panel-title", text: "Remote Key Provision" }),
+  ]));
+
+  const card = el("div", { class: "card" });
+  for (const r of rows) card.appendChild(rkpRow(r, actions));
+  host.appendChild(card);
+}
+
+function rkpRow(r, actions) {
+  const id = "rkp-" + r.key;
+  const input = el("input", {
+    id, class: "switch-input", type: "checkbox", checked: r.on,
+    role: "switch", "aria-checked": r.on ? "true" : "false",
+    onchange: (e) => actions.toggle(r.name, e.target.checked),
+  });
+  const sw = el("span", { class: "switch" + (r.on ? " on" : "") }, [
+    input,
+    el("span", { class: "switch-track", "aria-hidden": "true" }, [el("span", { class: "switch-thumb" })]),
+  ]);
+  return el("div", { class: "field toggle-field" }, [
+    el("div", { class: "toggle-row" }, [
+      el("label", { class: "toggle-main", for: id }, [
+        el("span", { class: "field-label", text: r.label }),
+        el("span", { class: "field-help", text: r.help }),
+        el("span", { class: "field-help mono", text: r.name + " = " + r.value }),
+      ]),
+      sw,
+    ]),
+  ]);
+}

--- a/module/webroot/js/ui/rkp-view.js
+++ b/module/webroot/js/ui/rkp-view.js
@@ -20,6 +20,19 @@ export function renderRkpSection(host, state, actions) {
     el("h1", { class: "panel-title", text: "Remote Key Provision" }),
   ]));
 
+  // These knobs almost never need touching: the module already handles remote provisioning so the
+  // keybox stays in effect. Turning them off is an escape hatch for the rare device where keybox
+  // attestation explicitly fails — hence the calm, informational tone rather than an alarm.
+  if (rows.some((r) => r.on)) {
+    host.appendChild(el("div", { class: "card" }, [el("div", { class: "banner" }, [
+      el("div", { text: "You usually don't need to change these." }),
+      el("div", { class: "muted small", text:
+        "The module handles remote provisioning while these stay on. Only if a device explicitly fails " +
+        "keybox attestation — a rare case — should you toggle them all off to force keystore2 onto the " +
+        "keybox." }),
+    ])]));
+  }
+
   const card = el("div", { class: "card" });
   for (const r of rows) card.appendChild(rkpRow(r, actions));
   host.appendChild(card);


### PR DESCRIPTION
On rkp-only devices our RKP denial is skipped, so attestation roots in the real key and only Basic integrity passes. To debug this without a rebuild, `keymint_hook` now logs `remote_provisioning.tee/strongbox.rkp_only` and `enable_rkpd` once at install, plus the raw value read on every target `getRegistration`. The Keyboxes page gains a `Remote Key Provision` section surfacing whichever of those three props the device defines — read as root, refreshed on pull — and toggling each live via `resetprop`, so the gate can be flipped and observed in one place.
