### PR TITLE
Clamp the attested KeyMint version to the device's VINTF declaration

### DIFF
--- a/app/src/main/java/org/matrix/teesim/Harvester.kt
+++ b/app/src/main/java/org/matrix/teesim/Harvester.kt
@@ -366,6 +366,53 @@ object Harvester {
     }
 
     /**
+     * Cap the attestation/keymaster version we present so it never exceeds the KeyMint AIDL version the
+     * device declares in its VINTF manifest (see [Vintf.keyMintHalVersion]). That number is the ceiling an
+     * integrity checker — and Android's own attestation contract — cross-checks the attested version
+     * against, and one we cannot raise: it is baked into the vendor image. A VTS-compliant device already
+     * satisfies `attestationVersion / 100 <= vintfVersion`, so the clamp is a no-op there; it only bites an
+     * OEM image that ships an older HAL (e.g. `IKeyMintDevice/default@3` on Android 16) while its keys — or
+     * our OS-derived fabrication — claim a newer KeyMint. TEE is recorded as computed overrides so the
+     * WebUI, the config push and the TA all agree; StrongBox is clamped in its own field, which Resolver
+     * reads directly. A version below 400 also makes the TA drop MODULE_HASH, a v4-only tag, keeping the
+     * record self-consistent.
+     */
+    private fun clampAttestationToVintf(r: Record): Record {
+        var out = r
+
+        Vintf.keyMintHalVersion("default")?.let { hal ->
+            val ceiling = hal * 100
+            val current = out.effectiveInt("attestationVersion", out.attestationVersion)
+            if (current > ceiling) {
+                SystemLogger.info(
+                    "Harvest: clamping attestationVersion $current -> $ceiling to match the device's " +
+                        "VINTF-declared KeyMint HAL (IKeyMintDevice/default@$hal); a higher value would " +
+                        "contradict the vendor manifest"
+                )
+                out =
+                    out
+                        .withOverride("attestationVersion", ceiling.toString())
+                        .withOverride("keymasterVersion", keymasterVersionFor(ceiling).toString())
+            }
+        }
+
+        // StrongBox declares its own instance version; fall back to the default instance's when the manifest
+        // does not list a separate strongbox HAL (many devices share one KeyMint version across levels).
+        (Vintf.keyMintHalVersion("strongbox") ?: Vintf.keyMintHalVersion("default"))?.let { hal ->
+            val ceiling = hal * 100
+            if (out.strongBoxAttestationVersion > ceiling) {
+                SystemLogger.info(
+                    "Harvest: clamping strongBoxAttestationVersion ${out.strongBoxAttestationVersion} -> " +
+                        "$ceiling to match the device's VINTF-declared KeyMint StrongBox HAL (@$hal)"
+                )
+                out = out.copy(strongBoxAttestationVersion = ceiling)
+            }
+        }
+
+        return out
+    }
+
+    /**
      * Load the frozen record if present, attempt a fresh harvest, merge (preserving the frozen boot
      * key/hash), persist, and return the effective record.
      */
@@ -407,7 +454,7 @@ object Harvester {
             }
 
         val stable = freezeSynthBoot(effective, existing)
