### PR TITLE
Target apps per Android user so work profiles can be scoped

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -64,17 +64,30 @@ Once the framework is up, `App.main` wires the daemon and enters `Looper.loop()`
    returns without registering, so such a watcher looks healthy while never firing once. Re-reading
    the installed-app set on demand is the only thing that actually works, on every release.
 
-   **`Scope`** is the one place a profile's `apps[]` becomes the two wire arrays the native router
+   **`Scope`** is the one place a profile's `apps[]` becomes the wire arrays the native router
    matches on — `packages[]` (attestation package-name match, kept verbatim so a not-yet-installed
-   name still matches once the app lands) and `uids[]` (caller-uid match, the effective set with no
-   `-1`). An `apps[]` entry is a package name, an advanced `uid:N` token that targets a caller uid
-   directly (for a shared-uid app or one whose package is unknown), or — per profile —
-   `autoIncludeNewApps`, which folds in only apps installed AFTER a one-time baseline snapshot
-   (`known_packages.json`, seeded from the currently-installed set the first time the daemon runs), so
-   genuinely new apps are covered without an edit while existing apps are never silently captured. Every
-   entry is logged as it resolves (`Scope[<id>]: 'com.foo' -> uid 10123`, `-> NOT INSTALLED (dropped)`),
-   and a uid below the app range (a `shell`/`system_server`-style uid) is flagged with a warning — the
-   instrumentation that makes "which app is actually intercepted" answerable from the log.
+   name still matches once the app lands) with `packageUsers[]` beside it, and `uids[]` (caller-uid
+   match, the effective set with no `-1`) with `uidPackages[]` beside it. An `apps[]` entry is a
+   package name, the same name suffixed `@<user>` for an app inside another Android user, an advanced
+   `uid:N` token that targets a caller uid directly (for a shared-uid app or one whose package is
+   unknown), or — per profile — `autoIncludeNewApps`, which folds in only apps installed AFTER a
+   one-time baseline snapshot (`known_packages.json`, seeded from the currently-installed set the
+   first time the daemon runs), so genuinely new apps are covered without an edit while existing apps
+   are never silently captured. Every entry is logged as it resolves
+   (`Scope[<id>]: 'com.foo' -> uid 10123 (user 0)`, `-> NOT INSTALLED for user 10 (dropped)`), and a
+   uid whose app id is below the app range (a `shell`/`system_server`-style uid, in any user) is
+   flagged with a warning — the instrumentation that makes "which app is actually intercepted"
+   answerable from the log.
+
+   **Android users.** A work profile or a secondary user runs its own copy of an app under its own
+   uid (`userId * 100000 + appId`), so it is a separate caller to keystore and is targeted separately:
+   `com.foo` is the primary user's copy, `com.foo@10` the copy inside user 10. **`Packages`**
+   enumerates every user (`IUserManager`, falling back to the `/data/system/users` directories) and
+   every user's apps (`IPackageManager`'s per-user overloads, which the daemon may call because
+   PackageManagerService waives its cross-user permission check for uid 0), so the Scope picker lists
+   and labels them all. The name-match leg carries `packageUsers[]` because an attestation application
+   id names the package but never the user — without it, one user's entry would answer for the
+   other's copy.
 3. **`Injector`** finds the keystore daemon's pid (`keystore2` on API ≥ 31, `keystore` on 10/11),
    runs the packaged `inject` binary to load the right interceptor, and re-injects whenever the
    pid changes; it confirms the library actually checked in over `@teesim` and warns otherwise

--- a/app/src/main/java/org/matrix/teesim/App.kt
+++ b/app/src/main/java/org/matrix/teesim/App.kt
@@ -363,9 +363,13 @@ object App {
             val pkg = Packages.packagesForUid(uid).firstOrNull()?.takeIf { it.isNotEmpty() }
                 ?: hint.takeIf { it.isNotEmpty() }
                 ?: continue // no resolvable package: leave the cursor untouched so the count isn't lost
+            // Remembered under the app token, not the bare package: a work profile's copy of an app is
+            // a different caller and deserves its own count, and the token is also what the Scope
+            // picker and config.json spell it as.
+            val token = Scope.entryToken(pkg, Packages.userIdOf(uid))
             // lastBootMs is on CLOCK_BOOTTIME; the same offset (wallNow - bootNowMs) maps it to wall time.
             val lastUsedEpoch = if (lastBootMs > 0) wallNow - (bootNowMs - lastBootMs) else wallNow
-            UsageStore.applyLibSample(uid, pkg, current, lastUsedEpoch)
+            UsageStore.applyLibSample(uid, token, current, lastUsedEpoch)
             recorded++
         }
         SystemLogger.info("usage poll: ${apps.length()} uid(s) reported, $recorded merged")

