### PR TITLE
Parse imported EC private keys against the curve the caller expects

### DIFF
--- a/rust/build.sh
+++ b/rust/build.sh
@@ -32,11 +32,13 @@ fi
 # mismatch nor silently falls back to a different preinstalled NDK (CI runners preset ANDROID_NDK_ROOT).
 export ANDROID_NDK_HOME="$NDK_HOME" ANDROID_NDK_ROOT="$NDK_HOME" ANDROID_NDK="$NDK_HOME"
 
-# Adapt the reference TA to build under Cargo rather than Soong: the BoringSSL
-# backend (openssl-sys vs bssl-sys, kmr-crypto-boring.patch) and a per-request
-# attestation security level (kmr-ta-seclevel.patch). Each patch is applied to the
-# submodule working tree, idempotently — skipped when it already reverse-applies,
-# i.e. is already present.
+# Adapt the reference TA to build under Cargo rather than Soong — the BoringSSL backend
+# (openssl-sys vs bssl-sys, kmr-crypto-boring.patch) and the group-aware EC private key
+# parse that only Android's rust-openssl fork offers (kmr-crypto-boring-ec-group.patch) —
+# and to what an in-process TA can do: a per-request attestation security level
+# (kmr-ta-seclevel.patch) and auth tokens it holds no device HMAC key to verify
+# (kmr-ta-authtoken.patch). Each patch is applied to the submodule working tree,
+# idempotently — skipped when it already reverse-applies, i.e. is already present.
 for PATCH in "$HERE"/patches/*.patch; do
   if git -C "$ROOT/third_party/keymint" apply -p1 --reverse --check "$PATCH" 2>/dev/null; then
     :

--- a/rust/patches/kmr-crypto-boring-ec-group.patch
+++ b/rust/patches/kmr-crypto-boring-ec-group.patch
@@ -1,0 +1,37 @@
+diff --git a/boringssl/src/ec.rs b/boringssl/src/ec.rs
+index ddecdd1..7f41132 100644
+--- a/boringssl/src/ec.rs
++++ b/boringssl/src/ec.rs
+@@ -45,10 +45,29 @@ fn private_key_from_der_for_group(
+ #[cfg(not(soong))]
+ fn private_key_from_der_for_group(
+     der: &[u8],
+-    _group: &openssl::ec::EcGroupRef,
++    group: &openssl::ec::EcGroupRef,
+ ) -> Result<openssl::ec::EcKey<openssl::pkey::Private>, openssl::error::ErrorStack> {
+-    // This doesn't work if the encoded data is missing the curve.
+-    openssl::ec::EcKey::private_key_from_der(der)
++    use foreign_types::ForeignTypeRef;
++    // Upstream rust-openssl has no equivalent of that modification, and its `private_key_from_der`
++    // names no group: `EC_KEY_parse_private_key` then rejects a SEC1 key that legally omits its
++    // optional parameters field (RFC 5915, the curve being named by the enclosing PKCS#8
++    // AlgorithmIdentifier) with MISSING_PARAMETERS, and conversely accepts one naming a curve
++    // other than the one the caller is about to use the key with. Reach for the same entry point
++    // the Android modification uses; openssl-sys binds it from BoringSSL's headers just as
++    // bssl-sys does.
++    //
++    // Safety: `cbs` borrows `der`, which BoringSSL only reads from and only for the duration of
++    // the call, as it does `group`. A successful parse returns a fresh `EC_KEY` whose sole
++    // reference `EcKey` takes ownership of.
++    unsafe {
++        ffi::init();
++        let mut cbs = ffi::CBS { data: der.as_ptr(), len: der.len() };
++        let parsed = ffi::EC_KEY_parse_private_key(&mut cbs, group.as_ptr());
++        if parsed.is_null() {
++            return Err(openssl::error::ErrorStack::get());
++        }
++        Ok(openssl::ec::EcKey::from_ptr(parsed))
++    }
+ }
+ 
+ /// [`crypto::Ec`] implementation based on BoringSSL.


### PR DESCRIPTION
Reported in #238: importing a PKCS#8 EC key whose inner ECPrivateKey omits the optional parameters field — legal under RFC 5915, the curve already being named by the enclosing AlgorithmIdentifier — fails with MISSING_PARAMETERS, and apps do import such keys.

kmr-ta parses that DER through [`private_key_from_der_for_group`](https://android.googlesource.com/platform/system/keymint/+/cfeefc94bf8c4f19d19dca193d376a1fc05e8e3e/boringssl/src/ec.rs#36), which under Soong reaches [an Android modification of rust-openssl](https://android.googlesource.com/platform/external/rust/crates/openssl/+/refs/heads/main/src/ec.rs#1018) that hands the group to `EC_KEY_parse_private_key`. Our Cargo build takes the other arm, whose own comment says it "doesn't work if the encoded data is missing the curve", and [BoringSSL has to get that group from somewhere](https://boringssl.googlesource.com/boringssl/+/423b1aa3b1dc62f01e46bbd51affee5f5e021db0/crypto/ec/ec_asn1.cc#107).

The patch calls the same entry point; openssl-sys binds it from BoringSSL's headers just as bssl-sys does. Every caller gains it — public key derivation, signing, ECDH, keyblob deserialization — not only import, and a key naming a curve other than the caller's, which the group-less parse accepted, is now rejected.
