### PR TITLE
Serve each security level from its own KeyMint TA instance

### DIFF
--- a/keymint/README.md
+++ b/keymint/README.md
@@ -181,16 +181,19 @@ it is also ours — as does StrongBox:
 ### Per-level attestation identity
 
 The record's security level and version must match the HAL the request came through: a StrongBox
-key claims StrongBox and that HAL's version, a TEE key the TEE's. One TA serves both proxies, so
-before each creation the router passes the proxy's level to the TA, which overrides
-`hw_info.security_level` and the raw `attestation_version` for that one request
-(`override_attestation_identity`) and restores them after. The versions are harvested from throwaway
-attested keys at each level and carried in the config — or fabricated (TrustedEnvironment and the
-OS-appropriate version) when the device has no working hardware attestation; the `keyMintVersion` is
-then derived from `attestationVersion` in the TA (Keymaster 4.0 is attestation 3 / keymaster 4, 4.1 is
-4 / 41; KeyMint versions are equal). A broken StrongBox reuses the TEE version. Patch mode gets this
-for free — it re-signs the real leaf, whose version fields are
-already the hardware's.
+key claims StrongBox and that HAL's version, a TEE key the TEE's. Each profile builds a separate TA
+per level (`Profile::ta_tee` / `ta_strongbox`, selected by `Profile::TaFor`), mirroring a real
+device's independent per-level KeyMint instances. The proxy routes every request — and every
+operation on one of our blobs (`DefaultTaFor(level_)`) — to the instance for its own level, which is
+fixed at construction, so the level and version are never overridden per request and a key's
+characteristics are always read at the level it was minted at. The versions are harvested from
+throwaway attested keys at each level and carried in the config — or fabricated (TrustedEnvironment
+and the OS-appropriate version) when the device has no working hardware attestation; the
+`keyMintVersion` is then derived from `attestationVersion` in the TA (Keymaster 4.0 is attestation 3 /
+keymaster 4, 4.1 is 4 / 41; KeyMint versions are equal). A broken StrongBox reuses the TEE version.
+Patch mode gets this for free — it re-signs the real leaf, whose version fields are already the
+hardware's. Both instances share the same key-encryption key (it is level- and profile-independent),
+so any of our blobs decrypts under either.
 
 ### Recursion guard
 

--- a/keymint/keymint_router.cpp
+++ b/keymint/keymint_router.cpp
@@ -43,20 +43,29 @@ TaPtr WrapTa(::Ta* ta) {
   });
 }
 
-// A configured profile: its TA, the package names routed to it, and whether it patches the real
-// hardware attestation (patch mode) or mints the whole key in the TA (generation mode).
+// A configured profile: its per-level TAs, the package names routed to it, and whether it patches the
+// real hardware attestation (patch mode) or mints the whole key in the TA (generation mode).
 struct Profile {
   std::string id;
-  TaPtr ta;
+  // A separate fixed-level TA per security level, mirroring how a real device runs an independent
+  // KeyMint instance per level. Every op routes to the instance for the level it arrived on, so a
+  // key's characteristics are always read at the level the key was minted at.
+  TaPtr ta_tee;
+  TaPtr ta_strongbox;
   std::vector<std::string> packages;
   std::vector<int32_t> uids;  // resolved caller uids, for requests that carry no app-id to match
   bool patch_mode = false;
+
+  // The TA that serves requests arriving at `level`. Software-level KeyMint is never wrapped, so any
+  // non-StrongBox level maps to the TrustedEnvironment instance.
+  const TaPtr& TaFor(SecurityLevel level) const {
+    return level == SecurityLevel::STRONGBOX ? ta_strongbox : ta_tee;
+  }
 };
 
 // Live routing, swapped atomically by teesim_cfg_commit under g_cfg_mu.
 std::mutex g_cfg_mu;
 std::vector<Profile> g_profiles;
-TaPtr g_default_ta;  // serves ops on our blobs; any profile's TA decrypts them
 bool g_strongbox_ok = false;  // device can patch real StrongBox keys; else StrongBox forces generation
 // The device-wide MODULE_HASH to seed a freshly built TA with, so a generation-mode key carries the
 // tag keystore2 only sends once per boot (and never resends to a TA built afterwards). Preference:
@@ -124,7 +133,8 @@ struct RequestTarget {
   bool patch_mode = false;
 };
 
