### PR TITLE
Build the KeyMint profile from an EC-only keybox

### DIFF
--- a/rust/teesim-km/src/attest.rs
+++ b/rust/teesim-km/src/attest.rs
@@ -1,8 +1,11 @@
 // Attestation signing keys loaded from a keybox.xml.
 //
 // Implements the TA's `RetrieveCertSigningInfo` trait so that generated keys are
-// attested with the RSA and EC batch keys from the configured keybox. There is no
-// hard-coded fallback: a keybox must be supplied.
+// attested with the batch keys from the configured keybox. A factory batch keybox
+// carries both an RSA and an EC key and each attested key is signed with the matching
+// algorithm; an RKP-extracted keybox carries only an EC P-256 key, so every leaf
+// (RSA keys included) is signed with the EC key, exactly as a real RKP device does.
+// At least one key must be present, but neither is individually required.
 
 use base64::{engine::general_purpose, Engine as _};
 use kmr_common::{
@@ -19,44 +22,71 @@ struct AlgoInfo {
     chain: Vec<keymint::Certificate>,
 }
 
-/// Signing information for the asymmetric key types we attest with.
+/// Signing information for the asymmetric key types we attest with. Each algorithm is optional; a
+/// keybox must carry at least one, but an RKP-extracted keybox legitimately has only the EC key.
 #[derive(Clone)]
 pub struct CertSignInfo {
-    rsa: AlgoInfo,
-    ec: AlgoInfo,
+    rsa: Option<AlgoInfo>,
+    ec: Option<AlgoInfo>,
 }
 
 impl CertSignInfo {
-    /// The batch signing key and its keybox certificate chain for one algorithm (EC when `ec` is
-    /// true, else RSA). Patch mode re-signs a real attestation leaf with this key and appends this
-    /// chain, matching the algorithm of the key being attested.
-    pub fn batch(&self, ec: bool) -> (KeyMaterial, &[keymint::Certificate]) {
-        let a = if ec { &self.ec } else { &self.rsa };
-        (a.key.clone(), &a.chain)
+    /// Choose the batch key for an attested key, preferring the matching algorithm (`prefer_ec`) and
+    /// falling back to the other key when the keybox lacks the preferred one. Returns the key info
+    /// plus whether the chosen key is EC, so callers stamp the signature fields for the key that
+    /// actually signs rather than the key being attested. `new` guarantees at least one key exists,
+    /// so the fallback is always present.
+    fn pick(&self, prefer_ec: bool) -> (&AlgoInfo, bool) {
+        let (primary, other) = if prefer_ec { (&self.ec, &self.rsa) } else { (&self.rsa, &self.ec) };
+        match primary {
+            Some(a) => (a, prefer_ec),
+            None => (
+                other.as_ref().expect("keybox has at least one signing key"),
+                !prefer_ec,
+            ),
+        }
+    }
+
+    /// The batch signing key, its keybox certificate chain, and whether that key is EC. `prefer_ec`
+    /// requests the algorithm matching the key being attested; when absent, the other key is used
+    /// (an EC-only RKP keybox signs every leaf with its EC key). Patch mode re-signs a real
+    /// attestation leaf with this key and appends this chain.
+    pub fn batch(&self, prefer_ec: bool) -> (KeyMaterial, &[keymint::Certificate], bool) {
+        let (a, is_ec) = self.pick(prefer_ec);
+        (a.key.clone(), &a.chain, is_ec)
     }
 }
 
 impl CertSignInfo {
-    /// Parse a keybox.xml string and extract the RSA and EC signing keys/chains.
+    /// Parse a keybox.xml string and extract whichever of the RSA and EC signing keys/chains it
+    /// carries. Requires at least one; a factory keybox has both, an RKP-extracted keybox only EC.
     pub fn new(keybox_xml: &str) -> Result<Self, String> {
         let doc = Document::parse(keybox_xml).map_err(|e| format!("keybox parse: {e:?}"))?;
 
-        let rsa_node = doc
-            .descendants()
-            .find(|n| n.has_tag_name("Key") && n.attribute("algorithm") == Some("rsa"))
-            .ok_or("keybox: no <Key algorithm=\"rsa\">")?;
-        let ec_node = doc
-            .descendants()
-            .find(|n| n.has_tag_name("Key") && n.attribute("algorithm") == Some("ecdsa"))
-            .ok_or("keybox: no <Key algorithm=\"ecdsa\">")?;
-
-        let info = CertSignInfo {
-            rsa: parse_algo(rsa_node, SigningAlgorithm::Rsa)?,
-            ec: parse_algo(ec_node, SigningAlgorithm::Ec)?,
+        let node = |algo: &str| {
+            doc.descendants()
+                .find(|n| n.has_tag_name("Key") && n.attribute("algorithm") == Some(algo))
         };
-        log::info!("teesim_km: keybox parsed");
-        crate::resign::log_chain("teesim_km: keybox RSA chain", &info.rsa.chain);
-        crate::resign::log_chain("teesim_km: keybox EC chain", &info.ec.chain);
+
+        let rsa = node("rsa").map(|n| parse_algo(n, SigningAlgorithm::Rsa)).transpose()?;
+        let ec = node("ecdsa").map(|n| parse_algo(n, SigningAlgorithm::Ec)).transpose()?;
+
+        if rsa.is_none() && ec.is_none() {
+            return Err("keybox: no <Key algorithm=\"rsa\"> or <Key algorithm=\"ecdsa\">".to_string());
+        }
+
+        let info = CertSignInfo { rsa, ec };
+        log::info!(
+            "teesim_km: keybox parsed (rsa={}, ec={})",
+            info.rsa.is_some(),
+            info.ec.is_some()
+        );
+        if let Some(a) = &info.rsa {
+            crate::resign::log_chain("teesim_km: keybox RSA chain", &a.chain);
+        }
+        if let Some(a) = &info.ec {
+            crate::resign::log_chain("teesim_km: keybox EC chain", &a.chain);
+        }
         Ok(info)
     }
 }
@@ -109,16 +139,14 @@ fn decode_pem(pem: &str) -> Result<Vec<u8>, String> {
 
 impl RetrieveCertSigningInfo for CertSignInfo {
     fn signing_key(&self, key_type: SigningKeyType) -> Result<KeyMaterial, Error> {
-        Ok(match key_type.algo_hint {
-            SigningAlgorithm::Rsa => self.rsa.key.clone(),
-            SigningAlgorithm::Ec => self.ec.key.clone(),
-        })
+        // kmr-ta derives the leaf's signature algorithm from the returned key material, so the EC
+        // fallback for an RSA request on an EC-only keybox yields a correctly EC-signed leaf.
+        let prefer_ec = matches!(key_type.algo_hint, SigningAlgorithm::Ec);
+        Ok(self.pick(prefer_ec).0.key.clone())
     }
 
     fn cert_chain(&self, key_type: SigningKeyType) -> Result<Vec<keymint::Certificate>, Error> {
-        Ok(match key_type.algo_hint {
-            SigningAlgorithm::Rsa => self.rsa.chain.clone(),
-            SigningAlgorithm::Ec => self.ec.chain.clone(),
-        })
+        let prefer_ec = matches!(key_type.algo_hint, SigningAlgorithm::Ec);
+        Ok(self.pick(prefer_ec).0.chain.clone())
     }
 }

--- a/rust/teesim-km/src/resign.rs
+++ b/rust/teesim-km/src/resign.rs
@@ -70,9 +70,12 @@ impl Ta {
         let cert = Certificate::from_der(leaf).map_err(wrap("parse real leaf"))?;
         let mut tbs = cert.tbs_certificate;
 
-        // Sign with the keybox key matching the attested key's algorithm, and append that key's chain.
-        let is_ec = tbs.subject_public_key_info.algorithm.oid == ID_EC_PUBLIC_KEY;
-        let (batch_key, batch_chain) = self.sign_info.batch(is_ec);
+        // Sign with the keybox key matching the attested key's algorithm; batch() falls back to the
+        // keybox's other key when that algorithm is absent (an EC-only RKP keybox signs every leaf
+        // with its EC key) and reports which key it returned, so `is_ec` here is the signing key's
+        // algorithm — what the signature fields must describe, not the attested key's.
+        let want_ec = tbs.subject_public_key_info.algorithm.oid == ID_EC_PUBLIC_KEY;
+        let (batch_key, batch_chain, is_ec) = self.sign_info.batch(want_ec);
         let batch_leaf = batch_chain.first().ok_or_else(|| err("keybox chain is empty"))?;
         let batch_leaf =
             Certificate::from_der(&batch_leaf.encoded_certificate).map_err(wrap("parse keybox leaf"))?;


### PR DESCRIPTION
A keybox extracted from RKP carries only an ECDSA P-256 key, since that is the sole type [`IRemotelyProvisionedComponent`](https://cs.android.com/android/platform/superproject/main/+/main:hardware/interfaces/security/rkp/aidl/android/hardware/security/keymint/IRemotelyProvisionedComponent.aidl) provisions, via `generateEcdsaP256KeyPair`. We required both an RSA and an EC key, so such a keybox built no profile at all. Both algorithms are optional now: a keybox needs only one, and — as on a real RKP device, whose [attestation key](https://cs.android.com/android/platform/superproject/main/+/main:system/security/keystore2/src/remote_provisioning.rs) is that P-256 key — every leaf, RSA subjects included, is signed by the single EC batch key.