### PR TITLE
Carry MODULE_HASH on generation-mode keys, gated to KeyMint v4+

### DIFF
--- a/app/src/main/java/org/matrix/teesim/Harvester.kt
+++ b/app/src/main/java/org/matrix/teesim/Harvester.kt
@@ -214,6 +214,12 @@ object Harvester {
         private fun effectiveBoot(field: String, captured: ByteArray): ByteArray =
             overrides[field]?.value?.let { hexBytes(it) } ?: captured
 
+        /** The MODULE_HASH we present: the override (hex, synthesized when the leaf omitted the tag)
+         *  when active, else the raw capture. Null only when neither exists — the lib then omits the
+         *  tag, and its v4-only gate omits it for older profiles regardless. */
+        fun effectiveModuleHash(): ByteArray? =
+            overrides["moduleHash"]?.value?.let { hexBytes(it) } ?: moduleHash
+
         private fun capturedString(field: String): String =
             when (field) {
                 "serial" -> serial
@@ -257,8 +263,9 @@ object Harvester {
             sdk == 30 -> 4 // Android 11 (Keymaster 4.1)
             sdk <= 32 -> 100 // Android 12 / 12L (KeyMint 1.0)
             sdk == 33 -> 200 // Android 13 (KeyMint 2.0)
-            sdk == 34 -> 300 // Android 14 (KeyMint 3.0)
-            else -> 400 // Android 15+ (KeyMint 4.0)
+            sdk <= 35 -> 300 // Android 14, 15 (KeyMint 3.0; Android 15 did not bump KeyMint)
+            sdk == 36 -> 400 // Android 16 (KeyMint 4.0; first release to carry MODULE_HASH)
+            else -> 500 // Android 17+ (KeyMint 5.0)
         }
 
     /** The `keymasterVersion` matching an `attestationVersion` (same derivation as the TA's cert.rs):

--- a/app/src/main/java/org/matrix/teesim/Resolver.kt
+++ b/app/src/main/java/org/matrix/teesim/Resolver.kt
@@ -12,8 +12,9 @@ import org.json.JSONObject
  * common/control.cpp ApplyConfig().
  *
  * Field names mirror control.cpp exactly: top level: type, epoch, bootInfo, profiles bootInfo:
- * verifiedBootKey(b64), verifiedBootHash(b64), deviceLocked, verifiedBootState, strongBoxAvailable,
- * attestVersionTee, attestVersionStrongBox profile: id, keyboxB64, mode, securityLevel(int),
+ * verifiedBootKey(b64), verifiedBootHash(b64), moduleHash(b64, optional), deviceLocked,
+ * verifiedBootState, strongBoxAvailable, attestVersionTee, attestVersionStrongBox
+ * profile: id, keyboxB64, mode, securityLevel(int),
  * osVersion, osPatchLevel, vendorPatchLevel,
  * bootPatchLevel, deviceIds{...}, packages[], uids[]. packages[] is every explicit package-name
  * entry verbatim (kept even when not installed, since a name-match still fires on a later install);
@@ -40,6 +41,11 @@ object Resolver {
                 // capture. Never all-zero, so the attested key still verifies.
                 put("verifiedBootKey", b64.encodeToString(harvest.effectiveBootKey()))
                 put("verifiedBootHash", b64.encodeToString(harvest.effectiveBootHash()))
+                // The MODULE_HASH to attach to generation-mode keys, so they carry the tag keystore2
+                // sends the real HAL only once per boot (and never resends to a TA built afterwards).
+                // The lib prefers keystore2's own captured bytes and uses this only as a fallback; it
+                // is emitted only for KeyMint v4+ attestations, so an older profile never carries it.
+                harvest.effectiveModuleHash()?.let { put("moduleHash", b64.encodeToString(it)) }
                 // Always present a locked, Verified boot state. Module users run unlocked bootloaders, and
                 // reporting the device's real state (unlocked / Unverified) fails attestation by
                 // construction. These are the "required" overrides the WebUI shows read-only.

--- a/common/control.cpp
+++ b/common/control.cpp
@@ -179,11 +179,12 @@ void ApplyConfig(const tjson::Value &msg, uint64_t &epoch, int &applied, int &to
   if (const tjson::Value *e = msg.get("epoch")) epoch = static_cast<uint64_t>(e->as_int(0));
 
   // Device-wide boot info.
-  std::vector<uint8_t> vb_key, vb_hash;
+  std::vector<uint8_t> vb_key, vb_hash, module_hash;
   TsBootInfo boot{};
   if (const tjson::Value *bi = msg.get("bootInfo")) {
     if (const tjson::Value *k = bi->get("verifiedBootKey")) Base64Decode(k->as_string(), vb_key);
     if (const tjson::Value *h = bi->get("verifiedBootHash")) Base64Decode(h->as_string(), vb_hash);
+    if (const tjson::Value *m = bi->get("moduleHash")) Base64Decode(m->as_string(), module_hash);
     boot.device_locked = bi->get("deviceLocked") ? bi->get("deviceLocked")->as_bool(true) : true;
     boot.verified_boot_state =
         bi->get("verifiedBootState") ? int32_t(bi->get("verifiedBootState")->as_int(0)) : 0;
@@ -203,6 +204,8 @@ void ApplyConfig(const tjson::Value &msg, uint64_t &epoch, int &applied, int &to
   boot.verified_boot_key_len = vb_key.size();
   boot.verified_boot_hash = vb_hash.data();
   boot.verified_boot_hash_len = vb_hash.size();
+  boot.module_hash = module_hash.data();
+  boot.module_hash_len = module_hash.size();
   teesim_cfg_begin(&boot);
 
   const tjson::Value *profiles = msg.get("profiles");

--- a/common/control.h
+++ b/common/control.h
@@ -28,6 +28,11 @@ typedef struct {
   size_t verified_boot_key_len;
   const uint8_t *verified_boot_hash;
   size_t verified_boot_hash_len;
+  // SHA-256 the daemon computed over the device's active APEX/module set, to attach as
+  // Tag::MODULE_HASH on keys we mint. NULL/0 when unavailable; the TA emits the tag only for
+  // KeyMint v4+ attestations regardless, so an older-version profile never carries it.
+  const uint8_t *module_hash;
+  size_t module_hash_len;
   bool device_locked;
   int32_t verified_boot_state;
   bool strongbox_available;  // device can produce a real StrongBox-backed key; gates patch at that level

--- a/keymint/keymint_router.cpp
+++ b/keymint/keymint_router.cpp
@@ -58,11 +58,18 @@ std::mutex g_cfg_mu;
 std::vector<Profile> g_profiles;
 TaPtr g_default_ta;  // serves ops on our blobs; any profile's TA decrypts them
 bool g_strongbox_ok = false;  // device can patch real StrongBox keys; else StrongBox forces generation
+// The device-wide MODULE_HASH to seed a freshly built TA with, so a generation-mode key carries the
+// tag keystore2 only sends once per boot (and never resends to a TA built afterwards). Preference:
+// the exact bytes keystore2 pushed via setAdditionalAttestationInfo, captured below; the daemon's own
+// computed value (g_stage_module_hash) is only a fallback for when we never saw that one-shot call.
+// Guarded by g_cfg_mu. Empty until either source provides one.
+std::vector<uint8_t> g_module_hash;
 
 // Staging state built up by teesim_cfg_begin/add_profile before the swap.
 std::vector<Profile> g_staging;
 std::vector<uint8_t> g_stage_vb_key;
 std::vector<uint8_t> g_stage_vb_hash;
+std::vector<uint8_t> g_stage_module_hash;  // MODULE_HASH to seed each TA with at creation (may be empty)
 bool g_stage_locked = true;
 int32_t g_stage_vb_state = 0;
 bool g_stage_strongbox_ok = false;
@@ -160,6 +167,20 @@ std::vector<TaPtr> AllProfileTas() {
   tas.reserve(g_profiles.size());
   for (const auto& p : g_profiles) tas.push_back(p.ta);
   return tas;
+}
+
+// Record `hash` on `ta` as Tag::MODULE_HASH so a generation-mode key it mints carries the module
+// hash. No-op for an empty hash. Setting the value a TA already holds is idempotent in the reference
+// TA (a repeat of the same bytes is ignored), so the later keystore2 forward over the same value is
+// harmless; only a genuinely different value is rejected, which this logs.
+void SeedModuleHash(const TaPtr& ta, const std::vector<uint8_t>& hash) {
+  if (hash.empty() || !ta) return;
+  KmParam p{};
+  p.tag = static_cast<uint32_t>(Tag::MODULE_HASH);
+  p.blob = hash.data();
+  p.blob_len = hash.size();
+  int32_t rc = teesim_km_set_additional_attestation_info(ta.get(), &p, 1);
+  if (rc != 0) LOGW("SeedModuleHash: TA rejected (%d)", rc);
 }
 
 // --- AIDL KeyParameter <-> flat KmParam --------------------------------------
@@ -743,6 +764,14 @@ class TeesimKeyMintDevice : public BnKeyMintDevice {
   // key we attest carries the same value keystore2 pushes to the real HAL and a verifier that checks
   // it still validates. Applied to every profile since the info is device-wide; best-effort per TA.
   ndk::ScopedAStatus setAdditionalAttestationInfo(const std::vector<KeyParameter>& info) override {
+    // Latch keystore2's MODULE_HASH as the authoritative value to seed TAs built later this boot: it
+    // is the exact bytes the real HAL got, so a verifier comparing against a genuine device matches.
+    for (const auto& p : info) {
+      if (p.tag == Tag::MODULE_HASH && p.value.getTag() == KeyParameterValue::blob) {
+        std::lock_guard<std::mutex> lk(g_cfg_mu);
+        g_module_hash = p.value.get<KeyParameterValue::blob>();
+      }
+    }
     auto km = ToKmVec(info);
     for (const auto& ta : AllProfileTas()) {
       int32_t rc = teesim_km_set_additional_attestation_info(ta.get(), km.data(), km.size());
@@ -888,6 +917,7 @@ extern "C" void teesim_cfg_begin(const TsBootInfo* boot) {
                         boot->verified_boot_key + boot->verified_boot_key_len);
   g_stage_vb_hash.assign(boot->verified_boot_hash,
                          boot->verified_boot_hash + boot->verified_boot_hash_len);
+  g_stage_module_hash.assign(boot->module_hash, boot->module_hash + boot->module_hash_len);
   g_stage_locked = boot->device_locked;
   g_stage_vb_state = boot->verified_boot_state;
   g_stage_strongbox_ok = boot->strongbox_available;
@@ -909,6 +939,18 @@ extern "C" bool teesim_cfg_add_profile(const TsProfile* p) {
   prof.id = p->id ? p->id : "";
   prof.ta = WrapTa(ta);
   prof.patch_mode = p->mode && std::string(p->mode) == "patch";
+  // Seed the fresh TA with the device-wide MODULE_HASH so a generation-mode key it mints carries the
+  // tag, independent of keystore2's one-shot delivery. Prefer keystore2's captured bytes; fall back
+  // to the daemon's computed value when we never saw that call. The reference TA emits the tag only
+  // for KeyMint v4+ attestations, so seeding an older-version profile is harmless.
+  {
+    std::vector<uint8_t> seed;
+    {
+      std::lock_guard<std::mutex> lk(g_cfg_mu);
+      seed = g_module_hash.empty() ? g_stage_module_hash : g_module_hash;
+    }
+    SeedModuleHash(prof.ta, seed);
+  }
   for (int i = 0; i < p->n_packages && p->packages; ++i) {
     if (p->packages[i]) prof.packages.emplace_back(p->packages[i]);
   }

--- a/rust/patches/kmr-ta-seclevel.patch
+++ b/rust/patches/kmr-ta-seclevel.patch
@@ -1,5 +1,5 @@
 diff --git a/ta/src/cert.rs b/ta/src/cert.rs
-index ce07450..9d90f4b 100644
+index ce07450..39b4d20 100644
 --- a/ta/src/cert.rs
 +++ b/ta/src/cert.rs
 @@ -300,9 +300,21 @@ enum SecurityLevel {
@@ -25,7 +25,22 @@ index ce07450..9d90f4b 100644
      challenge: &'a [u8],
      app_id: &'a [u8],
      security_level: keymint::SecurityLevel,
-@@ -352,9 +364,9 @@ pub(crate) fn attestation_extension<'a>(
+@@ -333,6 +345,14 @@ pub(crate) fn attestation_extension<'a>(
+         keymint::SecurityLevel::Software => (params, &[]),
+         _ => (&[], params),
+     };
++    // Tag::MODULE_HASH (724) was introduced in KeyMint v4 (attestationVersion 400); no earlier
++    // KeyMint or Keymaster attestation carries it. Gate the additional info by the version this key
++    // is emitted at so the tag tracks that version even when the TA has a module hash recorded. The
++    // check is here (per emission) rather than at the TA's recorded state because a single TA attests
++    // at different versions per security level, so a dual-level device that reports v4 at TEE and v3
++    // at StrongBox stays honest at each level.
++    let additional_attestation_info: &[KeyParam] =
++        if attestation_version >= 400 { additional_attestation_info } else { &[] };
+     let sw_enforced = AuthorizationList::new(
+         sw_chars,
+         sw_params,
+@@ -352,9 +372,9 @@ pub(crate) fn attestation_extension<'a>(
      let sec_level = SecurityLevel::try_from(security_level as u32)
          .map_err(|_| km_err!(InvalidArgument, "invalid security level {security_level:?}"))?;
      let ext = AttestationExtension {


### PR DESCRIPTION
Fixes #236. Generation-mode keys were minted without attestation [tag 724 (MODULE_HASH)](https://android.googlesource.com/platform/hardware/interfaces/+/refs/heads/main/security/keymint/aidl/android/hardware/security/keymint/Tag.aidl), while harvested and patched leaves carried it.

keystore2 computes the APEX module hash and [pushes it to the KeyMint HAL via setAdditionalAttestationInfo](https://android.googlesource.com/platform/system/security/+/refs/heads/main/keystore2/src/maintenance.rs) exactly once per boot — latched by `keystore.module_hash.sent`, and only to instances at `versionNumber >= KEYMINT_V4` (400). Our TAs are rebuilt at every config commit, which lands after that one-shot, so they never received it; the number was never wrong, its recorded state just never reached a TA built afterwards.

- The embedded kmr-ta now emits MODULE_HASH only when the emitted [attestationVersion is >= 400](https://source.android.com/docs/security/features/keystore/attestation) (present only from KeyMint v4), decided per request, so a dual-level TA stays honest (v4 at TEE, v3 at StrongBox) and no pre-v4 profile carries it.
- The router latches keystore2's exact bytes and seeds every new TA with them; the daemon's own /apex computation (`bootInfo.moduleHash`) is only a fallback. Equal re-sets are [idempotent in the reference TA](https://android.googlesource.com/platform/system/keymint/+/refs/heads/main/ta/src/lib.rs) (only a different value is rejected), so keystore2's later forward never conflicts.
- Corrects fabricatedAttestationVersion: Android 15 = [300](https://source.android.com/docs/security/features/keystore/attestation) (no KeyMint bump; [v4/moduleHash arrived in Android 16](https://source.android.com/docs/whatsnew/android-16-release)), and [Android 17](https://developer.android.com/about/versions/17/behavior-changes-17) = [500](https://android.googlesource.com/platform/hardware/interfaces/+/refs/heads/main/security/keymint/aidl/android/hardware/security/keymint/KeyCreationResult.aidl).