-        val enriched = markFabricatedAttestation(supplementDeviceIds(stable))
+        val enriched = clampAttestationToVintf(markFabricatedAttestation(supplementDeviceIds(stable)))
         persist(enriched)
         SystemLogger.info(
             "Harvest complete: failed=${enriched.harvestFailed} " +

--- a/app/src/main/java/org/matrix/teesim/Vintf.kt
+++ b/app/src/main/java/org/matrix/teesim/Vintf.kt
@@ -1,0 +1,176 @@
+package org.matrix.teesim
+
+import android.util.Xml
+import java.io.File
+import org.xmlpull.v1.XmlPullParser
+
+/**
+ * Reads the KeyMint HAL AIDL interface version the device declares in its VINTF manifest — the `@N`
+ * in `android.hardware.security.keymint.IKeyMintDevice/default@N`. An integrity checker (and
+ * Android's own attestation contract, VtsAidlKeyMintTargetTest::check_attestation_version)
+ * cross-checks the attested `attestationVersion` against this number: `attestationVersion / 100`
+ * must not exceed it. It is baked into the vendor image and we cannot raise it, so it is the hard
+ * ceiling for the version we may present.
+ *
+ * The value is parsed straight from the on-disk manifest fragments, which is exactly what the
+ * platform assembles the declaration from; the module runs as root, so the vendor/odm paths are
+ * readable. A result (including "not declared") is cached for the process — VINTF cannot change
+ * without a reboot.
+ */
+object Vintf {
+
+    // The KeyMint HAL package and the device interface within it we care about. A hal block may
+    // also carry
+    // ISharedSecret/ISecureClock under the same package version, so the interface name is matched
+    // too.
+    private const val KEYMINT_HAL = "android.hardware.security.keymint"
+    private const val KEYMINT_IFACE = "IKeyMintDevice"
+
+    // Standard AIDL VINTF manifest locations, vendor first (KeyMint is a vendor HAL). The
+    // directories hold
+    // per-HAL fragments; the flat files are the legacy single-manifest form. All are scanned and
+    // the highest
+    // matching version wins, so a fragment declaring the real HAL is found wherever the OEM placed
+    // it.
+    private val MANIFEST_PATHS =
+        listOf(
+            "/vendor/etc/vintf/manifest.xml",
+            "/vendor/etc/vintf/manifest",
+            "/odm/etc/vintf/manifest.xml",
+            "/odm/etc/vintf/manifest",
+            "/vendor/manifest.xml",
+        )
+
+    private val cache = HashMap<String, Int?>()
+
+    /**
+     * The declared KeyMint AIDL version for [instance] (e.g. 3 for `IKeyMintDevice/default@3`), or
+     * null when no manifest declares it — a software-only device, or one whose manifest we could
+     * not read. Cached per instance, so repeated harvests pay the scan once.
+     */
+    @Synchronized
+    fun keyMintHalVersion(instance: String = "default"): Int? {
+        if (cache.containsKey(instance)) return cache[instance]
+        val v = runCatching {
+            scan(instance)
+        }
+            .getOrElse {
+                SystemLogger.info(
+                    "Vintf: manifest scan failed: ${it.javaClass.simpleName}: ${it.message}"
+                )
+                null
+            }
+        cache[instance] = v
+        SystemLogger.info(
+            "Vintf: declared KeyMint HAL version for instance '$instance' = ${v ?: "unknown"}"
+        )
+        return v
+    }
+
+    /** The highest KeyMint version declared for [instance] across every candidate manifest file. */
+    private fun scan(instance: String): Int? {
+        var best: Int? = null
+        for (path in MANIFEST_PATHS) {
+            val f = File(path)
+            val files =
+                when {
+                    !f.exists() -> emptyList()
+                    f.isDirectory ->
+                        f.listFiles { file -> file.isFile && file.name.endsWith(".xml") }?.toList()
+                            ?: emptyList()
+                    else -> listOf(f)
+                }
+            for (file in files) {
+                versionIn(file, instance)?.let { v -> best = maxOf(best ?: v, v) }
+            }
+        }
+        return best
+    }
+
+    /**
+     * The highest KeyMint `IKeyMintDevice/[instance]` AIDL version declared in one manifest file,
+     * or null. Walks each `<hal format="aidl">` block, collecting its package name, its version(s),
+     * and the instances it exposes — modern `<fqname>IKeyMintDevice/default</fqname>`, or the older
+     * `<interface><name>IKeyMintDevice</name><instance>default</instance></interface>` — and keeps
+     * the version of any block that both names KeyMint and exposes the requested instance.
+     *
+     * Element nesting is read from the parser depth (manifest=1, hal=2, a direct child of hal=3, a
+     * child of <interface>=4), which is how a package `<name>`/`<version>` is told apart from an
+     * interface `<name>` and its `<instance>`.
+     */
+    private fun versionIn(file: File, instance: String): Int? {
+        var best: Int? = null
+        file.inputStream().use { input ->
+            val parser = Xml.newPullParser()
+            parser.setInput(input, null)
+
+            // Per-<hal> accumulation, reset at each <hal> start.
+            var inHal = false
+            var isAidl = false
+            var halName: String? = null
+            val versions = ArrayList<Int>()
+            var instanceMatched = false
+            var ifaceName: String? = null // name of the <interface> currently being read
+
+            var event = parser.eventType
+            while (event != XmlPullParser.END_DOCUMENT) {
+                if (event == XmlPullParser.START_TAG) {
+                    val depth = parser.depth
+                    when (parser.name) {
+                        "hal" -> {
+                            inHal = true
+                            isAidl = "aidl".equals(parser.getAttributeValue(null, "format"), true)
+                            halName = null
+                            versions.clear()
+                            instanceMatched = false
+                            ifaceName = null
+                        }
+                        "interface" -> if (inHal) ifaceName = null
+                        "name" ->
+                            if (inHal) {
+                                val text = readText(parser)
+                                // depth 3: the package name under <hal>; depth 4: the interface
+                                // name.
+                                if (depth <= 3) halName = halName ?: text else ifaceName = text
+                            }
+                        "version" ->
+                            if (inHal && depth <= 3)
+                                readText(parser).toIntOrNull()?.let { versions.add(it) }
+                        "instance" ->
+                            if (
+                                inHal && KEYMINT_IFACE == ifaceName && readText(parser) == instance
+                            ) {
+                                instanceMatched = true
+                            }
+                        "fqname" ->
+                            if (inHal) {
+                                // Format: "IKeyMintDevice/default" (interface/instance).
+                                val fq = readText(parser)
+                                if (
+                                    fq.substringBefore('/') == KEYMINT_IFACE &&
+                                        fq.substringAfterLast('/') == instance
+                                ) {
+                                    instanceMatched = true
+                                }
+                            }
+                    }
+                } else if (event == XmlPullParser.END_TAG && parser.name == "hal") {
+                    if (inHal && isAidl && halName == KEYMINT_HAL && instanceMatched) {
+                        versions.maxOrNull()?.let { v -> best = maxOf(best ?: v, v) }
+                    }
+                    inHal = false
+                }
+                event = parser.next()
+            }
+        }
+        return best
+    }
+
+    /**
+     * Trimmed text of the element the parser is positioned on. Leaves the parser on the element's
+     * END_TAG, so the caller's `parser.next()` advances past it — matching a plain
+     * START_TAG/TEXT/END_TAG walk.
+     */
+    private fun readText(parser: XmlPullParser): String =
+        if (parser.next() == XmlPullParser.TEXT) parser.text?.trim().orEmpty() else ""
+}


### PR DESCRIPTION
Reported in #246 on a OnePlus Ace 5 Pro (ColorOS 16, Android 16). The leaf we hand apps carries `attestationVersion` 400 (KeyMint 4.0), but the device's vendor VINTF manifest declares [`android.hardware.security.keymint.IKeyMintDevice/default@3`](https://source.android.com/docs/core/architecture/vintf) — KeyMint 3.0. A checker that cross-references the two flags the record as inconsistent, and it is right to: Android's own attestation contract requires it, [`check_attestation_version`](https://android.googlesource.com/platform/hardware/interfaces/+/refs/heads/main/security/keymint/aidl/vts/functional/KeyMintAidlTestBase.cpp) asserting `attestationVersion / 100` never exceeds the AIDL interface version. We hook the existing KeyMint channel rather than re-registering the HAL, so the manifest stays at `@3` and we cannot raise it — the only lever is to lower the version we attest so it matches.

The version we present had never been bounded by what the vendor image declares:

- On a device with working hardware it is the harvested leaf's own `attestationVersion`.
- With no working hardware it is fabricated from the OS release (`Harvester.fabricatedAttestationVersion`, Android 16 → 400).

A VTS-compliant device keeps the leaf and the manifest in step, so neither path ever over-claimed and this stayed invisible — until an OEM shipped an older KeyMint HAL than its Android release. There the leaf (or our fabrication) claims a newer KeyMint than the frozen manifest admits.

`Vintf.keyMintHalVersion` reads the declared version straight from the on-disk manifest fragments the platform assembles `@N` from — the vendor and odm locations, both the modern `<fqname>IKeyMintDevice/default</fqname>` and the older `<interface>` form — which the daemon can do because it runs as root under `app_process`. `Harvester.clampAttestationToVintf` then caps `attestationVersion`/`keymasterVersion` (TEE as computed overrides so the WebUI, the config push and the TA agree; the StrongBox instance in its own field) to `vintfVersion * 100`.

It is a no-op wherever the device is already consistent — the common case — and it needs no native change. The ceiling rides the existing config push into the TA, and a version below 400 makes the reference TA omit MODULE_HASH on its own (a v4-only tag, gated in `cert.rs`), so the record stays self-consistent at the level it now claims.

One consequence worth calling out: if the genuine OnePlus firmware is itself inconsistent (attesting 400 under `@3`, which some non-Pixel images do), our clamped 300 now differs from it. This picks self-consistency — a record that matches a compliant KeyMint 3.0 device — over mirroring a manifest/leaf contradiction, since the hard VINTF mismatch is the thing #246 is about and we cannot make the manifest say 4.