--- a/app/src/main/java/org/matrix/teesim/ConfigStore.kt
+++ b/app/src/main/java/org/matrix/teesim/ConfigStore.kt
@@ -13,8 +13,10 @@ object ConfigStore {
 
     class ConfigException(message: String) : Exception(message)
 
-    // The two accepted apps[] entry shapes: a package name, or the advanced raw-uid token uid:N.
-    private val PKG_RE = Regex("^[A-Za-z0-9_.]+$")
+    // The accepted apps[] entry shapes: a package name (the app as installed for the primary user),
+    // the same name suffixed with @N for Android user N (a work profile or a secondary user), or the
+    // advanced raw-uid token uid:N.
+    private val PKG_RE = Regex("^[A-Za-z0-9_.]+(@\\d+)?$")
     private val UID_RE = Regex("^uid:\\d+$")
 
     /** One profile as written by the WebUI, before resolution against the device. */
@@ -106,13 +108,13 @@ object ConfigStore {
             if (apps.isEmpty() && !autoIncludeNewApps)
                 throw ConfigException("profile '$id' has no apps (and does not auto-include new apps)")
 
-            // Each apps[] entry is either a package name or the advanced raw-uid token uid:N. Validate
-            // the shape here so a typo can't silently slip through to routing, and keep the per-entry
-            // uniqueness (a package name OR a uid token may live in only one profile — the router needs
-            // exactly one owner per caller).
+            // Each apps[] entry is a package name, a pkg@user name, or the advanced raw-uid token
+            // uid:N. Validate the shape here so a typo can't silently slip through to routing, and keep
+            // the per-entry uniqueness (a package/user pair OR a uid token may live in only one profile
+            // — the router needs exactly one owner per caller).
             for (entry in apps) {
                 if (PKG_RE.matches(entry)) {
-                    // a plain package name — nothing further to validate
+                    // a package name, optionally naming the user it lives in — nothing further to validate
                 } else if (UID_RE.matches(entry)) {
                     val n = entry.substring(4).toIntOrNull()
                     if (n == null || n < 0)
@@ -121,7 +123,8 @@ object ConfigStore {
                         )
                 } else {
                     throw ConfigException(
-                        "profile '$id' app entry '$entry' is neither a package name nor a uid:N token"
+                        "profile '$id' app entry '$entry' is neither a package name (optionally " +
+                            "@<user>) nor a uid:N token"
                     )
                 }
                 val prev = seenApps.put(entry, id)
@@ -134,10 +137,12 @@ object ConfigStore {
                 // the SAME caller uid — a package vs a uid:N token (com.foo vs uid:10123), or two packages
                 // that share a uid (a sharedUserId pair). Both would put two profiles' keyboxes on one
                 // caller (last-writer-wins in routing). Reject on the effective uid too, when it resolves.
+                // Scope.parse is what splits pkg@user, so the uid compared here is the per-user one: the
+                // same package in two users is two callers and may legitimately sit in two profiles.
                 val uid =
                     when {
                         UID_RE.matches(entry) -> entry.substring(4).toIntOrNull() ?: -1
-                        else -> Packages.uidForPackage(entry)
+                        else -> Scope.parse(entry).uid
                     }
                 if (uid >= 0) {
                     val prevUid = seenUids.put(uid, id)

--- a/app/src/main/java/org/matrix/teesim/KeyAdmin.kt
+++ b/app/src/main/java/org/matrix/teesim/KeyAdmin.kt
@@ -69,7 +69,8 @@ object KeyAdmin {
 
     private const val ATTEST_OID = "1.3.6.1.4.1.11129.2.1.17"
     // A plausible package name for the /icon query, so a caller can't smuggle path/argument junk through
-    // ?pkg= into PackageManager. Same shape ConfigStore validates apps[] package entries with.
+    // ?pkg= into PackageManager. Same shape ConfigStore validates apps[] package entries with (the
+    // user an icon should be looked up in rides in its own ?user= parameter, not in the name).
     private val PKG_RE = Regex("^[A-Za-z0-9_.]+$")
     // Upper bound on a request body (bytes). The admin socket is localhost + token-authed, but a bogus
     // Content-Length should still never be trusted as an allocation size.
@@ -408,7 +409,14 @@ object KeyAdmin {
                     JSONObject()
                         .put("id", s.profileId)
                         .put("autoInclude", s.autoInclude)
-                        .put("packages", JSONArray(s.packageNames))
+                        // The entries as written, so a pkg@user target reads as one — packageNames
+                        // alone would show two users' copies of an app as the same line twice.
+                        .put(
+                            "packages",
+                            JSONArray(
+                                s.explicit.filter { it.pkg != null }.map { it.entry }
+                            ),
+                        )
                         .put("explicitUids", JSONArray((s.uids - s.autoUids).sorted()))
                         .put("autoUids", JSONArray(autos))
                 )
@@ -426,13 +434,18 @@ object KeyAdmin {
     }
 
     /**
-     * Every installed app, one entry per uid, for the WebUI's Scope picker. The daemon runs
-     * as root so [Packages.installedAppsByUid] sees all apps; `system` additionally folds in any uid
-     * below the first app uid. Each entry also carries the usage face the picker sorts/badges on:
-     * `installTime`, and (from [UsageStore], reduced over the entry's package names) `freq` (max count),
+     * Every installed app, one entry per uid, for the WebUI's Scope picker. The daemon runs as root so
+     * [Packages.installedAppsByUid] sees all apps in every Android user — an app installed in both the
+     * primary user and a work profile is two entries, with two uids, because it is two callers to
+     * keystore. `system` additionally folds in any privileged uid (its app id below the first app uid,
+     * in whichever user). Each entry also carries the usage face the picker sorts/badges on:
+     * `installTime`, and (from [UsageStore], reduced over the entry's app tokens) `freq` (max count),
      * `lastUsed` (max epoch), `recent` (any package seen this boot). Sorted server-side by label then uid;
      * the client re-sorts per its chosen order. A best-effort usage poll runs first so the freq/recent
      * columns reflect the very latest requests without waiting for the 15s background poll.
+     *
+     * `users` lists the device's users so the picker can label and group by them without inventing
+     * names from uid arithmetic.
      */
     private fun packages(): JSONObject {
         try {
@@ -447,15 +460,19 @@ object KeyAdmin {
             )
         val arr = JSONArray()
         for (e in entries) {
-            val freq = e.packages.maxOfOrNull { UsageStore.freqOf(it) } ?: 0L
-            val lastUsed = e.packages.maxOfOrNull { UsageStore.lastUsedOf(it) } ?: 0L
-            val recent = e.packages.any { UsageStore.isRecent(it) }
+            // Usage is remembered per app token (pkg, or pkg@user outside the primary user), so the
+            // work profile's copy of an app carries its own request count rather than the other's.
+            val tokens = e.packages.map { Scope.entryToken(it, e.userId) }
+            val freq = tokens.maxOfOrNull { UsageStore.freqOf(it) } ?: 0L
+            val lastUsed = tokens.maxOfOrNull { UsageStore.lastUsedOf(it) } ?: 0L
+            val recent = tokens.any { UsageStore.isRecent(it) }
             arr.put(
                 JSONObject()
                     .put("uid", e.uid)
+                    .put("userId", e.userId)
                     .put("packages", JSONArray(e.packages))
                     .put("label", e.label)
-                    .put("system", e.system || e.uid < firstAppUid)
+                    .put("system", e.system || Scope.isPrivilegedUid(e.uid))
                     .put("launchable", e.launchable)
                     .put("enabled", e.enabled)
                     .put("installTime", e.installTime)
@@ -464,10 +481,17 @@ object KeyAdmin {
                     .put("recent", recent)
             )
         }
-        SystemLogger.info("KeyAdmin: /packages -> ${entries.size} uid entr(ies), firstAppUid=$firstAppUid")
+        val users = JSONArray()
+        for (u in Packages.users())
+            users.put(JSONObject().put("id", u.id).put("name", u.name).put("managed", u.managed))
+        SystemLogger.info(
+            "KeyAdmin: /packages -> ${entries.size} uid entr(ies) across ${users.length()} user(s), " +
+                "firstAppUid=$firstAppUid"
+        )
         return JSONObject()
             .put("ok", true)
             .put("firstAppUid", firstAppUid)
+            .put("users", users)
             .put("apps", arr)
     }
 
@@ -495,7 +519,8 @@ object KeyAdmin {
     }
 
     /**
-     * Stream the rendered PNG icon for `?pkg=`. Validates the package shape before touching
+     * Stream the rendered PNG icon for `?pkg=`, looked up in `?user=` (default 0, so an app that only
+     * exists in a work profile still resolves). Validates the package shape before touching
      * PackageManager, answers 404 (as JSON) when the package has no icon or rendering fails, and relies
      * on [Packages.iconPng]'s in-memory cache so a scrolling list of <img> hits stays cheap.
      */
@@ -505,7 +530,12 @@ object KeyAdmin {
             respond(out, 400, JSONObject().put("ok", false).put("error", "bad pkg"))
             return
         }
-        val png = Packages.iconPng(pkg)
+        val user = query["user"]?.toIntOrNull() ?: 0
+        if (user < 0) {
+            respond(out, 400, JSONObject().put("ok", false).put("error", "bad user"))
+            return
+        }
+        val png = Packages.iconPng(pkg, user)
         if (png == null) {
             respond(out, 404, JSONObject().put("ok", false).put("error", "no icon"))
             return

--- a/app/src/main/java/org/matrix/teesim/Packages.kt
+++ b/app/src/main/java/org/matrix/teesim/Packages.kt
@@ -290,13 +290,26 @@ object Packages {
         return out
     }
 
+    /**
+     * Installed package names per Android user id, primary user first. One enumeration per user and
+     * nothing else — no labels, icons, install times or launcher probes — because the baseline paths
+     * that use it care only about which names exist, and would otherwise pay two binder calls per
+     * package for answers they throw away.
+     */
+    fun installedPackageNamesByUser(): Map<Int, Set<String>> {
+        val out = LinkedHashMap<Int, Set<String>>()
+        for (user in users())
+            out[user.id] = installedApplications(user.id).mapTo(HashSet()) { it.packageName }
+        return out
+    }
+
     /** Every installed package name on the device, in every user, for the auto-include baseline seed.
      *  Empty on failure so a broken enumeration never seeds an empty baseline that later mislabels
      *  everything new. The set is user-agnostic on purpose: the baseline answers "did this app exist
      *  when TEESimulator first ran", which is a question about the app, not about one user's copy. */
     fun allInstalledPackageNames(): Set<String> {
         val out = HashSet<String>()
-        for (user in users()) installedApplications(user.id).mapTo(out) { it.packageName }
+        for (names in installedPackageNamesByUser().values) out.addAll(names)
         if (out.isEmpty()) SystemLogger.warning("allInstalledPackageNames: enumeration came back empty")
         return out
     }

--- a/app/src/main/java/org/matrix/teesim/Packages.kt
+++ b/app/src/main/java/org/matrix/teesim/Packages.kt
@@ -1,23 +1,30 @@
 package org.matrix.teesim
 
 import android.content.Context
+import android.content.Intent
 import android.content.pm.ApplicationInfo
 import android.content.pm.IPackageManager
 import android.content.pm.PackageManager
+import android.content.pm.ParceledListSlice
+import android.content.pm.ResolveInfo
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import android.os.Build
+import android.os.IUserManager
 import android.os.Process
 import android.os.ServiceManager
 import android.util.LruCache
 import java.io.ByteArrayOutputStream
+import java.io.File
 
 /**
- * Package-name to uid resolution. Prefers the public [PackageManager] from the system context (it
- * hides the per-version aidl flag drift); keeps an [IPackageManager] handle for the reverse uid to
- * package-name mapping the legacy path needs.
+ * Package-name to uid resolution, across every Android user on the device. The public
+ * [PackageManager] from the system context answers for user 0 (it hides the per-version aidl flag
+ * drift); a work profile or a secondary user lives behind [IPackageManager]'s per-user overloads,
+ * which the daemon may call because it runs as root — PackageManagerService waives its
+ * cross-user permission check for uid 0.
  */
 object Packages {
 
@@ -27,27 +34,191 @@ object Packages {
         pm = context.packageManager
     }
 
-    /** Resolve a package name to its app uid, or -1 when it is not installed. */
-    fun uidForPackage(pkg: String): Int =
-        try {
-            @Suppress("DEPRECATION") pm.getPackageUid(pkg, 0)
-        } catch (e: PackageManager.NameNotFoundException) {
-            -1
-        } catch (e: Exception) {
-            SystemLogger.warning("uidForPackage($pkg) failed", e)
-            -1
-        }
+    // android.os.UserHandle.PER_USER_RANGE: the stride between two users' uids for the same app.
+    // A uid is therefore userId * 100000 + appId — user 0's Play Store is 10123, the work
+    // profile's clone of it is 1010123, and the two are different callers to keystore.
+    const val PER_USER_RANGE = 100000
+
+    /** The Android user a caller uid belongs to (0 for the primary/owner user). */
+    fun userIdOf(uid: Int): Int = if (uid < 0) 0 else uid / PER_USER_RANGE
+
+    /** The per-user uid of [appId] (a uid with its user stripped) inside user [userId]. */
+    fun uidOf(userId: Int, appId: Int): Int = userId * PER_USER_RANGE + appId % PER_USER_RANGE
+
+    /**
+     * Resolve a package name to its app uid inside [userId], or -1 when it is not installed there.
+     * User 0 goes through the public PackageManager (the path this has always taken); another user
+     * is asked of the package service directly, which is the only way to see a work profile.
+     */
+    fun uidForPackage(pkg: String, userId: Int = 0): Int =
+        if (userId == 0)
+            try {
+                @Suppress("DEPRECATION") pm.getPackageUid(pkg, 0)
+            } catch (e: PackageManager.NameNotFoundException) {
+                -1
+            } catch (e: Exception) {
+                SystemLogger.warning("uidForPackage($pkg) failed", e)
+                -1
+            }
+        else applicationInfoAsUser(pkg, userId)?.uid ?: -1
 
     /** The first uid the platform hands to a normal app; anything below is a system/shell uid. */
     fun firstAppUid(): Int = Process.FIRST_APPLICATION_UID
+
+    // --- users (work profiles and secondary users) -------------------------------
+
+    /**
+     * One Android user. [id] is what a uid carries (uid / [PER_USER_RANGE]), [name] is the label the
+     * WebUI shows next to an app, and [managed] marks a work profile — the common case behind #237,
+     * and the one worth naming as such when the ROM hands back an empty user name.
+     */
+    data class UserEntry(val id: Int, val name: String, val managed: Boolean)
+
+    // android.content.pm.UserInfo.FLAG_MANAGED_PROFILE.
+    private const val FLAG_MANAGED_PROFILE = 0x00000020
+
+    // The last user set we logged, so a per-resolve enumeration doesn't reprint the same line
+    // forever but a profile being created or removed still shows up in logcat when it happens.
+    @Volatile private var lastUsersLogged: String? = null
+
+    /**
+     * Every user on the device, primary first. Tries the user service (the authoritative answer,
+     * which root may ask), then falls back to the on-disk user directories, and finally to a
+     * single user 0 — a device with no work profile then behaves exactly as it did before.
+     */
+    fun users(): List<UserEntry> {
+        val found = usersFromService() ?: usersFromDisk() ?: listOf(UserEntry(0, "Owner", false))
+        val users = found.sortedBy { it.id }
+        val signature = users.joinToString(",") { "${it.id}:${it.name}" }
+        if (signature != lastUsersLogged) {
+            lastUsersLogged = signature
+            SystemLogger.info(
+                "Packages: ${users.size} user(s) on device — " +
+                    users.joinToString(", ") { "${it.id} '${it.name}'${if (it.managed) " (work)" else ""}" }
+            )
+        } else {
+            SystemLogger.verbose("Packages: ${users.size} user(s) on device (unchanged)")
+        }
+        return users
+    }
+
+    /**
+     * The user list from IUserManager, or null when the service is unreachable or its aidl does not
+     * match. getUsers grew its excludePartial/excludePreCreated arguments in Android 11, so the
+     * three-argument form is tried first on R+ and the Android 10 one-argument form is the retry;
+     * a ROM that reshuffled the interface lands on NoSuchMethodError and we fall back to disk.
+     */
+    private fun usersFromService(): List<UserEntry>? {
+        val binder =
+            try {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R)
+                    ServiceManager.waitForService("user")
+                else ServiceManager.getService("user")
+            } catch (e: Exception) {
+                SystemLogger.warning("Packages: user service lookup failed", e)
+                null
+            }
+        if (binder == null) {
+            SystemLogger.warning("Packages: user service not available; falling back to /data/system/users")
+            return null
+        }
+        val um =
+            try {
+                IUserManager.Stub.asInterface(binder)
+            } catch (e: Throwable) {
+                SystemLogger.warning("Packages: IUserManager.asInterface failed", e)
+                return null
+            }
+        val infos =
+            try {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) um.getUsers(true, true, true)
+                else um.getUsers(true)
+            } catch (e: Throwable) {
+                // NoSuchMethodError on an aidl mismatch, SecurityException if a ROM tightened the
+                // check beyond the platform's uid-0 waiver. Either way: try the other arity, then disk.
+                SystemLogger.warning("Packages: getUsers failed (${e.javaClass.simpleName}); retrying the legacy arity", e)
+                try {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) um.getUsers(true)
+                    else um.getUsers(true, true, true)
+                } catch (e2: Throwable) {
+                    SystemLogger.warning("Packages: getUsers unavailable on this ROM", e2)
+                    return null
+                }
+            }
+        if (infos == null || infos.isEmpty()) {
+            SystemLogger.warning("Packages: getUsers returned nothing; falling back to /data/system/users")
+            return null
+        }
+        return infos.mapNotNull { info ->
+            try {
+                val managed = (info.flags and FLAG_MANAGED_PROFILE) != 0
+                UserEntry(info.id, userLabel(info.id, info.name, managed), managed)
+            } catch (e: Throwable) {
+                SystemLogger.warning("Packages: unreadable UserInfo entry", e)
+                null
+            }
+        }
+    }
+
+    // /data/system/users/<id>/ is one directory per user and <id>.xml its record; the daemon is root,
+    // so reading them is a dependable last resort when the user service cannot be talked to. Only the
+    // ids are taken from the directory names; the name and the managed-profile flag are lifted out of
+    // the record with a narrow regex rather than a full XML parse, and both are optional.
+    private val USER_NAME_RE = Regex("<name>([^<]*)</name>")
+    private val USER_FLAGS_RE = Regex("flags=\"(-?\\d+)\"")
+
+    private fun usersFromDisk(): List<UserEntry>? {
+        val dir = File("/data/system/users")
+        val ids =
+            try {
+                dir.listFiles()?.filter { it.isDirectory }?.mapNotNull { it.name.toIntOrNull() }
+            } catch (e: Exception) {
+                SystemLogger.warning("Packages: cannot list /data/system/users", e)
+                null
+            }
+        if (ids.isNullOrEmpty()) return null
+        return ids.map { id ->
+            var name = ""
+            var flags = 0
+            try {
+                val xml = File(dir, "$id.xml")
+                if (xml.canRead()) {
+                    val text = xml.readText()
+                    name = USER_NAME_RE.find(text)?.groupValues?.get(1)?.trim().orEmpty()
+                    flags = USER_FLAGS_RE.find(text)?.groupValues?.get(1)?.toIntOrNull() ?: 0
+                }
+            } catch (e: Exception) {
+                SystemLogger.warning("Packages: cannot read /data/system/users/$id.xml", e)
+            }
+            val managed = (flags and FLAG_MANAGED_PROFILE) != 0
+            UserEntry(id, userLabel(id, name, managed), managed)
+        }
+    }
+
+    /** The display name for a user: what the platform recorded, else a role-shaped stand-in. */
+    private fun userLabel(id: Int, name: String?, managed: Boolean): String {
+        val given = name?.trim().orEmpty()
+        if (given.isNotEmpty()) return given
+        return when {
+            id == 0 -> "Owner"
+            managed -> "Work profile"
+            else -> "User $id"
+        }
+    }
 
     /**
      * One installed app collapsed to its uid — the shape the Scope page and `GET /packages` render.
      * A shared-uid app contributes several [packages] under one entry; [label] is the best human
      * name; [system]/[launchable]/[enabled] are the aggregate flags described on [installedAppsByUid].
+     *
+     * [userId] is the Android user the entry was enumerated in, and [uid] already carries it (a work
+     * profile's clone of an app has both a different uid and the same [packages] as user 0's copy),
+     * so one app installed in two users is two entries here — which is exactly how a profile targets
+     * one of them without the other.
      */
     data class AppEntry(
         val uid: Int,
+        val userId: Int,
         val packages: List<String>,
         val label: String,
         val system: Boolean,
@@ -59,80 +230,173 @@ object Packages {
     )
 
     /**
-     * Every installed application on the device, grouped by uid (the daemon runs as root, so its
-     * PackageManager sees all apps as one uid namespace). Packages that share a uid collapse into a
-     * single entry whose [AppEntry.packages] lists them sorted. [AppEntry.system] is true when ANY
-     * member carries FLAG_SYSTEM; [AppEntry.launchable] when ANY member has a launcher entry;
-     * [AppEntry.label]/[AppEntry.enabled] come from the group's representative (first sorted) package.
-     * Failures are logged and swallowed per app so one bad entry never empties the whole list.
+     * Every installed application on the device, in every user, grouped by uid. Packages that share a
+     * uid collapse into a single entry whose [AppEntry.packages] lists them sorted. [AppEntry.system]
+     * is true when ANY member carries FLAG_SYSTEM; [AppEntry.launchable] when ANY member has a
+     * launcher entry; [AppEntry.label]/[AppEntry.enabled] come from the group's representative (first
+     * sorted) package. Failures are logged and swallowed per app, and per user, so one bad entry — or
+     * one unreadable work profile — never empties the whole list.
      */
     fun installedAppsByUid(): List<AppEntry> {
-        val infos =
-            try {
-                @Suppress("DEPRECATION") pm.getInstalledApplications(0)
-            } catch (e: Exception) {
-                SystemLogger.warning("installedAppsByUid: getInstalledApplications failed", e)
-                return emptyList()
+        val out = ArrayList<AppEntry>()
+        var total = 0
+        for (user in users()) {
+            val infos = installedApplications(user.id)
+            if (infos.isEmpty()) {
+                SystemLogger.warning("installedAppsByUid: user ${user.id} enumerated no app")
+                continue
             }
-        val byUid = HashMap<Int, MutableList<ApplicationInfo>>()
-        for (ai in infos) byUid.getOrPut(ai.uid) { ArrayList() }.add(ai)
+            total += infos.size
+            val byUid = HashMap<Int, MutableList<ApplicationInfo>>()
+            for (ai in infos) byUid.getOrPut(ai.uid) { ArrayList() }.add(ai)
 
-        val out = ArrayList<AppEntry>(byUid.size)
-        for ((uid, members) in byUid) {
-            try {
-                members.sortBy { it.packageName }
-                val pkgNames = members.map { it.packageName }
-                val rep = members.first()
-                val label =
-                    try {
-                        pm.getApplicationLabel(rep).toString().takeIf { it.isNotBlank() }
-                            ?: rep.packageName
-                    } catch (e: Exception) {
-                        rep.packageName
-                    }
-                val system = members.any { (it.flags and ApplicationInfo.FLAG_SYSTEM) != 0 }
-                // getLaunchIntentForPackage(pkg) is the simplest "has a launcher entry" probe — it is
-                // exactly what a home screen would use to start the app.
-                val launchable = pkgNames.any { pm.getLaunchIntentForPackage(it) != null }
-                // Oldest member's first-install time is the group's install age; a per-package failure
-                // contributes nothing (0) rather than aborting the whole entry.
-                val installTime =
-                    pkgNames.mapNotNull { p ->
+            for ((uid, members) in byUid) {
+                try {
+                    members.sortBy { it.packageName }
+                    val pkgNames = members.map { it.packageName }
+                    val rep = members.first()
+                    val label =
                         try {
-                            @Suppress("DEPRECATION") pm.getPackageInfo(p, 0).firstInstallTime
+                            pm.getApplicationLabel(rep).toString().takeIf { it.isNotBlank() }
+                                ?: rep.packageName
                         } catch (e: Exception) {
-                            null
+                            rep.packageName
                         }
-                    }.minOrNull() ?: 0L
-                out.add(
-                    AppEntry(
-                        uid = uid,
-                        packages = pkgNames,
-                        label = label,
-                        system = system,
-                        launchable = launchable,
-                        enabled = rep.enabled,
-                        installTime = installTime,
+                    val system = members.any { (it.flags and ApplicationInfo.FLAG_SYSTEM) != 0 }
+                    val launchable = pkgNames.any { hasLauncherEntry(it, user.id) }
+                    // Oldest member's first-install time is the group's install age; a per-package failure
+                    // contributes nothing (0) rather than aborting the whole entry. It is read per user
+                    // because a work profile installs its clone of an app at its own moment.
+                    val installTime =
+                        pkgNames.mapNotNull { p -> firstInstallTime(p, user.id) }.minOrNull() ?: 0L
+                    out.add(
+                        AppEntry(
+                            uid = uid,
+                            userId = user.id,
+                            packages = pkgNames,
+                            label = label,
+                            system = system,
+                            launchable = launchable,
+                            enabled = rep.enabled,
+                            installTime = installTime,
+                        )
                     )
-                )
-            } catch (e: Exception) {
-                SystemLogger.warning("installedAppsByUid: skipping uid $uid", e)
+                } catch (e: Exception) {
+                    SystemLogger.warning("installedAppsByUid: skipping uid $uid (user ${user.id})", e)
+                }
             }
         }
-        SystemLogger.info("Packages: enumerated ${infos.size} app(s) across ${out.size} uid(s)")
+        SystemLogger.info("Packages: enumerated $total app(s) across ${out.size} uid(s) in all users")
         return out
     }
 
-    /** Every installed package name on the device, for the auto-include baseline seed. Empty on
-     *  failure so a broken enumeration never seeds an empty baseline that later mislabels everything new. */
-    fun allInstalledPackageNames(): Set<String> =
-        try {
-            @Suppress("DEPRECATION")
-            pm.getInstalledApplications(0).mapTo(HashSet()) { it.packageName }
-        } catch (e: Exception) {
-            SystemLogger.warning("allInstalledPackageNames: getInstalledApplications failed", e)
-            emptySet()
+    /** Every installed package name on the device, in every user, for the auto-include baseline seed.
+     *  Empty on failure so a broken enumeration never seeds an empty baseline that later mislabels
+     *  everything new. The set is user-agnostic on purpose: the baseline answers "did this app exist
+     *  when TEESimulator first ran", which is a question about the app, not about one user's copy. */
+    fun allInstalledPackageNames(): Set<String> {
+        val out = HashSet<String>()
+        for (user in users()) installedApplications(user.id).mapTo(out) { it.packageName }
+        if (out.isEmpty()) SystemLogger.warning("allInstalledPackageNames: enumeration came back empty")
+        return out
+    }
+
+    // --- per-user PackageManager calls -------------------------------------------
+
+    /**
+     * Every application installed for [userId]. User 0 keeps the public PackageManager path it has
+     * always used; any other user goes through the package service, whose bulk call widened its
+     * `flags` argument from int to long in Android 13 — hence [sliceOf], which tries the arity this
+     * SDK expects and retries the other one when a ROM disagrees.
+     */
+    private fun installedApplications(userId: Int): List<ApplicationInfo> {
+        if (userId == 0)
+            return try {
+                @Suppress("DEPRECATION") pm.getInstalledApplications(0)
+            } catch (e: Exception) {
+                SystemLogger.warning("installedApplications(user 0): getInstalledApplications failed", e)
+                emptyList()
+            }
+        val ipm = packageManagerService() ?: return emptyList()
+        return sliceOf("getInstalledApplications(user $userId)") { wide ->
+            if (wide) ipm.getInstalledApplications(0L, userId) else ipm.getInstalledApplications(0, userId)
+        } ?: emptyList()
+    }
+
+    /** [pkg]'s ApplicationInfo inside [userId], or null when it is not installed there. */
+    private fun applicationInfoAsUser(pkg: String, userId: Int): ApplicationInfo? {
+        val ipm = packageManagerService() ?: return null
+        return callBothArities("getApplicationInfo($pkg, user $userId)") { wide ->
+            if (wide) ipm.getApplicationInfo(pkg, 0L, userId) else ipm.getApplicationInfo(pkg, 0, userId)
         }
+    }
+
+    /** [pkg]'s first-install epoch inside [userId], or null when it cannot be read. */
+    private fun firstInstallTime(pkg: String, userId: Int): Long? {
+        if (userId == 0)
+            return try {
+                @Suppress("DEPRECATION") pm.getPackageInfo(pkg, 0).firstInstallTime
+            } catch (e: Exception) {
+                null
+            }
+        val ipm = packageManagerService() ?: return null
+        return callBothArities("getPackageInfo($pkg, user $userId)") { wide ->
+                if (wide) ipm.getPackageInfo(pkg, 0L, userId) else ipm.getPackageInfo(pkg, 0, userId)
+            }
+            ?.firstInstallTime
+    }
+
+    /**
+     * Does [pkg] have a launcher entry in [userId] — the "is this a normal app the user can open"
+     * probe the picker's User/System split rides on. User 0 asks the same getLaunchIntentForPackage a
+     * home screen would; another user resolves the MAIN/LAUNCHER intent through the package service,
+     * which is the only cross-user form of that query.
+     */
+    private fun hasLauncherEntry(pkg: String, userId: Int): Boolean {
+        if (userId == 0) {
+            return try {
+                pm.getLaunchIntentForPackage(pkg) != null
+            } catch (e: Exception) {
+                false
+            }
+        }
+        val ipm = packageManagerService() ?: return false
+        val intent = Intent(Intent.ACTION_MAIN).addCategory(Intent.CATEGORY_LAUNCHER).setPackage(pkg)
+        val list =
+            sliceOf("queryIntentActivities($pkg, user $userId)") { wide ->
+                if (wide) ipm.queryIntentActivities(intent, null, 0L, userId)
+                else ipm.queryIntentActivities(intent, null, 0, userId)
+            }
+        return !list.isNullOrEmpty()
+    }
+
+    /** [callBothArities] for the calls that answer with a chunked list. */
+    private fun <T> sliceOf(what: String, call: (Boolean) -> ParceledListSlice<T>?): List<T>? =
+        callBothArities(what, call)?.list
+
+    /**
+     * Run an IPackageManager call that exists in an int-`flags` and a long-`flags` form (the widening
+     * landed in Android 13), starting with the one this SDK level expects. A ROM whose aidl sits on
+     * the other side of that line answers with NoSuchMethodError, so the other arity is the retry
+     * rather than a hard failure; anything else is logged and swallowed as "not available".
+     */
+    private fun <T> callBothArities(what: String, call: (Boolean) -> T?): T? {
+        val wideFirst = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+        return try {
+            call(wideFirst)
+        } catch (e: NoSuchMethodError) {
+            SystemLogger.info("Packages: $what has the other flags arity on this ROM; retrying")
+            try {
+                call(!wideFirst)
+            } catch (e2: Throwable) {
+                SystemLogger.warning("Packages: $what failed on both arities", e2)
+                null
+            }
+        } catch (e: Throwable) {
+            SystemLogger.warning("Packages: $what failed", e)
+            null
+        }
+    }
 
     // Rendered PNG icons keyed by package. A browser <img> re-hits /icon on every list scroll, so caching
     // the encoded bytes (small; ~a few KB each) keeps those repeats off PackageManager + the PNG encoder.
@@ -143,12 +407,17 @@ object Packages {
      * The app icon for [pkg] rendered to a [ICON_PX]×[ICON_PX] PNG, or null when the package has no icon
      * or anything fails. Adaptive/vector icons have no intrinsic bitmap, so the drawable is always drawn
      * onto a fixed ARGB_8888 canvas rather than read as a bitmap. Results are memoized in [iconCache].
+     *
+     * [userId] only says where to LOOK the package up — an app installed in a work profile is missing
+     * from user 0's PackageManager — not what to draw: every user runs the same apk off the same
+     * sourceDir, so the rendered icon is identical and the cache stays keyed by package alone. The
+     * managed-profile badge a launcher overlays is a launcher's doing, and is deliberately not drawn.
      */
-    fun iconPng(pkg: String): ByteArray? {
+    fun iconPng(pkg: String, userId: Int = 0): ByteArray? {
         iconCache.get(pkg)?.let {
             return it
         }
-        val drawable = loadIconDrawable(pkg) ?: return null
+        val drawable = loadIconDrawable(pkg, userId) ?: return null
         return try {
             val png = drawableToPng(drawable)
             if (png != null) iconCache.put(pkg, png)
@@ -173,10 +442,18 @@ object Packages {
      * resource directly sidesteps the OEM path entirely and yields the real icon on every device.
      * getApplicationIcon is kept only as a last resort for apps that declare no icon resource.
      */
-    private fun loadIconDrawable(pkg: String): Drawable? {
+    private fun loadIconDrawable(pkg: String, userId: Int): Drawable? {
         try {
-            val ai = pm.getApplicationInfo(pkg, 0)
-            if (ai.icon != 0) {
+            // User 0's record first even for another user's app: it is the cheap public call, and the
+            // two describe the same apk. Only a package that user 0 does not have (a work-profile-only
+            // install) needs the per-user lookup.
+            val ai =
+                try {
+                    pm.getApplicationInfo(pkg, 0)
+                } catch (e: PackageManager.NameNotFoundException) {
+                    applicationInfoAsUser(pkg, userId)
+                }
+            if (ai != null && ai.icon != 0) {
                 pm.getResourcesForApplication(ai).getDrawable(ai.icon, null)?.let {
                     return it
                 }
@@ -187,7 +464,7 @@ object Packages {
         return try {
             pm.getApplicationIcon(pkg)
         } catch (e: Exception) {
-            SystemLogger.warning("iconPng($pkg): getApplicationIcon failed", e)
+            SystemLogger.warning("iconPng($pkg, user $userId): getApplicationIcon failed", e)
             null
         }
     }

--- a/app/src/main/java/org/matrix/teesim/Resolver.kt
+++ b/app/src/main/java/org/matrix/teesim/Resolver.kt
@@ -159,11 +159,22 @@ object Resolver {
         // packages[] (attestation name-match, verbatim incl. not-yet-installed) and uids[] (caller-uid
         // fallback, effective set with no -1) resolved centrally by Scope, which also folds in raw
         // uid:N tokens and the autoIncludeNewApps expansion and logs the per-entry detail. The two
-        // arrays are independent here (uids[] may be longer or shorter than packages[]).
+        // arrays are independent here (uids[] may be longer or shorter than packages[]), so each
+        // carries its own companion: packageUsers[] says which Android user a name-match is confined
+        // to, and uidPackages[] names the package behind a uid for the legacy keystore1 path, which
+        // has to rebuild an attestation application id the caller never got to send.
         o.put("packages", JSONArray(scope.packageNames))
+        val packageUsers = JSONArray()
+        for (u in scope.packageUsers) packageUsers.put(u)
+        o.put("packageUsers", packageUsers)
         val uids = JSONArray()
-        for (u in scope.uids) uids.put(u)
+        val uidPackages = JSONArray()
+        for (u in scope.uids) {
+            uids.put(u)
+            uidPackages.put(scope.uidPackages[u] ?: "")
+        }
         o.put("uids", uids)
+        o.put("uidPackages", uidPackages)
         return o
     }
 

--- a/app/src/main/java/org/matrix/teesim/Scope.kt
+++ b/app/src/main/java/org/matrix/teesim/Scope.kt
@@ -337,7 +337,8 @@ object Scope {
      * packages only. Left as it was, every app that lives solely in a work profile would read as
      * "installed after the baseline" and an auto-include profile would swallow the whole profile at
      * once on the first run after an update. Such a file is therefore topped up once — with the
-     * packages of every user — and rewritten as version 2.
+     * packages that live OUTSIDE the primary user, and only those, so user 0's half of the baseline
+     * keeps the moment it was frozen at — and rewritten as version 2.
      */
     private const val BASELINE_VERSION = 2
 
@@ -369,22 +370,39 @@ object Scope {
                 return set
             }
             if (set.isNotEmpty()) {
-                // Pre-multi-user baseline: fold today's every-user enumeration in. An enumeration that
-                // comes back empty is the same transient failure the seed path guards against, so the
-                // old set is returned UNCACHED and the top-up retries on the next call. Nothing is
-                // auto-included meanwhile: resolve() walks the very enumeration that just failed.
-                val live = Packages.allInstalledPackageNames()
-                if (live.isEmpty()) {
+                // Pre-multi-user baseline: fold in the apps the v1 file COULD NOT SEE, and only those
+                // — the packages that exist in some other user and not in the primary one.
+                //
+                // Emphatically NOT today's whole enumeration. The baseline's meaning is "what existed
+                // when TEESimulator first ran", and user 0's part of it is already recorded accurately;
+                // merging user 0's CURRENT list would advance that frame of reference to now, marking
+                // every app installed since the seed as pre-existing and silently dropping it out of
+                // auto-include — on a single-user device too, where this migration has nothing to add.
+                // A package is excluded when the primary user has it for the same reason: the baseline
+                // is keyed by bare name, so folding in a work profile's copy of an app user 0 also
+                // installed after the seed would lose that app just the same.
+                //
+                // An enumeration that comes back empty ENTIRELY is the transient failure the seed path
+                // guards against, so the old set is returned UNCACHED and the top-up retries on the
+                // next call. Nothing is auto-included meanwhile: resolve() walks the very enumeration
+                // that just failed. An empty result with a non-empty enumeration is not a failure — it
+                // is a device with nothing outside user 0, which upgrades to v2 adding nothing.
+                val byUser = Packages.installedPackageNamesByUser()
+                if (byUser.values.all { it.isEmpty() }) {
                     SystemLogger.warning(
                         "Scope: package enumeration empty; deferring the known_packages.json v$version -> " +
                             "v$BASELINE_VERSION top-up (will retry)"
                     )
                     return set
                 }
-                val merged = HashSet(set).apply { addAll(live) }
+                val primary = byUser[0].orEmpty()
+                val secondaryOnly =
+                    byUser.filterKeys { it != 0 }.values.flatten().filterNot { it in primary }.toSet()
+                val merged = HashSet(set).apply { addAll(secondaryOnly) }
                 SystemLogger.info(
-                    "Scope: topped up the v$version baseline with every user's packages — " +
-                        "${set.size} -> ${merged.size} package(s)"
+                    "Scope: topped up the v$version baseline with ${secondaryOnly.size} package(s) that " +
+                        "live outside the primary user — ${set.size} -> ${merged.size} package(s); " +
+                        "user 0's baseline is left at its original frame of reference"
                 )
                 writeBaseline(f, merged)
                 baselineCache = merged

--- a/app/src/main/java/org/matrix/teesim/Scope.kt
+++ b/app/src/main/java/org/matrix/teesim/Scope.kt
@@ -5,16 +5,24 @@ import org.json.JSONArray
 import org.json.JSONObject
 
 /**
- * The one place that turns a profile's `apps[]` list into the two wire arrays the native router
- * matches against — `packages[]` (attestation package-name match, primary) and `uids[]` (caller-uid
- * match, fallback) — plus the derived sets the WebUI and re-attest paths need. Resolver, ReAttest
- * and KeyAdmin all go through here so uid resolution, the raw-`uid:N` syntax, the auto-include
- * expansion and the low-uid warnings live once, not copied three ways with drift between them.
+ * The one place that turns a profile's `apps[]` list into the wire arrays the native router matches
+ * against — `packages[]` with its per-entry `packageUsers[]` (attestation package-name match,
+ * primary) and `uids[]` with `uidPackages[]` (caller-uid match, fallback) — plus the derived sets
+ * the WebUI and re-attest paths need. Resolver, ReAttest and KeyAdmin all go through here so uid
+ * resolution, the raw-`uid:N` syntax, the auto-include expansion and the low-uid warnings live once,
+ * not copied three ways with drift between them.
  *
- * An `apps[]` entry is one of three shapes (see [parse]): a plain package name, an advanced
+ * An `apps[]` entry is one of these shapes (see [parse]): a plain package name (the app as installed
+ * for the primary user), a `pkg@N` token naming the same app inside Android user N — a work profile
+ * or a secondary user, whose clone of an app is a different caller uid entirely — an advanced
  * `uid:N` token that targets a caller uid directly, or something malformed. A package name is kept
  * on the wire verbatim even when the app is not installed yet, because a later install still
  * name-matches; a uid is only ever pushed when it actually resolves (never -1).
+ *
+ * The user a package entry names is carried onto the wire beside it rather than folded away: the
+ * attestation application id an app embeds says which package asked, never which user it ran as, so
+ * only the pushed user id lets the router tell user 0's Play Store from the work profile's clone —
+ * and hence lets two profiles hold two keyboxes for the same package in two users.
  */
 object Scope {
 
@@ -23,21 +31,30 @@ object Scope {
     const val FIRST_APP_UID = 10000
 
     enum class Kind {
-        /** A package name that is currently installed; [Explicit.uid] is its resolved app uid. */
+        /** A package name that is currently installed in its entry's user; [Explicit.uid] is its
+         *  resolved per-user app uid. */
         PACKAGE,
         /** An advanced `uid:N` token; [Explicit.uid] is N, [Explicit.pkg] is null. */
         RAW_UID,
-        /** A package-shaped name that is not installed (uid -1, but [Explicit.pkg] is kept), or a
-         *  genuinely malformed entry (uid -1, [Explicit.pkg] null). */
+        /** A package-shaped name that is not installed for its user (uid -1, but [Explicit.pkg] is
+         *  kept), or a genuinely malformed entry (uid -1, [Explicit.pkg] null). */
         INVALID,
     }
 
     /**
      * One resolved `apps[]` entry, in the same order as written. [pkg] is non-null for anything
      * package-shaped (installed or not) and null for a `uid:N` token or a malformed entry — which is
-     * exactly the "is this a wire package name?" test [ProfileScope.packageNames] uses.
+     * exactly the "is this a wire package name?" test [ProfileScope.packageNames] uses. [userId] is
+     * the Android user the entry names: 0 for a plain package name, N for `pkg@N`, and (for a raw uid
+     * token) the user that uid already encodes.
      */
-    data class Explicit(val entry: String, val kind: Kind, val uid: Int, val pkg: String?)
+    data class Explicit(
+        val entry: String,
+        val kind: Kind,
+        val uid: Int,
+        val pkg: String?,
+        val userId: Int,
+    )
 
     /** The fully resolved scope of one profile against the live device. */
     data class ProfileScope(
@@ -49,9 +66,19 @@ object Scope {
         val explicit: List<Explicit>, // one per apps[] entry, in order
         val autoUids: Set<Int>, // extra uids contributed by autoIncludeNewApps
         val packageNames: List<String>, // wire packages[]: every package-shaped entry, verbatim
+        val packageUsers: List<Int>, // wire packageUsers[]: parallel to packageNames, one user each
         val uids: Set<Int>, // wire uids[]: effective caller uids, never containing -1
-        val lowUids: Set<Int>, // effective uids below FIRST_APP_UID, for the privileged-uid warning
+        val uidPackages: Map<Int, String>, // wire uidPackages[]: the package name behind a resolved uid
+        val lowUids: Set<Int>, // effective uids whose app id is below FIRST_APP_UID, for the warning
     )
+
+    /** The `apps[]` entry naming [pkg] inside [userId] — the plain name for the primary user, the
+     *  `pkg@N` form for any other. The one place that spelling is decided. */
+    fun entryToken(pkg: String, userId: Int): String = if (userId == 0) pkg else "$pkg@$userId"
+
+    /** Is [uid] a privileged (system/shell) caller? Asked of its APP id, so the answer holds in a
+     *  secondary user too — user 10's system_server is uid 1001000, far above [FIRST_APP_UID]. */
+    fun isPrivilegedUid(uid: Int): Boolean = uid % Packages.PER_USER_RANGE < FIRST_APP_UID
 
     /** Classify a single `apps[]` entry. Never throws — a malformed entry becomes [Kind.INVALID]. */
     fun parse(entry: String): Explicit {
@@ -59,17 +86,28 @@ object Scope {
         if (e.startsWith("uid:")) {
             val digits = e.substring(4)
             val n = if (digits.isNotEmpty() && digits.all { it.isDigit() }) digits.toIntOrNull() else null
-            return if (n != null) Explicit(e, Kind.RAW_UID, n, null)
-            else Explicit(e, Kind.INVALID, -1, null)
+            return if (n != null) Explicit(e, Kind.RAW_UID, n, null, Packages.userIdOf(n))
+            else Explicit(e, Kind.INVALID, -1, null, 0)
         }
-        if (e.isNotEmpty() && e.all { it.isLetterOrDigit() || it == '_' || it == '.' }) {
-            val uid = Packages.uidForPackage(e)
-            // Package-shaped: PACKAGE when installed, INVALID (but pkg kept) when not — the name still
-            // rides the wire so a later install name-matches, yet contributes no uid until it resolves.
-            return if (uid >= 0) Explicit(e, Kind.PACKAGE, uid, e)
-            else Explicit(e, Kind.INVALID, -1, e)
+        // pkg@N splits into the package and the Android user it names; a bare package name is user 0.
+        // Everything after the first '@' must be digits, so an '@' inside the package part (never
+        // legal in a package name anyway) still falls through to INVALID below.
+        val at = e.indexOf('@')
+        val name = if (at < 0) e else e.substring(0, at)
+        val userDigits = if (at < 0) "" else e.substring(at + 1)
+        val userId =
+            if (at < 0) 0
+            else if (userDigits.isNotEmpty() && userDigits.all { it.isDigit() }) userDigits.toIntOrNull() ?: -1
+            else -1
+        if (userId >= 0 && name.isNotEmpty() && name.all { it.isLetterOrDigit() || it == '_' || it == '.' }) {
+            val uid = Packages.uidForPackage(name, userId)
+            // Package-shaped: PACKAGE when installed for that user, INVALID (but pkg kept) when not —
+            // the name still rides the wire so a later install name-matches, yet contributes no uid
+            // until it resolves.
+            return if (uid >= 0) Explicit(e, Kind.PACKAGE, uid, name, userId)
+            else Explicit(e, Kind.INVALID, -1, name, userId)
         }
-        return Explicit(e, Kind.INVALID, -1, null)
+        return Explicit(e, Kind.INVALID, -1, null, 0)
     }
 
     /**
@@ -92,32 +130,68 @@ object Scope {
         val explicit = profile.apps.map { parse(it) }
 
         val packageNames = ArrayList<String>()
+        val packageUsers = ArrayList<Int>()
         val uids = LinkedHashSet<Int>()
+        val uidPackages = LinkedHashMap<Int, String>()
+        // The secondary users a primary-user entry might ALSO want to name. Resolved once, and only
+        // on the logging (push) path — the point of it is the hint below, which the quiet aggregators
+        // do not emit anyway.
+        val otherUsers = if (quiet) emptyList() else Packages.users().filter { it.id != 0 }
         for (x in explicit) {
-            if (x.pkg != null) packageNames.add(x.pkg)
+            if (x.pkg != null) {
+                packageNames.add(x.pkg)
+                packageUsers.add(x.userId)
+            }
             when (x.kind) {
                 Kind.PACKAGE -> {
                     uids.add(x.uid)
-                    if (!quiet) SystemLogger.info("Scope[$id]: '${x.entry}' -> uid ${x.uid}")
+                    // The uid -> package pairing the legacy keystore1 path needs: downstream of that
+                    // hook the caller's attestation application id is gone, so it rebuilds one from
+                    // this name. It must be carried explicitly, never inferred from array position —
+                    // packages[] and uids[] have long since stopped lining up 1:1.
+                    x.pkg?.let { uidPackages[x.uid] = it }
+                    if (!quiet) {
+                        SystemLogger.info(
+                            "Scope[$id]: '${x.entry}' -> uid ${x.uid} (user ${x.userId})"
+                        )
+                        // An entry names one user's copy of the app. Say when the same app also runs
+                        // in another user, because that copy is a different caller and stays
+                        // untargeted until it is named — a silence that would otherwise read as a bug.
+                        if (x.userId == 0 && x.pkg != null) {
+                            val also = otherUsers.filter { Packages.uidForPackage(x.pkg, it.id) >= 0 }
+                            if (also.isNotEmpty())
+                                SystemLogger.info(
+                                    "Scope[$id]: '${x.entry}' is also installed for " +
+                                        also.joinToString(", ") { "user ${it.id} ('${it.name}')" } +
+                                        " — add '${x.pkg}@<user>' to target that copy too"
+                                )
+                        }
+                    }
                 }
                 Kind.RAW_UID -> {
                     uids.add(x.uid)
-                    if (!quiet) SystemLogger.info("Scope[$id]: raw uid:${x.uid}")
+                    if (!quiet)
+                        SystemLogger.info("Scope[$id]: raw uid:${x.uid} (user ${x.userId})")
                 }
                 Kind.INVALID -> {
                     if (quiet) Unit
                     else if (x.pkg != null)
-                        SystemLogger.info("Scope[$id]: '${x.entry}' -> NOT INSTALLED (dropped)")
-                    else SystemLogger.warning("Scope[$id]: '${x.entry}' is not a valid package name or uid:N token (dropped)")
+                        SystemLogger.info(
+                            "Scope[$id]: '${x.entry}' -> NOT INSTALLED for user ${x.userId} (dropped)"
+                        )
+                    else SystemLogger.warning("Scope[$id]: '${x.entry}' is not a valid package name, pkg@user or uid:N token (dropped)")
                 }
             }
         }
 
-        // Auto-include (future-installs only): a user-app uid (>= FIRST_APP_UID) is folded in ONLY
-        // when NONE of its package names was present at the baseline — i.e. the app was installed AFTER
-        // TEESimulator first ran — and no OTHER profile claims it and this profile does not already name
-        // it. The baseline (known_packages.json, seeded once) is what makes this "new apps only": every
-        // app that already existed is by definition in the baseline and never auto-added.
+        // Auto-include (future-installs only): a user-app uid (an app id >= FIRST_APP_UID, in any
+        // Android user) is folded in ONLY when NONE of its package names was present at the baseline —
+        // i.e. the app was installed AFTER TEESimulator first ran — and no OTHER profile claims it and
+        // this profile does not already name it. The baseline (known_packages.json, seeded once) is
+        // what makes this "new apps only": every app that already existed is by definition in the
+        // baseline and never auto-added. The baseline holds bare package names, so a work profile's
+        // clone of an app that user 0 already had counts as pre-existing and is NOT auto-added — the
+        // safe direction for a rule whose failure mode is applying a keybox where nobody asked.
         val autoUids = LinkedHashSet<Int>()
         if (profile.autoIncludeNewApps) {
             val baseline = baselineKnownPackages()
@@ -134,7 +208,7 @@ object Scope {
             val claimedElsewhere = explicitUidsOf(others)
             val mine = explicit.mapNotNull { if (it.uid >= 0) it.uid else null }.toHashSet()
             for (app in Packages.installedAppsByUid()) {
-                if (app.uid < FIRST_APP_UID) continue
+                if (isPrivilegedUid(app.uid)) continue
                 if (app.uid in claimedElsewhere) continue
                 if (app.uid in mine) continue
                 // Every member package known at baseline => pre-existing app, skip. Any member absent from
@@ -150,12 +224,13 @@ object Scope {
             }
         }
 
-        val lowUids = uids.filter { it < FIRST_APP_UID }.toSet()
+        val lowUids = uids.filter { isPrivilegedUid(it) }.toSet()
         if (!quiet)
             for (u in lowUids)
                 SystemLogger.warning(
-                    "Scope[$id]: WARNING targeting privileged uid $u (< first app uid $FIRST_APP_UID) — " +
-                        "this is a system/shell uid (e.g. shell, system_server), not a normal app"
+                    "Scope[$id]: WARNING targeting privileged uid $u (app id ${u % Packages.PER_USER_RANGE} " +
+                        "< first app uid $FIRST_APP_UID) — this is a system/shell uid (e.g. shell, " +
+                        "system_server), not a normal app"
                 )
 
         val invalidCount = explicit.count { it.kind == Kind.INVALID }
@@ -171,7 +246,9 @@ object Scope {
             explicit = explicit,
             autoUids = autoUids,
             packageNames = packageNames,
+            packageUsers = packageUsers,
             uids = uids,
+            uidPackages = uidPackages,
             lowUids = lowUids,
         )
     }
@@ -255,16 +332,27 @@ object Scope {
      * this call WITHOUT writing the file, so the very next call retries and seeds properly once
      * PackageManager answers. A genuinely-present baseline file (even if it read back empty because the
      * device really had nothing) is honoured; only the seed path guards against the transient case.
+     *
+     * A version-1 file was written before the daemon could see past user 0, so it lists that user's
+     * packages only. Left as it was, every app that lives solely in a work profile would read as
+     * "installed after the baseline" and an auto-include profile would swallow the whole profile at
+     * once on the first run after an update. Such a file is therefore topped up once — with the
+     * packages of every user — and rewritten as version 2.
      */
+    private const val BASELINE_VERSION = 2
+
     fun baselineKnownPackages(): Set<String> {
         baselineCache?.let {
             return it
         }
         val f = Const.knownPackagesFile
         if (f.exists()) {
+            var version = BASELINE_VERSION
             val set =
                 try {
-                    val arr = JSONObject(f.readText()).optJSONArray("packages") ?: JSONArray()
+                    val root = JSONObject(f.readText())
+                    version = root.optInt("version", 1)
+                    val arr = root.optJSONArray("packages") ?: JSONArray()
                     (0 until arr.length()).mapTo(HashSet()) { arr.getString(it) }
                 } catch (e: Exception) {
                     // A corrupt baseline file is a hard problem retrying can't fix, but caching an empty
@@ -276,9 +364,31 @@ object Scope {
             // An EMPTY existing baseline (truncated write, hand-edit) is never cached and falls through
             // to a reseed below — auto-include is disabled (resolve() guards on empty) until a real set
             // is written, rather than freezing "everything is new".
-            if (set.isNotEmpty()) {
+            if (set.isNotEmpty() && version >= BASELINE_VERSION) {
                 baselineCache = set
                 return set
+            }
+            if (set.isNotEmpty()) {
+                // Pre-multi-user baseline: fold today's every-user enumeration in. An enumeration that
+                // comes back empty is the same transient failure the seed path guards against, so the
+                // old set is returned UNCACHED and the top-up retries on the next call. Nothing is
+                // auto-included meanwhile: resolve() walks the very enumeration that just failed.
+                val live = Packages.allInstalledPackageNames()
+                if (live.isEmpty()) {
+                    SystemLogger.warning(
+                        "Scope: package enumeration empty; deferring the known_packages.json v$version -> " +
+                            "v$BASELINE_VERSION top-up (will retry)"
+                    )
+                    return set
+                }
+                val merged = HashSet(set).apply { addAll(live) }
+                SystemLogger.info(
+                    "Scope: topped up the v$version baseline with every user's packages — " +
+                        "${set.size} -> ${merged.size} package(s)"
+                )
+                writeBaseline(f, merged)
+                baselineCache = merged
+                return merged
             }
             SystemLogger.warning("Scope: known_packages.json is empty; reseeding from a live enumeration")
         }
@@ -289,8 +399,19 @@ object Scope {
             SystemLogger.warning("Scope: package enumeration empty; deferring known_packages.json seed (will retry)")
             return emptySet()
         }
+        SystemLogger.info("Scope: seeding known_packages.json baseline with ${seeded.size} package(s)")
+        writeBaseline(f, seeded)
+        baselineCache = seeded
+        return seeded
+    }
+
+    /** Persist the baseline through a temp file and a rename, so a kill mid-write cannot truncate it
+     *  into the "empty baseline" case above. A failure is logged, not thrown: the in-memory set still
+     *  holds for this run, and the next start seeds again. */
+    private fun writeBaseline(f: File, packages: Set<String>) {
         try {
-            val root = JSONObject().put("version", 1).put("packages", JSONArray(seeded.sorted()))
+            val root =
+                JSONObject().put("version", BASELINE_VERSION).put("packages", JSONArray(packages.sorted()))
             f.parentFile?.mkdirs()
             val tmp = File(f.parentFile, "${f.name}.tmp")
             tmp.writeText(root.toString())
@@ -298,12 +419,10 @@ object Scope {
                 f.writeText(root.toString())
                 tmp.delete()
             }
-            SystemLogger.info("Scope: seeded known_packages.json baseline with ${seeded.size} package(s)")
+            SystemLogger.info("Scope: wrote known_packages.json (v$BASELINE_VERSION, ${packages.size} package(s))")
         } catch (e: Exception) {
-            SystemLogger.warning("Scope: failed to seed known_packages.json", e)
+            SystemLogger.warning("Scope: failed to write known_packages.json", e)
         }
-        baselineCache = seeded
-        return seeded
     }
 
     /** The set of explicit caller uids (installed packages + `uid:N` tokens) named across [profiles]. */
@@ -335,14 +454,16 @@ object Scope {
     }
 
     /**
-     * uid -> a representative package name for the WebUI's stored-keys view. A resolved package entry
-     * maps to its name; a raw or auto-included uid has no package, so it maps to its `uid:N` token so
-     * the UI still shows something recognisable. Package names win over tokens on the same uid.
+     * uid -> a representative app name for the WebUI's stored-keys view. A resolved package entry maps
+     * to the entry as written — so a secondary user's app keeps its `pkg@user` spelling and cannot be
+     * mistaken for the primary user's copy; a raw or auto-included uid has no package, so it maps to
+     * its `uid:N` token so the UI still shows something recognisable. Package entries win over tokens
+     * on the same uid.
      */
     fun uidToPackage(config: ConfigStore.Config, force: Boolean = false): Map<Int, String> {
         val map = HashMap<Int, String>()
         for (scope in scopesFor(config, force)) {
-            for (x in scope.explicit) if (x.kind == Kind.PACKAGE && x.pkg != null) map[x.uid] = x.pkg
+            for (x in scope.explicit) if (x.kind == Kind.PACKAGE && x.pkg != null) map[x.uid] = x.entry
             for (u in scope.uids) if (u !in map) map[u] = "uid:$u"
         }
         return map

--- a/app/src/main/java/org/matrix/teesim/UsageStore.kt
+++ b/app/src/main/java/org/matrix/teesim/UsageStore.kt
@@ -6,9 +6,11 @@ import org.json.JSONObject
 /**
  * The persistent key-request frequency memory behind the Scope picker ([Const.usageFile]). Every uid
  * that asks keystore for a key is recorded by the lib and polled by [App]; that poll turns per-uid
- * deltas into per-PACKAGE updates here. Package name (not uid) is the key because a uid is recycled on
- * reinstall/clear-data while the package identity the user recognises persists — so "com.foo asked for
- * 42 keys" survives an uninstall/reinstall and even a factory boot.
+ * deltas into per-APP updates here. The key is the app token — the package name, or `pkg@user` outside
+ * the primary user, exactly as [Scope.entryToken] spells it — and not the uid, because a uid is
+ * recycled on reinstall/clear-data while the app identity the user recognises persists, so "com.foo
+ * asked for 42 keys" survives an uninstall/reinstall and even a factory boot. The user is part of the
+ * key so a work profile's copy of an app keeps its own count rather than inheriting the other's.
  *
  * On disk: { "version":1, "apps": { "com.foo": { "count":42, "lastUsed":<epochMs> } } }. [count]
  * accumulates across boots (the poller adds deltas); [lastUsed] is the wall-clock epoch of the most

--- a/common/control.cpp
+++ b/common/control.cpp
@@ -142,7 +142,10 @@ struct ProfileStorage {
   std::vector<uint8_t> keybox;
   std::vector<std::string> pkg_strings;
   std::vector<const char *> pkg_ptrs;
+  std::vector<int32_t> pkg_users;
   std::vector<int32_t> uids;
+  std::vector<std::string> uid_pkg_strings;
+  std::vector<const char *> uid_pkg_ptrs;
   std::string brand, device, product, serial, imei, imei2, meid, manufacturer, model;
   TsDeviceIds ids{};
   bool has_ids = false;
@@ -227,10 +230,26 @@ void ApplyConfig(const tjson::Value &msg, uint64_t &epoch, int &applied, int &to
       }
       s.pkg_ptrs.reserve(s.pkg_strings.size());
       for (const auto &p : s.pkg_strings) s.pkg_ptrs.push_back(p.c_str());
+      // packageUsers[] is parallel to packages[]; a short (or absent) array leaves the rest at user 0,
+      // which is what a package name meant before per-user targeting existed.
+      if (const tjson::Value *pkg_users = pj.get("packageUsers")) {
+        for (size_t j = 0; j < pkg_users->size(); ++j)
+          s.pkg_users.push_back(static_cast<int32_t>(pkg_users->at(j).as_int(0)));
+      }
+      s.pkg_users.resize(s.pkg_strings.size(), 0);
       if (const tjson::Value *uids = pj.get("uids")) {
         for (size_t j = 0; j < uids->size(); ++j)
           s.uids.push_back(static_cast<int32_t>(uids->at(j).as_int(-1)));
       }
+      // uidPackages[] is parallel to uids[]; "" (and any missing tail) means "this uid has no package
+      // name", which is the honest answer for a raw uid:N or an auto-included app.
+      if (const tjson::Value *uid_pkgs = pj.get("uidPackages")) {
+        for (size_t j = 0; j < uid_pkgs->size(); ++j)
+          s.uid_pkg_strings.push_back(uid_pkgs->at(j).as_string());
+      }
+      s.uid_pkg_strings.resize(s.uids.size());
+      s.uid_pkg_ptrs.reserve(s.uid_pkg_strings.size());
+      for (const auto &p : s.uid_pkg_strings) s.uid_pkg_ptrs.push_back(p.c_str());
       if (const tjson::Value *ids = pj.get("deviceIds")) s.has_ids = FillDeviceIds(*ids, s);
 
       TsProfile tp{};
@@ -248,8 +267,10 @@ void ApplyConfig(const tjson::Value &msg, uint64_t &epoch, int &applied, int &to
       tp.ids = s.has_ids ? &s.ids : nullptr;
       tp.packages = s.pkg_ptrs.data();
       tp.n_packages = static_cast<int>(s.pkg_ptrs.size());
+      tp.package_users = s.pkg_users.data();
       tp.uids = s.uids.data();
       tp.n_uids = static_cast<int>(s.uids.size());
+      tp.uid_packages = s.uid_pkg_ptrs.data();
 
       if (teesim_cfg_add_profile(&tp)) ++applied;
     }

--- a/common/control.h
+++ b/common/control.h
@@ -56,8 +56,18 @@ typedef struct {
   const TsDeviceIds *ids;  // NULL if the profile provisions no device IDs
   const char *const *packages;  // for keystore2 name-match
   int n_packages;
-  const int32_t *uids;  // for keystore1 uid-match (may be shorter than packages)
+  // Parallel to packages[]: the Android user each name is confined to (0 is the primary user, 10+ a
+  // work profile or secondary user). An attestation application id names the package but never the
+  // user, so this is what keeps user 0's copy of an app and a work profile's clone — different
+  // callers, possibly in different profiles — from matching each other's name. NULL means "every
+  // entry is user 0", the shape an older daemon pushed.
+  const int32_t *package_users;
+  const int32_t *uids;  // caller-uid match (may be shorter or longer than packages)
   int n_uids;
+  // Parallel to uids[]: the package name behind each uid, or "" for a raw uid:N / auto-included one.
+  // keystore1 rebuilds an attestation application id from it, since downstream of that hook the
+  // caller's own is already gone. NULL means "no names known".
+  const char *const *uid_packages;
 } TsProfile;
 
 // --- staging API, implemented by each router ---------------------------------

--- a/keymint/keymint_router.cpp
+++ b/keymint/keymint_router.cpp
@@ -43,6 +43,18 @@ TaPtr WrapTa(::Ta* ta) {
   });
 }
 
+// The stride between two Android users' uids for the same app (android.os.UserHandle.PER_USER_RANGE).
+// A caller uid is userId * 100000 + appId, so this is what turns one into the other.
+constexpr int32_t kPerUserRange = 100000;
+
+// One package name routed to a profile, and the Android user it is routed in. An attestation
+// application id carries the package but not the user, so without `user_id` a work profile's clone of
+// an app would answer to the primary user's entry and vice versa.
+struct TargetPackage {
+  std::string name;
+  int32_t user_id = 0;
+};
+
 // A configured profile: its per-level TAs, the package names routed to it, and whether it patches the
 // real hardware attestation (patch mode) or mints the whole key in the TA (generation mode).
 struct Profile {
@@ -52,7 +64,7 @@ struct Profile {
   // key's characteristics are always read at the level the key was minted at.
   TaPtr ta_tee;
   TaPtr ta_strongbox;
-  std::vector<std::string> packages;
+  std::vector<TargetPackage> packages;
   std::vector<int32_t> uids;  // resolved caller uids, for requests that carry no app-id to match
   bool patch_mode = false;
 
@@ -137,7 +149,13 @@ RequestTarget ProfileForRequest(const std::vector<KeyParameter>& params, uid_t c
                                 SecurityLevel level) {
   std::lock_guard<std::mutex> lk(g_cfg_mu);
   if (g_profiles.empty()) return {};
+  // The Android user the request came from, or -1 when the caller is unknown (no binder transaction
+  // in flight). An unknown user cannot contradict a name match, so it accepts any entry's user.
+  const int32_t caller_user =
+      caller_uid == static_cast<uid_t>(-1) ? -1 : static_cast<int32_t>(caller_uid) / kPerUserRange;
   // Primary match: the ATTESTATION_APPLICATION_ID the app embeds in the request names its package.
+  // The blob names only the package, so the caller's user is what separates two users' copies of one
+  // app — a work profile's Play Store must not pick up the entry written for the primary user's.
   for (const auto& p : params) {
     if (p.tag != Tag::ATTESTATION_APPLICATION_ID) continue;
     if (p.value.getTag() != KeyParameterValue::blob) continue;
@@ -145,7 +163,13 @@ RequestTarget ProfileForRequest(const std::vector<KeyParameter>& params, uid_t c
     std::string hay(id.begin(), id.end());
     for (const auto& prof : g_profiles) {
       for (const auto& pkg : prof.packages) {
-        if (hay.find(pkg) != std::string::npos) return {prof.TaFor(level), prof.patch_mode};
+        if (hay.find(pkg.name) == std::string::npos) continue;
+        if (caller_user >= 0 && pkg.user_id != caller_user) {
+          LOGI("route: '%s' matches profile '%s' but for user %d, not the caller's user %d — skipped",
+               pkg.name.c_str(), prof.id.c_str(), pkg.user_id, caller_user);
+          continue;
+        }
+        return {prof.TaFor(level), prof.patch_mode};
       }
     }
   }
@@ -982,12 +1006,16 @@ extern "C" bool teesim_cfg_add_profile(const TsProfile* p) {
     SeedModuleHash(prof.ta_strongbox, seed);
   }
   for (int i = 0; i < p->n_packages && p->packages; ++i) {
-    if (p->packages[i]) prof.packages.emplace_back(p->packages[i]);
+    if (!p->packages[i]) continue;
+    // No package_users[] at all means an older daemon that only ever targeted the primary user.
+    prof.packages.push_back({p->packages[i], p->package_users ? p->package_users[i] : 0});
   }
   for (int i = 0; i < p->n_uids && p->uids; ++i) prof.uids.push_back(p->uids[i]);
   LOGI("cfg: staged profile '%s' (mode=%s, security_level=%d, %zu package(s), %zu uid(s))",
        prof.id.c_str(), prof.patch_mode ? "patch" : "generation", p->security_level,
        prof.packages.size(), prof.uids.size());
+  for (const auto& pkg : prof.packages)
+    LOGI("cfg:   package '%s' in user %d", pkg.name.c_str(), pkg.user_id);
   g_staging.push_back(std::move(prof));
   return true;
 }

--- a/keystore/keystore_router.cpp
+++ b/keystore/keystore_router.cpp
@@ -826,12 +826,16 @@ extern "C" bool teesim_cfg_add_profile(const TsProfile* p) {
   Profile prof;
   prof.id = p->id ? p->id : "";
   prof.ta = WrapTa(ta);
-  // uids[] is aligned 1:1 with packages[]; -1 marks a package that is not installed.
+  // uid_packages[] is aligned 1:1 with uids[] and names the package behind each one, or "" for a raw
+  // uid:N or an auto-included app that no entry names. It is carried on the wire rather than read off
+  // packages[] by index: the two arrays have not lined up since a profile could name an app it does
+  // not (yet) have installed, and pairing them by position hands a uid the wrong package name — which
+  // this hook would then attest under.
   for (int i = 0; i < p->n_uids && p->uids; ++i) {
     if (p->uids[i] < 0) continue;
-    const char* pkg =
-        (i < p->n_packages && p->packages && p->packages[i]) ? p->packages[i] : "";
+    const char* pkg = (p->uid_packages && p->uid_packages[i]) ? p->uid_packages[i] : "";
     prof.uids[p->uids[i]] = pkg;
+    LOGI("cfg:   uid %d -> package '%s'", p->uids[i], pkg);
   }
   g_staging.push_back(std::move(prof));
   return true;

--- a/module/webroot/css/app.css
+++ b/module/webroot/css/app.css
@@ -541,6 +541,11 @@ html, body { overscroll-behavior-y: contain; }
 .scope-filters { display: flex; align-self: stretch; max-width: 100%; flex: none; }
 .scope-filters .seg { flex: 1; padding: 8px 6px; white-space: nowrap; min-width: 0; }
 
+/* User filter: the same segmented control, drawn only on a device with more than one Android user.
+ * A user name can be long ("Work profile"), so segs scroll sideways instead of squeezing. */
+.scope-users { display: flex; align-self: stretch; max-width: 100%; flex: none; overflow-x: auto; }
+.scope-users .seg { flex: 1 0 auto; padding: 6px 12px; white-space: nowrap; font-size: 13px; min-height: 36px; }
+
 /* Ops row: the bulk selection verbs on the left, a live selected-count on the right. */
 .scope-ops { display: flex; align-items: center; justify-content: space-between; gap: 12px; flex-wrap: wrap; flex: none; padding: 2px 2px 0; }
 .scope-ops-btns { display: flex; align-items: center; gap: 16px; flex-wrap: wrap; }
@@ -577,6 +582,10 @@ html, body { overscroll-behavior-y: contain; }
 .scope-name { font-weight: 600; font-size: 14px; overflow-wrap: anywhere; }
 .scope-pkg { color: var(--muted); font-size: 11px; overflow-wrap: anywhere; }
 .scope-pill { font-size: 10px; padding: 2px 8px; }
+/* Which Android user a row's copy of the app lives in. Neutral by default; a work profile is the
+ * one worth picking out, since its apps are the ones a profile most often means to target. */
+.scope-user { font-size: 10px; padding: 2px 8px; background: var(--chip); color: var(--muted); font-weight: 600; }
+.scope-user.managed { color: var(--accent); background: var(--accent-weak); }
 .scope-claimed { color: var(--muted); }
 /* Usage badges: a small accent dot when the app has asked for a key since boot, and a pill with
  * the recorded request count. */

--- a/module/webroot/js/controllers/config-controller.js
+++ b/module/webroot/js/controllers/config-controller.js
@@ -13,7 +13,7 @@ import { load as ioLoad, save as ioSave, listKeyboxes } from "../data/config-io.
 import { getStatus } from "../data/status.js";
 import { keyAdmin, API_BASE, adminToken } from "../data/keyadmin.js";
 import { validateConfig } from "../domain/validate.js";
-import { emptyProfile, emptyConfig, FIELDS, PROFILE_RE } from "../domain/schema.js";
+import { emptyProfile, emptyConfig, FIELDS, PROFILE_RE, entryToken } from "../domain/schema.js";
 import { setPath, getPath } from "../domain/path.js";
 import { renderProfileList, renderProfileEditor } from "../ui/config-view.js";
 import { renderScope } from "../ui/scope-view.js";
@@ -59,6 +59,7 @@ export function create(mount) {
   let scopeSearch = "";      // the Scope page's search text
   let scopeSearchTimer = null; // debounce handle for search-driven re-renders
   let scopeFilter = "recent"; // "recent" (default) | "user" | "system" | "selected"
+  let scopeUserFilter = null; // an Android user id to show alone, or null for every user
   let scopeSort = "freq";    // "freq" (default) | "recent" | "name" | "install"
   let scopeLoading = false;  // the /packages fetch is in flight
   let scopeError = null;     // the /packages fetch failed with this message
@@ -85,10 +86,13 @@ export function create(mount) {
     if (!packagesCache || !Array.isArray(packagesCache.apps)) return null;
     const labelMap = new Map();
     const installedSet = new Set();
+    // Keyed by apps[] ENTRY, not bare package: "com.foo" and "com.foo@10" are two installs of one
+    // app in two users, and only the entry says which of them a chip is about.
     for (const row of packagesCache.apps) {
       for (const p of (row.packages || [])) {
-        installedSet.add(p);
-        if (!labelMap.has(p)) labelMap.set(p, row.label || p);
+        const entry = entryToken(p, row.userId || 0);
+        installedSet.add(entry);
+        if (!labelMap.has(entry)) labelMap.set(entry, row.label || p);
       }
     }
     return { labelMap, installedSet };
@@ -256,9 +260,13 @@ export function create(mount) {
   // so this builds synchronously (a browser <img> cannot set the token header, so it rides the
   // query, exactly like the log-download route). Null until the token is in hand — the row then
   // shows a letter-avatar instead.
-  function iconUrl(pkg) {
+  // `userId` says which Android user to look the package up in: an app installed only in a work
+  // profile has no record in user 0 for the daemon to read an icon from.
+  function iconUrl(pkg, userId) {
     if (!iconToken || !pkg) return null;
-    return API_BASE + "/icon?pkg=" + encodeURIComponent(pkg) + "&token=" + encodeURIComponent(iconToken);
+    return API_BASE + "/icon?pkg=" + encodeURIComponent(pkg) +
+      "&user=" + encodeURIComponent(userId || 0) +
+      "&token=" + encodeURIComponent(iconToken);
   }
 
   function renderScopeView() {
@@ -273,7 +281,7 @@ export function create(mount) {
       packages: packagesCache,
       claimedByOther: claimedByOther(scoping),
       firstAppUid: (packagesCache && packagesCache.firstAppUid) || 10000,
-      search: scopeSearch, filter: scopeFilter, sort: scopeSort,
+      search: scopeSearch, filter: scopeFilter, userFilter: scopeUserFilter, sort: scopeSort,
       loading: scopeLoading, error: scopeError, iconUrl,
       // The daemon's auto-include truth, and whether the draft has diverged from what it resolved.
       // The view states "auto-include updates when you save" off pendingSave rather than predicting
@@ -350,6 +358,7 @@ export function create(mount) {
     scoping = name;
     scopeSearch = "";
     scopeFilter = "recent";
+    scopeUserFilter = null;
     scopeSort = "freq";
     scopeError = null;
     // Draft = a private copy of the profile's current picks. The Scope page mutates this alone;
@@ -489,14 +498,18 @@ export function create(mount) {
   }
 
   // The uid an entry resolves to, from the cached device list — so a system/shell pick can be
-  // confirmed before it lands. A uid: token carries its uid directly; a package is looked up in
-  // the /packages inventory. Returns -1 when unknown (uninstalled package: no privileged risk).
+  // confirmed before it lands. A uid: token carries its uid directly; a package entry is looked up
+  // in the /packages inventory, matched on the entry (package AND user) so a work profile's copy
+  // resolves to its own uid rather than the primary user's. Returns -1 when unknown (uninstalled
+  // package: no privileged risk).
   function uidForEntry(entry) {
     const m = /^uid:(\d+)$/.exec(entry);
     if (m) return Number(m[1]);
     if (packagesCache && Array.isArray(packagesCache.apps)) {
       for (const row of packagesCache.apps) {
-        if ((row.packages || []).includes(entry)) return row.uid;
+        for (const p of (row.packages || [])) {
+          if (entryToken(p, row.userId || 0) === entry) return row.uid;
+        }
       }
     }
     return -1;
@@ -514,7 +527,9 @@ export function create(mount) {
         // confirm it explicitly so a mis-tap on a low uid can't silently target system_server.
         const uid = uidForEntry(entry);
         const firstAppUid = (packagesCache && packagesCache.firstAppUid) || 10000;
-        if (uid >= 0 && uid < firstAppUid) {
+        // The APP id decides: a secondary user's system uid is 1001000, above firstAppUid but no
+        // less privileged than user 0's 1000.
+        if (uid >= 0 && uid % 100000 < firstAppUid) {
           const ok = await confirmDialog(
             `Target privileged uid ${uid}?\n\nThis is a system/shell uid (e.g. shell, system_server), not a normal app. Only do this if you know exactly why.`,
             { confirmLabel: "Target it", danger: true });
@@ -546,6 +561,7 @@ export function create(mount) {
     // The in-field search button / Enter: render right now rather than on the debounce.
     onSearchSubmit() { clearTimeout(scopeSearchTimer); renderScopeView(); },
     onSetFilter(id) { scopeFilter = id; renderScopeView(); },
+    onSetUserFilter(id) { scopeUserFilter = id; renderScopeView(); },
     onOpenSort() { openSortSheet(); },
     // The three bulk ops act on the visible entries the view computed, each { add, cur }:
     // `add` is the entry a select would add, `cur` the entry currently selecting the row.

--- a/module/webroot/js/data/keyadmin.js
+++ b/module/webroot/js/data/keyadmin.js
@@ -23,22 +23,26 @@
 //   keyAdmin("keysDbDelete", { ids }) -> { ok, deleted, requested }
 //       remove those keyentry ids from keystore2; the daemon re-verifies each is one of
 //       our marked target-app keys before deleting, so a stray id is a no-op.
-//   keyAdmin("packages")             -> { ok, firstAppUid,
-//                                          apps:[{ uid, packages:[…], label, system,
+//   keyAdmin("packages")             -> { ok, firstAppUid, users:[{ id, name, managed }],
+//                                          apps:[{ uid, userId, packages:[…], label, system,
 //                                                  launchable, enabled, installTime, freq,
 //                                                  lastUsed, recent }] }
 //       the live device app list, ONE entry per uid (packages sharing a uid are collapsed;
 //       `packages` lists them all, sorted). `label` is the best human name, `system` is
-//       true for a framework/system-flagged app or any uid below firstAppUid, `launchable`
-//       whether it has a launcher activity, `enabled` the representative app's state.
-//       firstAppUid is Process.FIRST_APPLICATION_UID (10000). Feeds the Scope picker.
+//       true for a framework/system-flagged app or any privileged uid (app id below
+//       firstAppUid), `launchable` whether it has a launcher activity, `enabled` the
+//       representative app's state. firstAppUid is Process.FIRST_APPLICATION_UID (10000).
+//       `users` lists every Android user, and `userId` says which one an entry was found in:
+//       an app installed in both the primary user and a work profile appears TWICE, under two
+//       uids, because it is two callers to keystore and is targeted separately (as `com.foo`
+//       and `com.foo@10`). Feeds the Scope picker.
 //       The usage columns: `installTime` epoch ms of first install (0 unknown), `freq`
-//       the persistent count of key requests this app has made (max over its package names,
+//       the persistent count of key requests this app has made (max over its app tokens,
 //       0 if none), `lastUsed` epoch ms of the last request (0 if never), `recent` true when
 //       the app has asked for a key since THIS boot. These drive the Scope sort/badges.
 //   keyAdmin("usageClear")           -> { ok, cleared }
 //       wipes the daemon's persisted frequency memory (usage.json). The Scope page's "Clear
-//       usage" button calls this; `cleared` is how many package entries were dropped.
+//       usage" button calls this; `cleared` is how many app entries were dropped.
 //   keyAdmin("inspect", { alias })   -> { ok, alias, cert{…}, attestation:{…}|null }
 //   keyAdmin("delete",  { alias })   -> { ok, deleted }
 //   keyAdmin("logs", { after, max }) -> { ok, lines:[{ seq, level, tag, text }], nextAfter }

--- a/module/webroot/js/domain/schema.js
+++ b/module/webroot/js/domain/schema.js
@@ -16,13 +16,34 @@ export const VERSION = 1;
 // same regexes double as the shell-injection backstop (defence in depth — even
 // unmatched input stays quoted by bridge/shell.js).
 export const PKG_RE = /^[A-Za-z0-9_.]+$/;
+// A package name optionally suffixed with the Android user it lives in: "com.foo" is the app as
+// installed for the primary user, "com.foo@10" the same app inside user 10 — a work profile or a
+// secondary user, whose copy runs under its own uid and is a separate caller to keystore.
+export const PKG_USER_RE = /^[A-Za-z0-9_.]+@\d+$/;
 // A raw-uid targeting token (advanced): "uid:" followed by one or more digits, e.g.
 // "uid:10123". It lets a profile target a caller uid directly — a shared-uid app, or an
 // app whose package name is unknown — bypassing package-name resolution. An apps[] entry
-// is valid when it is EITHER a package name OR a uid token; APP_ENTRY_RE is that union and
-// is the per-item check the schema/validator use in place of the package-only PKG_RE.
+// is valid when it is a package name, a package@user name, OR a uid token; APP_ENTRY_RE is that
+// union and is the per-item check the schema/validator use in place of the package-only PKG_RE.
 export const UID_RE = /^uid:\d+$/;
-export const APP_ENTRY_RE = /^([A-Za-z0-9_.]+|uid:\d+)$/;
+export const APP_ENTRY_RE = /^([A-Za-z0-9_.]+(@\d+)?|uid:\d+)$/;
+
+// The package half and the user half of an apps[] entry. A bare package name is user 0, which is
+// what it has always meant; anything unparseable comes back as user 0 with the whole string as the
+// name, so a caller never has to special-case a malformed entry that validation already rejects.
+export function splitEntry(entry) {
+  const s = String(entry == null ? "" : entry);
+  const at = s.indexOf("@");
+  if (at < 0) return { pkg: s, userId: 0 };
+  const digits = s.slice(at + 1);
+  if (!digits || !/^\d+$/.test(digits)) return { pkg: s, userId: 0 };
+  return { pkg: s.slice(0, at), userId: Number(digits) };
+}
+
+/** The apps[] entry naming `pkg` inside `userId` — the mirror of splitEntry, and of Scope.entryToken. */
+export function entryToken(pkg, userId) {
+  return userId ? pkg + "@" + userId : pkg;
+}
 export const PROFILE_RE = /^[A-Za-z0-9_-]{1,32}$/;
 export const KEYBOX_RE = /^[A-Za-z0-9._-]+\.xml$/;
 // harvested | system_property | today | no | YYYY-MM | YYYY-MM-DD, with month 01-12

--- a/module/webroot/js/domain/validate.js
+++ b/module/webroot/js/domain/validate.js
@@ -33,7 +33,8 @@ export function validateProfile(name, profile) {
       if (f.required && apps.length < 1 && !autoIncludes) {
         errors.push({ field: f.key, msg: "At least one app is required (or turn on Auto-include new apps)." });
       }
-      // Each entry is a package name OR a raw uid: token (APP_ENTRY_RE), not package-only.
+      // Each entry is a package name, a package@user name, OR a raw uid: token (APP_ENTRY_RE),
+      // not package-only.
       for (const entry of apps) {
         if (typeof entry !== "string" || !APP_ENTRY_RE.test(entry)) {
           errors.push({ field: f.key, msg: `Invalid app entry: ${entry}` });

--- a/module/webroot/js/ui/field.js
+++ b/module/webroot/js/ui/field.js
@@ -26,7 +26,7 @@
 // case below.
 
 import { el } from "./dom.js";
-import { UID_RE } from "../domain/schema.js";
+import { UID_RE, splitEntry } from "../domain/schema.js";
 
 export function renderField(descriptor, value, onChange, context = {}) {
   switch (descriptor.type) {
@@ -227,6 +227,9 @@ function scopeWidget(d, value, ctx) {
       const isUid = UID_RE.test(entry);
       const missing = !isUid && installedSet && !installedSet.has(entry);
       const label = isUid ? entry : ((labelMap && labelMap.get && labelMap.get(entry)) || entry);
+      // Two users' copies of one app share a label, so the user rides along on the chip — without
+      // it a work-profile pick and the primary user's are the same word twice.
+      const userId = isUid ? 0 : splitEntry(entry).userId;
       return el("span", {
         class: "chip scope-chip" + (isUid ? " advanced" : "") + (missing ? " warn" : ""),
         title: isUid ? "Advanced: targets caller uid " + entry.slice(4)
@@ -234,6 +237,7 @@ function scopeWidget(d, value, ctx) {
       }, [
         (isUid || missing) ? el("span", { class: "scope-chip-dot", "aria-hidden": "true" }) : null,
         el("span", { class: "chip-text" + (isUid ? " mono" : ""), text: label }),
+        userId ? el("span", { class: "chip-sub", text: "user " + userId }) : null,
       ]);
     });
     if (apps.length > SCOPE_PREVIEW_MAX) {

--- a/module/webroot/js/ui/scope-view.js
+++ b/module/webroot/js/ui/scope-view.js
@@ -10,9 +10,9 @@
 //   renderScope(host, state, actions)
 //     host    the overlay content node (an .editor-host div)
 //     state   { profileName, apps, packages, claimedByOther, firstAppUid,
-//               search, filter, sort, loading, error, iconUrl,
+//               search, filter, userFilter, sort, loading, error, iconUrl,
 //               autoOwner, autoInfo, autoCount, pendingSave }
-//               - apps            the DRAFT entry strings (packages + uid: tokens)
+//               - apps            the DRAFT entry strings (packages, pkg@user names + uid: tokens)
 //               - autoOwner       Map(uid -> profile name) for uids the DAEMON includes automatically
 //                                 (autoIncludeNewApps). These are NEVER in `apps` — config.json does
 //                                 not name them — so this is the only way the picker can know. The
@@ -27,27 +27,34 @@
 // never both selected and auto: pinning an app removes it from the daemon's auto set on the next
 // resolve (Scope.kt drops uids the profile now names explicitly).
 //               - packages        the keyAdmin("packages") result, or null while loading; each
-//                                 row carries uid/packages/label/system/launchable/enabled plus
-//                                 the usage columns installTime/freq/lastUsed/recent
+//                                 row carries uid/userId/packages/label/system/launchable/enabled
+//                                 plus the usage columns installTime/freq/lastUsed/recent, and
+//                                 packages.users lists the device's Android users
 //               - claimedByOther  Map(entry -> owning profile name) for entries already claimed
 //                                 by ANOTHER profile (greyed out and inert here)
-//               - firstAppUid     Process.FIRST_APPLICATION_UID; uids below it warn
+//               - firstAppUid     Process.FIRST_APPLICATION_UID; a uid whose APP id (uid % 100000,
+//                                 so the test holds in a secondary user too) is below it warns
 //               - filter          "recent" | "user" | "system" | "selected" (Recent is default)
+//               - userFilter      an Android user id to show alone, or null for every user
 //               - sort            "freq" | "recent" | "name" | "install"
-//               - iconUrl         fn(pkg) -> a daemon /icon URL string, or null before the admin
-//                                 token is in hand; the row <img> falls back to a letter-avatar
+//               - iconUrl         fn(pkg, userId) -> a daemon /icon URL string, or null before the
+//                                 admin token is in hand; the row <img> falls back to a letter-avatar
 //     actions { onClose (leave — asks to keep changes if any), onDone (commit + leave),
 //               onToggleApp(entry), onSetSearch(text), onSearchSubmit(),
-//               onSetFilter(id), onOpenSort(), onClearUsage(),
+//               onSetFilter(id), onSetUserFilter(id|null), onOpenSort(), onClearUsage(),
 //               onSelectAllVisible(entries), onClearVisible(entries), onInvertVisible(entries) }
 //
-// Selecting a normal app toggles its PACKAGE-NAME entry (the primary, sorted package), never a
+// One app installed in several Android users is several rows — its work-profile copy runs under its
+// own uid and is a separate caller to keystore, so it is targeted separately. A row therefore
+// selects the entry naming ITS user: "com.foo" in the primary user, "com.foo@10" in user 10.
+//
+// Selecting a normal app toggles that PACKAGE-NAME entry (the primary, sorted package), never a
 // uid: token — uid tokens are advanced and only ever added/removed manually, or removed from
 // the pinned "In scope" section here. The three bulk ops act on the CURRENTLY visible rows
 // only: the view computes that set and hands it to the controller as { add, cur } descriptors.
 
 import { el, clear, svgIcon, ICON_SEARCH, ICON_SORT } from "./dom.js";
-import { UID_RE } from "../domain/schema.js";
+import { UID_RE, entryToken, splitEntry } from "../domain/schema.js";
 
 const SEARCH_ID = "scope-search-input";
 
@@ -78,18 +85,35 @@ function avatarLetter(label, pkg) {
   return /[a-z0-9]/i.test(ch) ? ch.toUpperCase() : "#";
 }
 
+// The apps[] entries that would select this row — one per package it groups, each naming the row's
+// Android user. The first is the primary: what a plain tap adds.
+function rowEntries(row) {
+  return (row.packages || []).map((p) => entryToken(p, row.userId || 0));
+}
+
+// The user a row belongs to, as the picker shows it. `users` is the daemon's list; an id missing
+// from it (a profile removed between two fetches) still gets an honest "user N" rather than nothing.
+function userOf(row, users) {
+  const id = row.userId || 0;
+  const found = (users || []).find((u) => u.id === id);
+  return found || { id, name: id === 0 ? "Owner" : "User " + id, managed: false };
+}
+
 export function renderScope(host, state, actions) {
   const focus = captureFocus(host);
   clear(host);
 
   const {
     profileName, apps = [], packages = null, claimedByOther = new Map(),
-    firstAppUid = 10000, search = "", filter = "recent", sort = "freq",
+    firstAppUid = 10000, search = "", filter = "recent", userFilter = null, sort = "freq",
     loading = false, error = null,
     // Defaulted so an older daemon (no /scope route) renders exactly the previous UI.
     autoOwner = new Map(), autoInfo = null, autoCount = 0, pendingSave = false,
   } = state;
   const iconUrl = typeof state.iconUrl === "function" ? state.iconUrl : () => null;
+  // An older daemon answers /packages without `users`; then every row is user 0 and no user
+  // segmented control is drawn, which is exactly the single-user device's view too.
+  const users = (packages && Array.isArray(packages.users)) ? packages.users : [];
 
   const appsSet = new Set(apps);
   // "In scope automatically, for THIS profile, and not already pinned." A pinned row is selected,
@@ -109,7 +133,7 @@ export function renderScope(host, state, actions) {
   // ---- search row: a leading search-icon button inside the field, a trailing sort button ----
   const searchInput = el("input", {
     id: SEARCH_ID, class: "input scope-search-input", type: "search", value: search,
-    placeholder: "Search apps, packages, or uid…",
+    placeholder: "Search apps, packages, users, or uid…",
     autocapitalize: "off", autocorrect: "off", spellcheck: "false",
     oninput: (e) => actions.onSetSearch(e.target.value),
     onkeydown: (e) => { if (e.key === "Enter") { e.preventDefault(); actions.onSearchSubmit(); } },
@@ -134,6 +158,21 @@ export function renderScope(host, state, actions) {
       onclick: () => actions.onSetFilter(f.id),
     }, f.label))));
 
+  // ---- user filter: only on a device that HAS more than one user ---------
+  // A work profile roughly doubles the list, and the same app then appears once per user, so the
+  // narrowing control earns its row there — and is absent (identical to the old UI) everywhere else.
+  if (users.length > 1) {
+    const segs = [{ id: null, label: "All users" }].concat(
+      users.map((u) => ({ id: u.id, label: u.name })));
+    body.appendChild(el("div", { class: "segmented scope-users" },
+      segs.map((s) => el("button", {
+        type: "button", class: "seg" + (userFilter === s.id ? " on" : ""),
+        "aria-pressed": userFilter === s.id ? "true" : "false",
+        title: s.id == null ? "Show apps from every Android user" : "Show only user " + s.id,
+        onclick: () => actions.onSetUserFilter(s.id),
+      }, s.label))));
+  }
+
   // ---- loading / error short-circuits ---------------------------------
   if (loading) {
     body.appendChild(el("div", { class: "scope-status" }, [
@@ -148,11 +187,13 @@ export function renderScope(host, state, actions) {
 
   // The installed inventory, for both the pinned "orphan" computation and the main list.
   const installed = (packages && Array.isArray(packages.apps)) ? packages.apps : [];
-  const installedPkgs = new Set();
+  // Entries, not bare package names: "com.foo" is installed only if user 0 has it, and the pinned
+  // section below decides what to show from exactly that distinction.
+  const installedEntries = new Set();
   const installedUids = new Set();
   for (const row of installed) {
     installedUids.add(row.uid);
-    (row.packages || []).forEach((p) => installedPkgs.add(p));
+    rowEntries(row).forEach((e) => installedEntries.add(e));
   }
 
   // The visible rows: search + group filter, then sorted. Computed once so the ops row and the
@@ -162,7 +203,8 @@ export function renderScope(host, state, actions) {
   // scope, so the Selected tab must list it and the float-to-top must lift it.
   const inScope = (row) => isSelected(row, appsSet) || autoMine(row);
   const rows = installed
-    .filter((row) => matchSearch(row, q))
+    .filter((row) => userFilter == null || (row.userId || 0) === userFilter)
+    .filter((row) => matchSearch(row, q, userOf(row, users)))
     .filter((row) => matchFilter(row, filter, inScope(row)))
     // Selected rows always float to the top of every group (and of a search result), with the chosen
     // sort applied within the selected and unselected partitions alike — so what you've picked is
@@ -185,11 +227,13 @@ export function renderScope(host, state, actions) {
   // Clear and Invert have no meaning on them, and Select-all pinning the whole auto set in one tap
   // is never what the gesture was asking for. Only a deliberate per-row tap pins one.
   const visibleEntries = rows
-    .filter((row) => !claimOf(row, claimedByOther) && row.uid >= firstAppUid && !autoOwner.has(row.uid))
+    // The privileged test is on the APP id: user 10's system uid is 1001000, above firstAppUid yet
+    // no less privileged than user 0's 1000.
+    .filter((row) => !claimOf(row, claimedByOther) && row.uid % 100000 >= firstAppUid && !autoOwner.has(row.uid))
     .map((row) => {
-      const pkgs = row.packages || [];
-      const add = pkgs[0] || ("uid:" + row.uid);
-      const cur = pkgs.find((p) => appsSet.has(p)) || (appsSet.has("uid:" + row.uid) ? "uid:" + row.uid : null);
+      const entries = rowEntries(row);
+      const add = entries[0] || ("uid:" + row.uid);
+      const cur = entries.find((e) => appsSet.has(e)) || (appsSet.has("uid:" + row.uid) ? "uid:" + row.uid : null);
       return { add, cur };
     });
 
@@ -232,20 +276,26 @@ export function renderScope(host, state, actions) {
   // with a remove ✕. (Installed selections just show checked in the list.)
   const orphans = apps.filter((entry) => {
     if (UID_RE.test(entry)) return !installedUids.has(Number(entry.slice(4)));
-    return !installedPkgs.has(entry);
+    return !installedEntries.has(entry);
   });
   if (orphans.length) {
     body.appendChild(el("div", { class: "scope-pinned" }, [
       el("div", { class: "scope-section-title", text: "In scope" }),
       el("div", { class: "applist" }, orphans.map((entry) => {
         const isUid = UID_RE.test(entry);
+        const { pkg, userId } = splitEntry(entry);
+        // "Not installed" is a per-user answer: the app may well be on the device, just not in the
+        // user this entry names, and saying so is the difference between a typo and a stale target.
+        const where = userId ? " for " + userOf({ userId }, users).name : "";
         return el("span", {
           class: "chip removable scope-chip" + (isUid ? " advanced" : " warn"),
-          title: isUid ? "Advanced: targets caller uid " + entry.slice(4) : entry + " is not installed on this device",
+          title: isUid
+            ? "Advanced: targets caller uid " + entry.slice(4)
+            : pkg + " is not installed" + (where || " on this device"),
         }, [
           isUid ? el("span", { class: "chip-avatar-uid", "aria-hidden": "true", text: "#" }) : null,
           el("span", { class: "chip-text" + (isUid ? " mono" : ""), text: entry }),
-          el("span", { class: "chip-sub", text: isUid ? "advanced uid" : "not installed" }),
+          el("span", { class: "chip-sub", text: isUid ? "advanced uid" : "not installed" + where }),
           el("button", { type: "button", class: "chip-x", "aria-label": "Remove " + entry, text: "✕", onclick: () => actions.onToggleApp(entry) }),
         ]);
       })),
@@ -265,7 +315,7 @@ export function renderScope(host, state, actions) {
     } else if (rows.length) {
       const list = el("div", { class: "scope-list" });
       for (const row of rows) {
-        list.appendChild(scopeRow(row, { appsSet, claimedByOther, firstAppUid, iconUrl, autoOwner, profileName }, actions));
+        list.appendChild(scopeRow(row, { appsSet, claimedByOther, firstAppUid, iconUrl, autoOwner, profileName, users, showUser: users.length > 1 }, actions));
       }
       body.appendChild(list);
     }
@@ -294,17 +344,20 @@ function emptyText(filter, total, q) {
   return "No apps match.";
 }
 
-// Is this uid-row currently in scope — by any of its package names, or by a uid: token?
+// Is this uid-row currently in scope — by one of its entries (each naming this row's user), or by
+// a uid: token?
 function isSelected(row, appsSet) {
   if (appsSet.has("uid:" + row.uid)) return true;
-  return (row.packages || []).some((p) => appsSet.has(p));
+  return rowEntries(row).some((e) => appsSet.has(e));
 }
 
-function matchSearch(row, q) {
+function matchSearch(row, q, user) {
   if (!q) return true;
   if (row.label && row.label.toLowerCase().includes(q)) return true;
   if (String(row.uid).includes(q)) return true;
-  return (row.packages || []).some((p) => p.toLowerCase().includes(q));
+  // The user is searchable by name and by its entry suffix, so "@10" and "work" both narrow to it.
+  if (user && user.name && user.name.toLowerCase().includes(q)) return true;
+  return rowEntries(row).some((e) => e.toLowerCase().includes(q));
 }
 
 function matchFilter(row, filter, selected) {
@@ -316,9 +369,11 @@ function matchFilter(row, filter, selected) {
   return true;
 }
 
-// Whom does this row belong to elsewhere? Any of its packages or its uid token; null if free.
+// Whom does this row belong to elsewhere? Any of its entries or its uid token; null if free. The
+// entries carry the row's user, so another profile holding the SAME app in a DIFFERENT user does
+// not claim this row — two users' copies are two callers and may legitimately sit apart.
 function claimOf(row, claimedByOther) {
-  for (const p of (row.packages || [])) if (claimedByOther.has(p)) return claimedByOther.get(p);
+  for (const e of rowEntries(row)) if (claimedByOther.has(e)) return claimedByOther.get(e);
   if (claimedByOther.has("uid:" + row.uid)) return claimedByOther.get("uid:" + row.uid);
   return null;
 }
@@ -348,24 +403,31 @@ function byLabel(a, b) {
 // per-app exclusion, so the check is honestly a pin/unpin control whose "off" floor is "still in
 // scope automatically". The title says exactly that, because the pill alone cannot.
 function scopeRow(row, ctx, actions) {
-  const { appsSet, claimedByOther, firstAppUid, iconUrl, autoOwner = new Map(), profileName } = ctx;
+  const {
+    appsSet, claimedByOther, firstAppUid, iconUrl, autoOwner = new Map(), profileName,
+    users = [], showUser = false,
+  } = ctx;
   const pkgs = (row.packages || []).slice();
-  const primary = pkgs[0] || ("uid:" + row.uid);
-  const label = row.label || primary;
+  const entries = rowEntries(row);
+  const primary = entries[0] || ("uid:" + row.uid);
+  const label = row.label || pkgs[0] || primary;
+  const user = userOf(row, users);
 
-  const selectedByPkg = pkgs.find((p) => appsSet.has(p));
+  const selectedByPkg = entries.find((e) => appsSet.has(e));
   const selectedByUid = appsSet.has("uid:" + row.uid);
   const selected = !!selectedByPkg || selectedByUid;
 
   const claimedBy = claimOf(row, claimedByOther);
-  const lowUid = row.uid < firstAppUid;
+  // Asked of the app id, not the raw uid: user 10's system_server is uid 1001000, which is above
+  // firstAppUid yet every bit as privileged as user 0's 1000.
+  const lowUid = row.uid % 100000 < firstAppUid;
 
   // The entry a tap acts on: the package/token that is selected (to remove it) or the primary
   // package (to add it).
   const toggleEntry = selectedByPkg || (selectedByUid ? ("uid:" + row.uid) : primary);
 
-  const pkgLine = pkgs.length
-    ? (pkgs.length === 1 ? pkgs[0] : pkgs[0] + " +" + (pkgs.length - 1))
+  const pkgLine = entries.length
+    ? (entries.length === 1 ? entries[0] : entries[0] + " +" + (entries.length - 1))
     : "uid:" + row.uid;
 
   const autoBy = autoOwner.get(row.uid) || null;
@@ -373,6 +435,14 @@ function scopeRow(row, ctx, actions) {
   const autoOther = !!autoBy && autoBy !== profileName;
 
   const pills = [];
+  // Which user this copy of the app lives in — drawn only where the device actually has more than
+  // one, so a single-user phone keeps the row it always had.
+  if (showUser)
+    pills.push(el("span", {
+      class: "pill scope-user" + (user.managed ? " managed" : ""),
+      title: "Installed for user " + user.id + (user.managed ? " (work profile)" : ""),
+      text: user.name,
+    }));
   if (lowUid) pills.push(el("span", { class: "pill warn scope-pill", text: "system uid" }));
   if (claimedBy) pills.push(el("span", { class: "chip small scope-claimed", text: "in " + claimedBy }));
   if (autoMine) pills.push(el("span", { class: "pill scope-auto", text: "auto" }));
@@ -398,7 +468,7 @@ function scopeRow(row, ctx, actions) {
     title,
     onclick: claimedBy ? null : () => actions.onToggleApp(toggleEntry),
   }, [
-    iconEl(row, primary, label, iconUrl),
+    iconEl(row, pkgs[0] || primary, label, iconUrl),
     el("span", { class: "scope-meta" }, [
       el("span", { class: "scope-label" }, [
         el("span", { class: "scope-name", text: label }),
@@ -419,7 +489,9 @@ function iconEl(row, primary, label, iconUrl) {
     class: "scope-avatar", style: "background:" + hashColor(label + "/" + row.uid), text: avatarLetter(row.label, primary),
   });
   const pkg = (row.packages || [])[0];
-  const url = pkg ? iconUrl(pkg) : null;
+  // The user rides along: an app that exists only in a work profile has no record in user 0 for the
+  // daemon to read an icon out of.
+  const url = pkg ? iconUrl(pkg, row.userId || 0) : null;
   if (!url) { wrap.appendChild(avatar()); return wrap; }
   const img = el("img", {
     class: "scope-ico-img", loading: "lazy", decoding: "async", alt: "", src: url,

--- a/module/webroot/tests/domain.test.mjs
+++ b/module/webroot/tests/domain.test.mjs
@@ -8,7 +8,8 @@ import assert from "node:assert/strict";
 
 import {
   emptyProfile, emptyConfig,
-  PKG_RE, PROFILE_RE, KEYBOX_RE, PATCH_RE, OSVER_RE, MODE_RE, UID_RE, APP_ENTRY_RE,
+  PKG_RE, PKG_USER_RE, PROFILE_RE, KEYBOX_RE, PATCH_RE, OSVER_RE, MODE_RE, UID_RE, APP_ENTRY_RE,
+  splitEntry, entryToken,
 } from "../js/domain/schema.js";
 import { validateConfig, validateProfile } from "../js/domain/validate.js";
 
@@ -138,6 +139,46 @@ test("a malformed uid token is rejected", () => {
   }
 });
 
+// --- scope: per-user (work profile / secondary user) entries -------------
+test("a pkg@user entry is accepted as an app entry", () => {
+  const r = validateConfig(configWith({ p: validProfile(["com.ok", "com.ok@10", "com.other@11"]) }));
+  assert.equal(r.ok, true, JSON.stringify(r.errors));
+});
+
+test("a malformed user suffix is rejected", () => {
+  for (const bad of ["com.ok@", "com.ok@x", "com.ok@ 10", "com.ok@-1", "com.ok@1.0", "com.ok@10@11", "@10"]) {
+    const r = validateConfig(configWith({ p: validProfile([bad]) }));
+    assert.equal(r.ok, false, `expected ${bad} to be rejected`);
+    assert.ok(r.errors.some((e) => e.field === "apps"), `expected an apps error for ${bad}`);
+  }
+});
+
+test("the same package in two users may live in two profiles", () => {
+  // They are two callers with two uids, so this is not the double-claim the router forbids.
+  const r = validateConfig(configWith({ a: validProfile(["com.dual"]), b: validProfile(["com.dual@10"]) }));
+  assert.equal(r.ok, true, JSON.stringify(r.errors));
+});
+
+test("the same pkg@user in two profiles is still a duplicate claim", () => {
+  const r = validateConfig(configWith({ a: validProfile(["com.dual@10"]), b: validProfile(["com.dual@10"]) }));
+  assert.equal(r.ok, false);
+  assert.ok(r.errors.some((e) => e.field === "apps" && /unique/i.test(e.msg)));
+});
+
+test("splitEntry / entryToken round-trip an entry", () => {
+  assert.deepEqual(splitEntry("com.foo"), { pkg: "com.foo", userId: 0 });
+  assert.deepEqual(splitEntry("com.foo@10"), { pkg: "com.foo", userId: 10 });
+  // A malformed suffix is never split: the whole string stays the package, so a caller sees the
+  // entry validation already rejects rather than a silently truncated name.
+  assert.deepEqual(splitEntry("com.foo@x"), { pkg: "com.foo@x", userId: 0 });
+  assert.equal(entryToken("com.foo", 0), "com.foo");
+  assert.equal(entryToken("com.foo", 10), "com.foo@10");
+  for (const e of ["com.foo", "com.foo@10", "com.foo@0"]) {
+    const { pkg, userId } = splitEntry(e);
+    assert.equal(entryToken(pkg, userId), e === "com.foo@0" ? "com.foo" : e);
+  }
+});
+
 test("autoIncludeNewApps=true makes an empty apps list valid", () => {
   const p = validProfile([]);
   p.autoIncludeNewApps = true;
@@ -174,7 +215,9 @@ test("exactly one profile auto-including new apps is fine", () => {
 const cases = [
   [PKG_RE, ["com.foo", "com.foo.bar", "a_b.c", "A9._"], ["", "com foo", "com;rm -rf", "com/foo", "com-foo"]],
   [UID_RE, ["uid:0", "uid:10123", "uid:2000"], ["", "uid:", "uid:x", "uid: 10", "uid:-1", "uid:10.0", "10123", "com.foo"]],
-  [APP_ENTRY_RE, ["com.foo", "com.foo.bar", "uid:0", "uid:10123"], ["", "uid:", "uid:x", "com foo", "com/foo", "uid:1.0"]],
+  [PKG_USER_RE, ["com.foo@10", "a_b.c@0", "A9._@999"], ["com.foo", "", "com.foo@", "com.foo@x", "@10", "com.foo@1.0", "com.foo@10@11"]],
+  [APP_ENTRY_RE, ["com.foo", "com.foo.bar", "com.foo@10", "com.foo@0", "uid:0", "uid:10123"],
+    ["", "uid:", "uid:x", "com foo", "com/foo", "uid:1.0", "com.foo@", "com.foo@x", "@10", "com.foo@10@11", "uid:10@1"]],
   [PROFILE_RE, ["pixel", "a-b_c", "x".repeat(32)], ["", "x".repeat(33), "has space", "bad!", "dot.name"]],
   [KEYBOX_RE, ["keybox.xml", "a-b_c.1.xml"], ["keybox", "keybox.XML", "../x.xml", "a b.xml", "keybox.xml.bak"]],
   [PATCH_RE, ["today", "no", "harvested", "system_property", "2024-01", "2024-12", "2024-01-15", "2024-12-31", "YYYY-MM", "YYYY-MM-05", "YYYY-MM-DD"], ["2024", "2024-1", "2024-1-1", "yesterday", "", "2024-00", "2024-13", "2024-01-00", "2024-01-32", "2024-13-01", "MM-05", "YYYY-13-01"]],

--- a/stub/src/main/java/android/content/pm/IPackageManager.java
+++ b/stub/src/main/java/android/content/pm/IPackageManager.java
@@ -1,5 +1,6 @@
 package android.content.pm;
 
+import android.content.Intent;
 import android.os.IBinder;
 
 public interface IPackageManager {
@@ -8,6 +9,23 @@ public interface IPackageManager {
     PackageInfo getPackageInfo(String packageName, long flags, int userId);
 
     PackageInfo getPackageInfo(String packageName, int flags, int userId);
+
+    // The `flags` argument widened from int to long in Android 13 (T), so every bulk/per-user call
+    // below is declared twice and picked by SDK level; calling the wrong one lands on a
+    // NoSuchMethodError, which the daemon catches and retries with the other.
+    ApplicationInfo getApplicationInfo(String packageName, long flags, int userId);
+
+    ApplicationInfo getApplicationInfo(String packageName, int flags, int userId);
+
+    ParceledListSlice<ApplicationInfo> getInstalledApplications(long flags, int userId);
+
+    ParceledListSlice<ApplicationInfo> getInstalledApplications(int flags, int userId);
+
+    ParceledListSlice<ResolveInfo> queryIntentActivities(
+            Intent intent, String resolvedType, long flags, int userId);
+
+    ParceledListSlice<ResolveInfo> queryIntentActivities(
+            Intent intent, String resolvedType, int flags, int userId);
 
     class Stub {
         public static IPackageManager asInterface(IBinder binder) {

--- a/stub/src/main/java/android/content/pm/ParceledListSlice.java
+++ b/stub/src/main/java/android/content/pm/ParceledListSlice.java
@@ -1,0 +1,13 @@
+package android.content.pm;
+
+import java.util.List;
+
+/**
+ * The chunked list wrapper every bulk IPackageManager call returns. Declared raw (the framework
+ * class is generic over Parcelable) because the daemon only ever calls getList() and casts.
+ */
+public class ParceledListSlice<T> {
+    public List<T> getList() {
+        throw new UnsupportedOperationException("STUB!");
+    }
+}

--- a/stub/src/main/java/android/content/pm/UserInfo.java
+++ b/stub/src/main/java/android/content/pm/UserInfo.java
@@ -1,0 +1,10 @@
+package android.content.pm;
+
+/** The framework's per-user record. Only the three fields the daemon reads are declared. */
+public class UserInfo {
+    public static final int FLAG_MANAGED_PROFILE = 0x00000020;
+
+    public int id;
+    public String name;
+    public int flags;
+}

--- a/stub/src/main/java/android/os/IUserManager.java
+++ b/stub/src/main/java/android/os/IUserManager.java
@@ -1,0 +1,20 @@
+package android.os;
+
+import android.content.pm.UserInfo;
+import java.util.List;
+
+public interface IUserManager {
+    // Android 11 (R) and later. Android 10 has the single-argument form below instead, so a caller
+    // must pick by SDK level and be ready for a NoSuchMethodError when a ROM disagrees.
+    List<UserInfo> getUsers(boolean excludePartial, boolean excludeDying, boolean excludePreCreated);
+
+    List<UserInfo> getUsers(boolean excludeDying);
+
+    UserInfo getUserInfo(int userId);
+
+    class Stub {
+        public static IUserManager asInterface(IBinder binder) {
+            throw new UnsupportedOperationException("STUB!");
+        }
+    }
+}


### PR DESCRIPTION
The Scope picker only ever saw user 0: `getInstalledApplications(0)` and `getPackageUid(pkg, 0)` answer for the user the daemon's system context belongs to, so an app installed in a work profile never appeared. Routing was half-blind the same way — a per-user copy runs as `userId * 100000 + appId`, so the caller-uid leg never matched it while the attestation name-match leg did.

An `apps[]` entry now names a user: `com.foo` is the primary user's copy, `com.foo@10` the one inside user 10. `Packages` enumerates users through `IUserManager` and their apps through `IPackageManager`'s per-user overloads, which root may call. `packageUsers[]` rides beside `packages[]`, since an attestation application id names the package but never the user, and `uidPackages[]` replaces keystore1's positional pairing, which had been attesting uids under the wrong package.

A plain package name therefore means the primary user only, and the picker lists each user's copy as its own row. Closes #237.