-RequestTarget ProfileForRequest(const std::vector<KeyParameter>& params, uid_t caller_uid) {
+RequestTarget ProfileForRequest(const std::vector<KeyParameter>& params, uid_t caller_uid,
+                                SecurityLevel level) {
   std::lock_guard<std::mutex> lk(g_cfg_mu);
   if (g_profiles.empty()) return {};
   // Primary match: the ATTESTATION_APPLICATION_ID the app embeds in the request names its package.
@@ -135,7 +145,7 @@ RequestTarget ProfileForRequest(const std::vector<KeyParameter>& params, uid_t c
     std::string hay(id.begin(), id.end());
     for (const auto& prof : g_profiles) {
       for (const auto& pkg : prof.packages) {
-        if (hay.find(pkg) != std::string::npos) return {prof.ta, prof.patch_mode};
+        if (hay.find(pkg) != std::string::npos) return {prof.TaFor(level), prof.patch_mode};
       }
     }
   }
@@ -145,17 +155,21 @@ RequestTarget ProfileForRequest(const std::vector<KeyParameter>& params, uid_t c
   if (caller_uid != static_cast<uid_t>(-1)) {
     for (const auto& prof : g_profiles) {
       for (int32_t uid : prof.uids) {
-        if (static_cast<uid_t>(uid) == caller_uid) return {prof.ta, prof.patch_mode};
+        if (static_cast<uid_t>(uid) == caller_uid) return {prof.TaFor(level), prof.patch_mode};
       }
     }
   }
   return {};
 }
 
-// The TA used for operations on an existing blob of ours (begin/upgrade/etc.).
-TaPtr DefaultTa() {
+// The TA used for operations on an existing blob of ours (begin/upgrade/etc.), at the level the op
+// arrived on. Any profile's TA can decrypt any of our blobs (the KEK is level- and profile-
+// independent), but the level must match so the reference TA finds the key's characteristics at its
+// own level; the front profile's instance for `level` serves as that default.
+TaPtr DefaultTaFor(SecurityLevel level) {
   std::lock_guard<std::mutex> lk(g_cfg_mu);
-  return g_default_ta;
+  if (g_profiles.empty()) return {};
+  return g_profiles.front().TaFor(level);
 }
 
 // A snapshot of every configured profile's TA, for device-state transitions (earlyBootEnded /
@@ -164,8 +178,11 @@ TaPtr DefaultTa() {
 std::vector<TaPtr> AllProfileTas() {
   std::lock_guard<std::mutex> lk(g_cfg_mu);
   std::vector<TaPtr> tas;
-  tas.reserve(g_profiles.size());
-  for (const auto& p : g_profiles) tas.push_back(p.ta);
+  tas.reserve(g_profiles.size() * 2);
+  for (const auto& p : g_profiles) {
+    if (p.ta_tee) tas.push_back(p.ta_tee);
+    if (p.ta_strongbox) tas.push_back(p.ta_strongbox);
+  }
   return tas;
 }
 
@@ -483,7 +500,7 @@ class TeesimKeyMintDevice : public BnKeyMintDevice {
                                  KeyCreationResult* out) override {
     const uid_t caller_uid = AIBinder_getCallingUid();
     RecordUsage(static_cast<int32_t>(caller_uid));  // every app that asks for a key, for the daemon's usage view
-    RequestTarget t = ProfileForRequest(keyParams, caller_uid);
+    RequestTarget t = ProfileForRequest(keyParams, caller_uid, level_);
     LOGI("generateKey: level=%d, %zu param(s), caller_uid=%d, caller_attest_key=%d, target=%d, "
          "patch_mode=%d, strongbox_ok=%d",
          static_cast<int>(level_), keyParams.size(), static_cast<int>(caller_uid),
@@ -547,7 +564,7 @@ class TeesimKeyMintDevice : public BnKeyMintDevice {
                                const std::vector<uint8_t>& keyData,
                                const std::optional<AttestationKey>& attestationKey,
                                KeyCreationResult* out) override {
-    RequestTarget t = ProfileForRequest(keyParams, AIBinder_getCallingUid());
+    RequestTarget t = ProfileForRequest(keyParams, AIBinder_getCallingUid(), level_);
     TaPtr ta = t.ta;
     if (!ta) {
       if (real_) {
@@ -568,7 +585,7 @@ class TeesimKeyMintDevice : public BnKeyMintDevice {
     auto km = ToKmVec(keyParams);
     auto ak = MakeAttestKey(attestationKey);
     TsCreationResult* res = nullptr;
-    int32_t rc = teesim_km_import_key(ta.get(), km.data(), km.size(), static_cast<int32_t>(level_),
+    int32_t rc = teesim_km_import_key(ta.get(), km.data(), km.size(),
                                       static_cast<int32_t>(keyFormat), keyData.data(), keyData.size(),
                                       ak.blob, ak.blob_len, ak.params.data(), ak.params.size(),
                                       ak.issuer, ak.issuer_len, &res);
@@ -591,7 +608,7 @@ class TeesimKeyMintDevice : public BnKeyMintDevice {
       }
       return Status(-100);
     }
-    TaPtr ta = DefaultTa();
+    TaPtr ta = DefaultTaFor(level_);
     if (!ta) return Status(-100);
     auto km = ToKmVec(params);
     TsAuthToken at;
@@ -623,7 +640,7 @@ class TeesimKeyMintDevice : public BnKeyMintDevice {
       }
       return ndk::ScopedAStatus::ok();
     }
-    TaPtr ta = DefaultTa();
+    TaPtr ta = DefaultTaFor(level_);
     if (!ta) return ndk::ScopedAStatus::ok();
     return Status(teesim_km_delete_key(ta.get(), keyBlob.data(), keyBlob.size()));
   }
@@ -639,7 +656,7 @@ class TeesimKeyMintDevice : public BnKeyMintDevice {
       }
       return Status(-100);
     }
-    TaPtr ta = DefaultTa();
+    TaPtr ta = DefaultTaFor(level_);
     if (!ta) return Status(-100);
     auto km = ToKmVec(upgradeParams);
     uint8_t* buf = nullptr;
@@ -664,7 +681,7 @@ class TeesimKeyMintDevice : public BnKeyMintDevice {
       }
       return Status(-100);
     }
-    TaPtr ta = DefaultTa();
+    TaPtr ta = DefaultTaFor(level_);
     if (!ta) return Status(-100);
     TsCharacteristics* res = nullptr;
     int32_t rc = teesim_km_get_key_characteristics(ta.get(), keyBlob.data(), keyBlob.size(),
@@ -857,7 +874,7 @@ class TeesimKeyMintDevice : public BnKeyMintDevice {
     auto km = ToKmVec(keyParams);
     auto ak = MakeAttestKey(attestationKey);
     TsCreationResult* res = nullptr;
-    int32_t rc = teesim_km_generate_key(ta, km.data(), km.size(), static_cast<int32_t>(level_),
+    int32_t rc = teesim_km_generate_key(ta, km.data(), km.size(),
                                         ak.blob, ak.blob_len, ak.params.data(), ak.params.size(),
                                         ak.issuer, ak.issuer_len, &res);
     if (rc != 0) return Status(rc);
@@ -926,30 +943,43 @@ extern "C" void teesim_cfg_begin(const TsBootInfo* boot) {
 }
 
 extern "C" bool teesim_cfg_add_profile(const TsProfile* p) {
-  ::Ta* ta = teesim_km_init_ex(p->keybox, p->keybox_len, p->security_level, p->os_version,
-                               p->os_patchlevel, p->vendor_patchlevel, p->boot_patchlevel,
-                               g_stage_vb_key.data(), g_stage_vb_key.size(), g_stage_vb_hash.data(),
-                               g_stage_vb_hash.size(), g_stage_locked, g_stage_vb_state,
-                               g_stage_attest_version_tee, g_stage_attest_version_strongbox, p->ids);
-  if (!ta) {
+  // A real device runs a separate KeyMint instance per security level; we mirror that with one fixed-
+  // level TA per level. Both are built from the same keybox and boot state, so their key-encryption
+  // keys match and any of our blobs decrypts under either — but each stamps its own level into the
+  // keys it mints, so operations read a key's characteristics at the level it was minted at with no
+  // per-request override. `p->security_level` is retained only for the staged-profile log line.
+  auto buildTa = [&](int32_t level) -> ::Ta* {
+    return teesim_km_init_ex(p->keybox, p->keybox_len, level, p->os_version, p->os_patchlevel,
+                             p->vendor_patchlevel, p->boot_patchlevel, g_stage_vb_key.data(),
+                             g_stage_vb_key.size(), g_stage_vb_hash.data(), g_stage_vb_hash.size(),
+                             g_stage_locked, g_stage_vb_state, g_stage_attest_version_tee,
+                             g_stage_attest_version_strongbox, p->ids);
+  };
+  ::Ta* ta_tee = buildTa(static_cast<int32_t>(SecurityLevel::TRUSTED_ENVIRONMENT));
+  ::Ta* ta_sb = buildTa(static_cast<int32_t>(SecurityLevel::STRONGBOX));
+  if (!ta_tee || !ta_sb) {
     LOGE("keymint: profile %s failed to build (bad keybox?)", p->id ? p->id : "?");
+    if (ta_tee) teesim_km_destroy(ta_tee);
+    if (ta_sb) teesim_km_destroy(ta_sb);
     return false;
   }
   Profile prof;
   prof.id = p->id ? p->id : "";
-  prof.ta = WrapTa(ta);
+  prof.ta_tee = WrapTa(ta_tee);
+  prof.ta_strongbox = WrapTa(ta_sb);
   prof.patch_mode = p->mode && std::string(p->mode) == "patch";
-  // Seed the fresh TA with the device-wide MODULE_HASH so a generation-mode key it mints carries the
-  // tag, independent of keystore2's one-shot delivery. Prefer keystore2's captured bytes; fall back
-  // to the daemon's computed value when we never saw that call. The reference TA emits the tag only
-  // for KeyMint v4+ attestations, so seeding an older-version profile is harmless.
+  // Seed both instances with the device-wide MODULE_HASH so a generation-mode key either mints carries
+  // the tag, independent of keystore2's one-shot delivery. Prefer keystore2's captured bytes; fall
+  // back to the daemon's computed value when we never saw that call. The reference TA emits the tag
+  // only for KeyMint v4+ attestations, so seeding an older-version profile is harmless.
   {
     std::vector<uint8_t> seed;
     {
       std::lock_guard<std::mutex> lk(g_cfg_mu);
       seed = g_module_hash.empty() ? g_stage_module_hash : g_module_hash;
     }
-    SeedModuleHash(prof.ta, seed);
+    SeedModuleHash(prof.ta_tee, seed);
+    SeedModuleHash(prof.ta_strongbox, seed);
   }
   for (int i = 0; i < p->n_packages && p->packages; ++i) {
     if (p->packages[i]) prof.packages.emplace_back(p->packages[i]);
@@ -966,7 +996,6 @@ extern "C" int teesim_cfg_commit(uint64_t /*epoch*/, char* /*err*/, size_t /*err
   std::lock_guard<std::mutex> lk(g_cfg_mu);
   g_profiles = std::move(g_staging);
   g_staging.clear();
-  g_default_ta = g_profiles.empty() ? nullptr : g_profiles.front().ta;
   g_strongbox_ok = g_stage_strongbox_ok;
   return static_cast<int>(g_profiles.size());
 }
@@ -994,7 +1023,8 @@ extern "C" bool teesim_cfg_resign(const char* profile_id, const uint8_t* leaf, s
     std::lock_guard<std::mutex> lk(g_cfg_mu);
     for (const auto& prof : g_profiles) {
       if (prof.id == profile_id) {
-        ta = prof.ta;
+        // Re-signing is level-independent (same keybox and patched root of trust at either level).
+        ta = prof.ta_tee;
         break;
       }
     }

--- a/keystore/keystore_router.cpp
+++ b/keystore/keystore_router.cpp
@@ -461,9 +461,9 @@ TsCreationResult* ImportKey(const PendingKey& k, int uid, const std::vector<KmPa
   std::vector<uint8_t> app_id;
   AddRequiredTags(params, uid, app_id, with_attestation);
   TsCreationResult* res = nullptr;
-  // The legacy Keystore HAL path has no wrapped KeyMint HAL to derive a level
-  // from, so -1 keeps the TA's configured default security level.
-  int32_t rc = teesim_km_import_key(ta.get(), params.data(), params.size(), /*security_level=*/-1,
+  // The legacy Keystore HAL path has a single TA per profile at its configured security level; the
+  // attestation is emitted at that level.
+  int32_t rc = teesim_km_import_key(ta.get(), params.data(), params.size(),
                                     KEY_FORMAT_PKCS8, k.pkcs8.data(), k.pkcs8.size(), nullptr, 0,
                                     nullptr, 0, nullptr, 0, &res);
   if (rc != 0 || !res) {

--- a/rust/teesim-km/README.md
+++ b/rust/teesim-km/README.md
@@ -105,19 +105,26 @@ built once in `Ta::new_ex` from the same boot info generation feeds `kmr-ta`, so
 report an identical one. `Ta` therefore retains a clone of `CertSignInfo` (the batch key
 `kmr-ta` also owns but doesn't expose) alongside the precomputed `patch_rot`.
 
-## Per-request attestation identity
+## Per-level attestation identity
 
-One `Ta` serves both the TEE and StrongBox proxies, so the record's security level and version are
-set per request rather than at construction. Each creation passes the requesting HAL's level;
-`ops.rs::override_attestation_identity` sets `hw_info.security_level` and a raw `attestation_version`
-for that one call and restores them after. The version is stored raw (2/3/4/100/…) so a pre-KeyMint
-device's Keymaster versions survive, and `cert.rs` derives the matching `keyMintVersion` from it
-(Keymaster 4.0 is attestation 3 / keymaster 4, 4.1 is 4 / 41; KeyMint versions are equal). The level
-and version come from the harvest, or are fabricated (TrustedEnvironment and the OS-appropriate
-version) when the device produced no working hardware attestation. The `security_level` /
-`attestation_version` getters and setters this needs are added to `kmr-ta` by
+A real device runs a separate KeyMint instance per security level, so the router builds one `Ta` per
+level (TEE and StrongBox) and routes each request to the instance for the level it arrived on. Each
+instance is fixed at construction: `new_ex` sets `hw_info.security_level` from the config and pins
+`attestation_version` to the version harvested for that level — there is no per-request override, so
+`begin`/`upgrade` read a key's characteristics at the level it was minted at without the router having
+to re-apply anything. The version is stored raw (2/3/4/100/…) so a pre-KeyMint device's Keymaster
+versions survive, and `cert.rs` derives the matching `keyMintVersion` from it (Keymaster 4.0 is
+attestation 3 / keymaster 4, 4.1 is 4 / 41; KeyMint versions are equal). The level and version come
+from the harvest, or are fabricated (TrustedEnvironment and the OS-appropriate version) when the
+device produced no working hardware attestation; a broken StrongBox reuses the TEE version. The
+`set_attestation_version` setter this construction needs is added to `kmr-ta` by
 [`patches/kmr-ta-seclevel.patch`](../patches/kmr-ta-seclevel.patch), applied the same idempotent way
 as the BoringSSL patch below.
+
+Every C-ABI entry that touches a TA handle takes the process-wide `lock_ta()` guard for the duration
+of the call: `kmr-ta` keeps mutable state and is not internally synchronized, but keystore2 drives us
+from a binder thread pool, so this serialization is what keeps concurrent threads from aliasing
+`&mut Ta`.
 
 ## BoringSSL backend
 

--- a/rust/teesim-km/include/teesim_km.h
+++ b/rust/teesim-km/include/teesim_km.h
@@ -115,12 +115,11 @@ void teesim_km_free_buf(uint8_t *ptr, size_t len);
 
 // --- generateKey / importKey -------------------------------------------------
 
-// `security_level` is the level of the real HAL the request came through (0
-// Software, 1 TrustedEnvironment, 2 StrongBox); the attestation record and key
-// characteristics are emitted at that level, overriding the TA's default. A value
-// outside that set keeps the TA's configured default.
+// The attestation record and key characteristics are emitted at this TA instance's fixed security
+// level. Route the request to the TA for the level the request came through (each level has its own
+// instance); there is no per-request override.
 int32_t teesim_km_generate_key(Ta *ta, const KmParam *params, size_t n_params,
-                               int32_t security_level, const uint8_t *ak_blob,
+                               const uint8_t *ak_blob,
                                size_t ak_blob_len, const KmParam *ak_params,
                                size_t ak_n_params, const uint8_t *ak_issuer,
                                size_t ak_issuer_len, TsCreationResult **out);
@@ -133,7 +132,7 @@ int32_t teesim_km_patch_attestation(Ta *ta, const uint8_t *leaf, size_t leaf_len
                                     TsCreationResult **out);
 
 int32_t teesim_km_import_key(Ta *ta, const KmParam *params, size_t n_params,
-                             int32_t security_level, int32_t key_format,
+                             int32_t key_format,
                              const uint8_t *key_data, size_t key_data_len,
                              const uint8_t *ak_blob, size_t ak_blob_len,
                              const KmParam *ak_params, size_t ak_n_params,

--- a/rust/teesim-km/src/capi.rs
+++ b/rust/teesim-km/src/capi.rs
@@ -343,7 +343,6 @@ pub unsafe extern "C" fn teesim_km_generate_key(
     ta: *mut Ta,
     params: *const KmParam,
     n_params: usize,
-    security_level: i32,
     ak_blob: *const u8,
     ak_blob_len: usize,
     ak_params: *const KmParam,
@@ -353,11 +352,12 @@ pub unsafe extern "C" fn teesim_km_generate_key(
     out: *mut *mut TsCreationResult,
 ) -> i32 {
     match call(|| {
+        let _lk = crate::lock_ta();
         let ta = &mut *ta;
         let key_params = to_keyparams(params, n_params)?;
         let attestation_key =
             build_attestation_key(ak_blob, ak_blob_len, ak_params, ak_n_params, ak_issuer, ak_issuer_len)?;
-        let result = ta.generate_key(key_params, attestation_key, security_level)?;
+        let result = ta.generate_key(key_params, attestation_key)?;
         Ok(TsCreationResult::new(result))
     }) {
         Ok(r) => {
@@ -375,7 +375,6 @@ pub unsafe extern "C" fn teesim_km_import_key(
     ta: *mut Ta,
     params: *const KmParam,
     n_params: usize,
-    security_level: i32,
     key_format: i32,
     key_data: *const u8,
     key_data_len: usize,
@@ -388,6 +387,7 @@ pub unsafe extern "C" fn teesim_km_import_key(
     out: *mut *mut TsCreationResult,
 ) -> i32 {
     match call(|| {
+        let _lk = crate::lock_ta();
         let ta = &mut *ta;
         let key_params = to_keyparams(params, n_params)?;
         let format = KeyFormat::n(key_format)
@@ -395,7 +395,7 @@ pub unsafe extern "C" fn teesim_km_import_key(
         let data = if key_data.is_null() { Vec::new() } else { slice::from_raw_parts(key_data, key_data_len).to_vec() };
         let attestation_key =
             build_attestation_key(ak_blob, ak_blob_len, ak_params, ak_n_params, ak_issuer, ak_issuer_len)?;
-        let result = ta.import_key(key_params, format, data, attestation_key, security_level)?;
+        let result = ta.import_key(key_params, format, data, attestation_key)?;
         Ok(TsCreationResult::new(result))
     }) {
         Ok(r) => {
@@ -420,6 +420,7 @@ pub unsafe extern "C" fn teesim_km_patch_attestation(
     out: *mut *mut TsCreationResult,
 ) -> i32 {
     match call(|| {
+        let _lk = crate::lock_ta();
         let ta = &*ta;
         let leaf = if leaf.is_null() { &[][..] } else { slice::from_raw_parts(leaf, leaf_len) };
         let certs = ta.patch_attestation(leaf)?;
@@ -517,6 +518,7 @@ pub unsafe extern "C" fn teesim_km_begin(
     out: *mut *mut TsBeginResult,
 ) -> i32 {
     match call(|| {
+        let _lk = crate::lock_ta();
         let ta = &mut *ta;
         let purpose = KeyPurpose::n(purpose)
             .ok_or(OpError { code: ERR_UNKNOWN, msg: format!("bad purpose {purpose}") })?;
@@ -610,6 +612,7 @@ pub unsafe extern "C" fn teesim_km_update(
     out_len: *mut usize,
 ) -> i32 {
     match call(|| {
+        let _lk = crate::lock_ta();
         let ta = &mut *ta;
         let data = if input.is_null() { Vec::new() } else { slice::from_raw_parts(input, input_len).to_vec() };
         ta.update(op_handle, data, auth_token(auth_token_ptr), timestamp_token(timestamp_token_ptr))
@@ -634,6 +637,7 @@ pub unsafe extern "C" fn teesim_km_update_aad(
     timestamp_token_ptr: *const TsTimestampToken,
 ) -> i32 {
     match call(|| {
+        let _lk = crate::lock_ta();
         let ta = &mut *ta;
         let data = if input.is_null() { Vec::new() } else { slice::from_raw_parts(input, input_len).to_vec() };
         ta.update_aad(op_handle, data, auth_token(auth_token_ptr), timestamp_token(timestamp_token_ptr))
@@ -661,6 +665,7 @@ pub unsafe extern "C" fn teesim_km_finish(
     out_len: *mut usize,
 ) -> i32 {
     match call(|| {
+        let _lk = crate::lock_ta();
         let ta = &mut *ta;
         ta.finish(
             op_handle,
@@ -683,7 +688,10 @@ pub unsafe extern "C" fn teesim_km_finish(
 /// See module docs.
 #[no_mangle]
 pub unsafe extern "C" fn teesim_km_abort(ta: *mut Ta, op_handle: i64) -> i32 {
-    match call(|| (&mut *ta).abort(op_handle)) {
+    match call(|| {
+        let _lk = crate::lock_ta();
+        (&mut *ta).abort(op_handle)
+    }) {
         Ok(()) => 0,
         Err(code) => code,
     }
@@ -695,7 +703,10 @@ pub unsafe extern "C" fn teesim_km_abort(ta: *mut Ta, op_handle: i64) -> i32 {
 /// `ta` is a valid TA handle.
 #[no_mangle]
 pub unsafe extern "C" fn teesim_km_early_boot_ended(ta: *mut Ta) -> i32 {
-    match call(|| (&mut *ta).early_boot_ended()) {
+    match call(|| {
+        let _lk = crate::lock_ta();
+        (&mut *ta).early_boot_ended()
+    }) {
         Ok(()) => 0,
         Err(code) => code,
     }
@@ -710,6 +721,7 @@ pub unsafe extern "C" fn teesim_km_set_additional_attestation_info(
     n_info: usize,
 ) -> i32 {
     match call(|| {
+        let _lk = crate::lock_ta();
         let ta = &mut *ta;
         let params = to_keyparams(info, n_info)?;
         ta.set_additional_attestation_info(params)
@@ -726,6 +738,7 @@ pub unsafe extern "C" fn teesim_km_set_additional_attestation_info(
 #[no_mangle]
 pub unsafe extern "C" fn teesim_km_delete_key(ta: *mut Ta, key_blob: *const u8, key_blob_len: usize) -> i32 {
     match call(|| {
+        let _lk = crate::lock_ta();
         let blob = if key_blob.is_null() { &[][..] } else { slice::from_raw_parts(key_blob, key_blob_len) };
         (&mut *ta).delete_key(blob)
     }) {
@@ -747,6 +760,7 @@ pub unsafe extern "C" fn teesim_km_upgrade_key(
     out_len: *mut usize,
 ) -> i32 {
     match call(|| {
+        let _lk = crate::lock_ta();
         let ta = &mut *ta;
         let blob = if key_blob.is_null() { &[][..] } else { slice::from_raw_parts(key_blob, key_blob_len) };
         let upgrade_params = to_keyparams(params, n_params)?;
@@ -779,6 +793,7 @@ pub unsafe extern "C" fn teesim_km_get_key_characteristics(
     out: *mut *mut TsCharacteristics,
 ) -> i32 {
     match call(|| {
+        let _lk = crate::lock_ta();
         let ta = &mut *ta;
         let blob = if key_blob.is_null() { &[][..] } else { slice::from_raw_parts(key_blob, key_blob_len) };
         let id = if app_id.is_null() { Vec::new() } else { slice::from_raw_parts(app_id, app_id_len).to_vec() };

--- a/rust/teesim-km/src/device.rs
+++ b/rust/teesim-km/src/device.rs
@@ -41,6 +41,21 @@ impl crypto::MonotonicClock for Clock {
     }
 }
 
+/// Wall-clock time as milliseconds since the Unix epoch, backed by `CLOCK_REALTIME`.
+///
+/// This is the value keystore2 would stamp into `Tag::CREATION_DATETIME`; we need it
+/// because the emulation wrapper around this device's Keymaster 4.0 HAL reports a
+/// pre-KeyMint version, so keystore2 never adds the tag itself (see `ops::ensure_creation_datetime`).
+pub fn realtime_ms_since_epoch() -> i64 {
+    let mut time = libc::timespec { tv_sec: 0, tv_nsec: 0 };
+    // Safety: `time` is a valid structure that the call fills in.
+    let rc = unsafe { libc::clock_gettime(libc::CLOCK_REALTIME, &mut time) };
+    if rc < 0 {
+        return 0;
+    }
+    (time.tv_sec * 1000) + (time.tv_nsec / 1_000_000)
+}
+
 /// Stub remote-provisioning artifacts. The interceptor never routes
 /// IRemotelyProvisionedComponent calls here, so only `derive_bytes_from_hbk`
 /// needs to work (and only to be deterministic).

--- a/rust/teesim-km/src/ffi.rs
+++ b/rust/teesim-km/src/ffi.rs
@@ -196,6 +196,7 @@ pub unsafe extern "C" fn teesim_km_process(
         if handle.is_null() || req_ptr.is_null() || out_ptr.is_null() || out_len.is_null() {
             return -1;
         }
+        let _lk = crate::lock_ta();
         let ta = &mut *handle;
         let req = slice::from_raw_parts(req_ptr, req_len);
         let rsp = ta.process(req);
@@ -236,6 +237,8 @@ pub unsafe extern "C" fn teesim_km_destroy(handle: *mut Ta) {
         return;
     }
     let _ = catch_unwind(AssertUnwindSafe(|| {
+        // Serialize against any in-flight operation on this handle before freeing it.
+        let _lk = crate::lock_ta();
         drop(Box::from_raw(handle));
     }));
 }

--- a/rust/teesim-km/src/lib.rs
+++ b/rust/teesim-km/src/lib.rs
@@ -46,6 +46,27 @@ pub fn is_marked(blob: &[u8]) -> bool {
     blob.starts_with(BLOB_MARKER)
 }
 
+/// Serializes every C-ABI entry that dereferences a TA handle.
+///
+/// The reference `KeyMintTa` keeps mutable state (the in-flight operation table, RNG) and is not
+/// internally synchronized: a TA runs single-threaded in its own secure world. We instead run it
+/// in-process under keystore2's binder thread pool, which dispatches concurrent calls to the same
+/// device, so without this every `&mut *ta` in `capi`/`ffi` would alias across threads (UB). Held
+/// only for the duration of a single call — never across a begin/finish pair — so an open operation
+/// never blocks unrelated ones; the operation table keeps the per-op state between calls.
+///
+/// This is a coarse process-wide lock: it serializes across all TA instances, not just aliasing
+/// accesses to one. That is fine because key operations are infrequent; it could be refined to a
+/// per-instance lock later. Poison from a panic (caught by `capi::call`) is ignored — the guarded
+/// state is the TA's own and stays consistent enough to keep serving.
+static TA_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Acquire the TA serialization lock; recovers from a poisoned mutex. Hold the returned guard across
+/// any `&mut *ta` / `Ta::process` access, then drop it.
+pub(crate) fn lock_ta() -> std::sync::MutexGuard<'static, ()> {
+    TA_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
 /// Assemble the software crypto backend around BoringSSL and the boot-time clock.
 fn crypto_impls() -> crypto::Implementation {
     crypto::Implementation {
@@ -76,11 +97,6 @@ pub struct Ta {
     /// The profile's root of trust (locked/Verified) as a DER `RootOfTrust` SEQUENCE, spliced into a
     /// real leaf's attestation extension in patch mode. Identical to what generation emits.
     patch_rot: Vec<u8>,
-    /// KeyMint HAL versions harvested at each level. The per-request override (see
-    /// `override_attestation_identity`) sets the record's attestation/keymint version to match the
-    /// HAL the request came through, so a generated key claims the real device's version.
-    attest_version_tee: i32,
-    attest_version_strongbox: i32,
     /// Profile OS / vendor / boot security levels. Patch mode writes these into a real leaf's
     /// attestation (see `patch_attestation`) so a patched record reports the profile's — typically
     /// fresh — patch level rather than the device's genuine, often stale, one. Generation feeds the
@@ -206,6 +222,16 @@ impl Ta {
 
         let mut inner = KeyMintTa::new(hw_info, RpcInfo::V3(rpc_info), crypto_impls(), dev);
 
+        // This TA instance is fixed at one security level (a real device runs a separate KeyMint
+        // instance per level). Pin the attestation record's version to the one harvested for that
+        // level so a generated key claims the real HAL's version; there is no per-request override.
+        let attestation_version = if security_level == SecurityLevel::Strongbox {
+            cfg.attest_version_strongbox
+        } else {
+            cfg.attest_version_tee
+        };
+        inner.set_attestation_version(attestation_version);
+
         let verified_boot_state = match cfg.verified_boot_state {
             1 => VerifiedBootState::SelfSigned,
             2 => VerifiedBootState::Unverified,
@@ -244,8 +270,6 @@ impl Ta {
             inner,
             sign_info,
             patch_rot,
-            attest_version_tee: cfg.attest_version_tee,
-            attest_version_strongbox: cfg.attest_version_strongbox,
             os_version: cfg.os_version,
             os_patchlevel: cfg.os_patchlevel,
             vendor_patchlevel: cfg.vendor_patchlevel,

--- a/rust/teesim-km/src/ops.rs
+++ b/rust/teesim-km/src/ops.rs
@@ -5,10 +5,10 @@
 // arguments coming from keystore2 have our marker stripped before they reach the
 // TA; blobs we hand back get the marker applied so later operations route here.
 
-use crate::{as_array, mark_blob, strip_marker, OpError, Ta};
+use crate::{as_array, device, mark_blob, strip_marker, OpError, Ta};
 use kmr_wire::keymint::{
-    AttestationKey, HardwareAuthToken, KeyCharacteristics, KeyCreationResult, KeyFormat, KeyParam,
-    KeyPurpose, SecurityLevel,
+    AttestationKey, DateTime, HardwareAuthToken, KeyCharacteristics, KeyCreationResult, KeyFormat,
+    KeyParam, KeyPurpose, Tag,
 };
 use kmr_wire::secureclock::TimeStampToken;
 use kmr_wire::{
@@ -63,87 +63,48 @@ impl Ta {
         Rsp::from_cbor_value(resp_value).map_err(|e| local(format!("{e:?}")))
     }
 
-    /// Apply a per-request attestation identity — security level and KeyMint HAL version — to the
-    /// inner TA for the duration of one generateKey/importKey, returning the previous pair to restore
-    /// afterwards. The record's `attestationSecurityLevel` / `keymasterSecurityLevel` and the
-    /// KeyCharacteristics `securityLevel` follow `hw_info.security_level`; its `attestationVersion`
-    /// follows the TA's raw `attestation_version` (and `keyMintVersion` is derived from it in cert.rs).
-    /// Overriding both makes the record reflect the real HAL the request came through: `security_level`
-    /// picks the level (0 Software, 1 TrustedEnvironment, 2 StrongBox) and the version harvested (or
-    /// fabricated) at that level (StrongBox falling back to the TEE version). A level outside the known
-    /// set leaves the TA's defaults in place.
-    fn override_attestation_identity(&mut self, security_level: i32) -> Option<(SecurityLevel, i32)> {
-        let level = match security_level {
-            0 => SecurityLevel::Software,
-            1 => SecurityLevel::TrustedEnvironment,
-            2 => SecurityLevel::Strongbox,
-            _ => return None,
-        };
-        let prev = (self.inner.security_level(), self.inner.attestation_version());
-        self.inner.set_security_level(level);
-        let version = match level {
-            SecurityLevel::Strongbox => self.attest_version_strongbox,
-            _ => self.attest_version_tee,
-        };
-        self.inner.set_attestation_version(version);
-        Some(prev)
-    }
-
-    /// generateKey. The returned key blob carries our marker. `security_level` is
-    /// the level of the HAL the request came through; the attestation is emitted at
-    /// that level, with the KeyMint version harvested for it (see
-    /// `override_attestation_identity`).
+    /// generateKey. The returned key blob carries our marker. This TA instance is fixed at one
+    /// security level, so the record's `attestationSecurityLevel` and version come from the instance
+    /// the request was routed to — no per-request override.
     pub fn generate_key(
         &mut self,
-        key_params: Vec<KeyParam>,
+        mut key_params: Vec<KeyParam>,
         attestation_key: Option<AttestationKey>,
-        security_level: i32,
     ) -> Result<KeyCreationResult, OpError> {
         log::info!(
-            "teesim_km: generate_key: {} param(s), security_level={}, attest_key={}",
+            "teesim_km: generate_key: {} param(s), security_level={:?}, attest_key={}",
             key_params.len(),
-            security_level,
+            self.inner.security_level(),
             attestation_key.is_some()
         );
-        let restore = self.override_attestation_identity(security_level);
+        ensure_creation_datetime(&mut key_params);
         let resp: Result<GenerateKeyResponse, OpError> =
             self.perform(GenerateKeyRequest { key_params, attestation_key });
-        if let Some((level, version)) = restore {
-            self.inner.set_security_level(level);
-            self.inner.set_attestation_version(version);
-        }
         let ret = resp?.ret;
         crate::resign::log_chain("teesim_km: generate_key result", &ret.certificate_chain);
         Ok(marked_result(ret))
     }
 
-    /// importKey. The returned key blob carries our marker. `security_level` is
-    /// the level of the HAL the request came through; the attestation is emitted at
-    /// that level, with the KeyMint version harvested for it (see
-    /// `override_attestation_identity`).
+    /// importKey. The returned key blob carries our marker. As with `generate_key`, the attestation
+    /// level and version follow this fixed-level TA instance.
     pub fn import_key(
         &mut self,
-        key_params: Vec<KeyParam>,
+        mut key_params: Vec<KeyParam>,
         key_format: KeyFormat,
         key_data: Vec<u8>,
         attestation_key: Option<AttestationKey>,
-        security_level: i32,
     ) -> Result<KeyCreationResult, OpError> {
         log::info!(
-            "teesim_km: import_key: {} param(s), format={:?}, {} key bytes, security_level={}, attest_key={}",
+            "teesim_km: import_key: {} param(s), format={:?}, {} key bytes, security_level={:?}, attest_key={}",
             key_params.len(),
             key_format,
             key_data.len(),
-            security_level,
+            self.inner.security_level(),
             attestation_key.is_some()
         );
-        let restore = self.override_attestation_identity(security_level);
+        ensure_creation_datetime(&mut key_params);
         let resp: Result<ImportKeyResponse, OpError> =
             self.perform(ImportKeyRequest { key_params, key_format, key_data, attestation_key });
-        if let Some((level, version)) = restore {
-            self.inner.set_security_level(level);
-            self.inner.set_attestation_version(version);
-        }
         let ret = resp?.ret;
         crate::resign::log_chain("teesim_km: import_key result", &ret.certificate_chain);
         Ok(marked_result(ret))
@@ -292,6 +253,27 @@ impl Ta {
         })?;
         Ok(resp.ret)
     }
+}
+
+/// Stamp `Tag::CREATION_DATETIME` into the parameters when keystore2 has not already done so.
+///
+/// On a genuine KeyMint device keystore2 always adds this tag before generateKey/importKey
+/// (`add_required_parameters`, gated on `hw_info.versionNumber >= 100`), and the reference TA both
+/// records it in the software-enforced attestation list and requires it whenever `INCLUDE_UNIQUE_ID`
+/// is set (unique-id derivation folds in the creation time). This device's KeyMaster 4.0 HAL is
+/// exposed to keystore2 through an emulation wrapper that reports version 40, so keystore2 skips the
+/// tag entirely: unique-id requests (Google Wallet / device-ID attestation) then fail with
+/// `INVALID_ARGUMENT`, and even ordinary attestations omit `creationDateTime` that a real device
+/// would carry. Adding it here reproduces the value keystore2 would have supplied.
+///
+/// Left untouched if the tag is already present, so a genuine KeyMint backend's value always wins.
+fn ensure_creation_datetime(params: &mut Vec<KeyParam>) {
+    if params.iter().any(|p| p.tag() == Tag::CreationDatetime) {
+        return;
+    }
+    let ms_since_epoch = device::realtime_ms_since_epoch();
+    log::info!("teesim_km: adding CreationDatetime={ms_since_epoch} (keystore2 omitted it)");
+    params.push(KeyParam::CreationDatetime(DateTime { ms_since_epoch }));
 }
 
 /// Apply our marker to the key blob inside a creation result.


### PR DESCRIPTION
Operations on one of our key blobs ran through a single default TA fixed at `TrustedEnvironment`, but a blob carries its characteristics at the level it was minted at. A StrongBox (or Software) key therefore failed `begin`/`upgradeKey` with `no parameters at security level TrustedEnvironment found` — the reference TA's [`characteristics_at(hw_info.security_level)`](https://android.googlesource.com/platform/system/keymint/+/refs/heads/main/common/src/tag.rs) finds no authorization list at the wrong level — so an app could no longer use a key it had generated (`com.worldcoin`'s symmetric keys, here). `generateKey` had stamped the correct level through a per-request override that `begin` and `upgradeKey` never re-applied.

A real device runs an independent [KeyMint](https://android.googlesource.com/platform/hardware/interfaces/+/refs/heads/main/security/keymint/aidl/android/hardware/security/keymint/SecurityLevel.aidl) instance per security level, so the router now mirrors that:

- Each profile builds one fixed-level TA per level (`Profile::ta_tee` / `ta_strongbox`, selected by `TaFor`). Every request — and every operation on our blobs, via `DefaultTaFor(level_)` — routes to the instance for the level it arrived on.
- Each TA pins its `security_level` and `attestationVersion` at construction, so the record follows the instance with no override to forget and characteristics are always read at the level the key was minted at. The per-request `override_attestation_identity` and the `security_level` argument to `teesim_km_generate_key`/`import_key` are gone.
- Both instances share the level-independent key-encryption key, so any of our blobs decrypts under either. The legacy keystore1 path is single-level and unchanged beyond dropping that argument.

The reference kmr-ta keeps mutable state and is not internally synchronized, yet keystore2 drives our device from a binder thread pool, so concurrent calls aliased `&mut Ta`. Every C-ABI entry that dereferences a handle now holds a process-wide `lock_ta()` guard for the call, serializing binder threads on the TA rather than racing its operation table and RNG (a per-instance lock is a later refinement).

Also fixes #241 (Google Wallet card setup on a broken-TEE device). keystore2 [adds `CREATION_DATETIME` only when the backend reports `versionNumber >= 100`](https://android.googlesource.com/platform/system/security/+/refs/heads/main/keystore2/src/security_level.rs), but a KeyMaster 4.0 HAL behind keystore2's emulation wrapper reports 40, so the tag never reaches the request. kmr-ta requires it whenever `INCLUDE_UNIQUE_ID` is set — GMS device-ID attestation does — and rejected those keys with `INVALID_ARGUMENT`, while v3.2's hand-rolled attestation never needed it. The TA shim now stamps `CREATION_DATETIME` from the wall clock when it is absent, exactly the value keystore2 would have supplied, so unique-id attestations succeed and ordinary records carry the `creationDateTime` a genuine device would.
