### PR TITLE
Re-root pre-existing keys as their owner so keystore2 persists the chain

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -100,8 +100,10 @@ Once the framework is up, `App.main` wires the daemon and enters `Looper.loop()`
    from the keystore2 database (**`KeystoreDb.attestedKeys`**, skipping our own keys and any leaf
    already rooted in the live keybox), asks the lib to re-sign each under the profile's keybox over
    a `resign` request on the same socket (the same patch the router applies to a fresh key), and
-   writes the patched chain back with **`Keystore2Service.updateSubcomponent`** — the key blob is
-   never touched, so the real hardware key keeps signing; only the certificate the app reads changes.
+   writes the patched chain back — as the key's **owner** first (**`updateSubcomponentAsUid`** seteuid's
+   so keystore2 accepts it), falling back to a direct database write (**`KeystoreDb.updateSubcomponents`**)
+   for anything keystore2 still refuses, mirroring the delete path. The key blob is never touched, so the
+   real hardware key keeps signing; only the certificate the app reads changes.
    Record-less and idempotent: it re-scans each run, so a keybox swap or a newly installed app
    self-heals on the next push.
 

--- a/app/src/main/java/org/matrix/teesim/App.kt
+++ b/app/src/main/java/org/matrix/teesim/App.kt
@@ -44,26 +44,48 @@ object App {
     // without blocking the config path across the multi-second fetch.
     private val usagePollLock = Any()
 
-    // The delete-helper child body (see main): keystore2 only lets a key's OWNER delete it, and only the
-    // owner's delete evicts keystore2's in-memory cache (a direct database delete does not). binder tells
-    // keystore2 the sender's EFFECTIVE uid, so we seteuid to the owner and then delete — our real uid
-    // stays root, and this is a throwaway process anyway. Exit code: 0 deleted, 1 keystore2 refused,
-    // 2 could-not-seteuid (so the parent falls back to a direct database delete + keystore2 restart).
+    // Shared body of the owner-scoped helper children the daemon spawns (see main). keystore2 authorizes
+    // an owner-only operation on a key by the caller's EFFECTIVE uid, so we seteuid to the key's owner and
+    // then run [action] against keystore2 as that app. Our real uid stays root and this is a throwaway
+    // process, so the euid drop is never reverted. [label] only names the caller in the log. Exit code:
+    // 0 success, 1 keystore2 refused (or [action] threw), 2 could-not-seteuid — the parent falls back to
+    // a direct database write on anything non-zero.
     @Suppress("DEPRECATION") // Os.seteuid is deprecated but is the only way to set the binder-reported euid
-    private fun runDeleteHelper(uid: Int, keyId: Long): Int {
+    private fun runAsOwner(label: String, uid: Int, action: () -> Boolean): Int {
         if (uid < 0) return 2
         try {
             android.system.Os.seteuid(uid)
         } catch (e: Throwable) {
-            SystemLogger.warning("delete-helper: seteuid($uid) failed: ${e.javaClass.simpleName}: ${e.message}")
+            SystemLogger.warning("$label: seteuid($uid) failed: ${e.javaClass.simpleName}: ${e.message}")
             return 2
         }
         return try {
-            if (Keystore2Service.deleteKeyById(keyId)) 0 else 1
+            if (action()) 0 else 1
         } catch (e: Throwable) {
-            SystemLogger.warning("delete-helper: deleteKeyById($keyId) as euid=$uid failed", e)
+            SystemLogger.warning("$label: keystore2 call as euid=$uid failed", e)
             1
         }
+    }
+
+    // The delete-helper child body (see main): delete the key as its owner — only the owner's delete
+    // evicts keystore2's in-memory cache (a direct database delete does not).
+    private fun runDeleteHelper(uid: Int, keyId: Long): Int =
+        runAsOwner("delete-helper", uid) { Keystore2Service.deleteKeyById(keyId) }
+
+    // The resign-helper child body (see main): swap the key's stored certificates as its owner. The leaf
+    // and the rest of the chain are read (as root) from the two files the parent wrote, BEFORE dropping
+    // to the owner uid; an unreadable file is reported as a refusal so the parent takes the DB fallback.
+    private fun runResignHelper(uid: Int, keyId: Long, leafPath: String, chainPath: String): Int {
+        val leaf: ByteArray
+        val chain: ByteArray
+        try {
+            leaf = java.io.File(leafPath).readBytes()
+            chain = java.io.File(chainPath).readBytes()
+        } catch (e: Throwable) {
+            SystemLogger.warning("resign-helper: reading cert files failed: ${e.javaClass.simpleName}: ${e.message}")
+            return 1
+        }
+        return runAsOwner("resign-helper", uid) { Keystore2Service.updateSubcomponent(keyId, leaf, chain) }
     }
 
     @JvmStatic
@@ -72,6 +94,18 @@ object App {
         // runDeleteHelper). Runs before any daemon setup and exits with the outcome as its code.
         if (args.size == 3 && args[0] == "del") {
             kotlin.system.exitProcess(runDeleteHelper(args[1].toIntOrNull() ?: -1, args[2].toLongOrNull() ?: 0L))
+        }
+        // Resign-helper mode (a child spawned to re-root one pre-existing key's certificates as its
+        // owning app — see runResignHelper). Same throwaway-child pattern as "del".
+        if (args.size == 5 && args[0] == "resign") {
+            kotlin.system.exitProcess(
+                runResignHelper(
+                    args[1].toIntOrNull() ?: -1,
+                    args[2].toLongOrNull() ?: 0L,
+                    args[3],
+                    args[4],
+                )
+            )
         }
         SystemLogger.info("TEESimulator control daemon starting")
         try {

--- a/app/src/main/java/org/matrix/teesim/Keystore2Service.kt
+++ b/app/src/main/java/org/matrix/teesim/Keystore2Service.kt
@@ -75,34 +75,43 @@ object Keystore2Service {
     }
 
     /**
-     * Delete keyentry [keyId] as its owning app [uid]. keystore2 only lets a key's owner delete it (and
-     * only that evicts its cache), so we cannot remove another app's key directly — we spawn a child
-     * app_process that seteuid's to [uid] before calling keystore2 (binder reports the effective uid).
-     * The child runs as root first, so it can read our dex; App.main handles the "del" arguments. Returns
-     * the child's exit code: 0 deleted, 1 keystore2 refused, 2 could-not-seteuid, -1 could-not-spawn.
+     * Run one owner-only keystore2 operation on keyentry [keyId] as its owning app [uid]. keystore2
+     * authorizes such operations (delete, cert update) by the caller's EFFECTIVE uid, and only the owner
+     * qualifies, so the daemon cannot act on another app's key directly. Instead we spawn a throwaway
+     * app_process that re-executes [App] with subcommand [op]: it seteuid's to [uid] and calls keystore2
+     * as that app (binder reports the effective uid). The child runs as root first, so it can read our
+     * dex; [App.main] parses `op uid keyId [extraArgs…]`. Returns the child's exit code: 0 done,
+     * 1 keystore2 refused, 2 could-not-seteuid, -1 could-not-spawn.
      */
-    fun deleteKeyByIdAsUid(keyId: Long, uid: Int): Int {
+    private fun spawnOwnerOp(op: String, uid: Int, keyId: Long, extraArgs: List<String> = emptyList()): Int {
         return try {
             val cp = System.getProperty("java.class.path")
             if (cp.isNullOrEmpty()) return -1
             val cmd = listOf(
                 "/system/bin/app_process", "-Djava.class.path=$cp", "/",
-                "--nice-name=teesim-del", "org.matrix.teesim.App", "del", uid.toString(), keyId.toString(),
-            )
+                "--nice-name=teesim-$op", "org.matrix.teesim.App", op, uid.toString(), keyId.toString(),
+            ) + extraArgs
             val p = ProcessBuilder(cmd).redirectErrorStream(true).start()
             val out = p.inputStream.bufferedReader().readText().trim()
             p.waitFor()
             val code = p.exitValue()
             SystemLogger.info(
-                "deleteKeyByIdAsUid(keyId=$keyId, uid=$uid): child exit $code" +
+                "spawnOwnerOp('$op', keyId=$keyId, uid=$uid): child exit $code" +
                     if (out.isEmpty()) "" else " | ${out.takeLast(180)}"
             )
             code
         } catch (e: Throwable) {
-            SystemLogger.warning("deleteKeyByIdAsUid(keyId=$keyId, uid=$uid) spawn failed", e)
+            SystemLogger.warning("spawnOwnerOp('$op', keyId=$keyId, uid=$uid) spawn failed", e)
             -1
         }
     }
+
+    /**
+     * Delete keyentry [keyId] as its owning app [uid] — the owner-scoped delete (see [spawnOwnerOp]).
+     * Only the owner's delete evicts keystore2's cache, so a direct database delete is the caller's
+     * fallback. Returns 0 deleted, 1 keystore2 refused, 2 could-not-seteuid, -1 could-not-spawn.
+     */
+    fun deleteKeyByIdAsUid(keyId: Long, uid: Int): Int = spawnOwnerOp("del", uid, keyId)
 
     /**
      * Fetch keystore2's stored supplementary attestation info for [tag] (e.g. MODULE_HASH's DER-encoded
@@ -156,6 +165,33 @@ object Keystore2Service {
                 "Keystore2Service.updateSubcomponent($keyId) failed: ${cause.javaClass.simpleName}: ${cause.message}"
             )
             false
+        }
+    }
+
+    /**
+     * Re-root keyentry [keyId]'s stored certificates as its owning app [uid] — the owner-scoped cert
+     * update (see [spawnOwnerOp]). The leaf and the rest of the chain go to the child through two
+     * short-lived files under [Const.DATA_DIR] (argv can't carry DER cleanly), which the child reads as
+     * root before it drops to [uid]. Returns 0 updated, 1 keystore2 refused (or the certs were
+     * unreadable), 2 could-not-seteuid, -1 could-not-spawn — the caller falls back to a direct database
+     * write on any non-zero result.
+     */
+    fun updateSubcomponentAsUid(keyId: Long, uid: Int, leaf: ByteArray, chain: ByteArray): Int {
+        val dir = java.io.File(Const.DATA_DIR, ".resign").apply { mkdirs() }
+        val leafFile = java.io.File(dir, "$keyId.leaf")
+        val chainFile = java.io.File(dir, "$keyId.chain")
+        return try {
+            leafFile.writeBytes(leaf)
+            chainFile.writeBytes(chain)
+            spawnOwnerOp("resign", uid, keyId, listOf(leafFile.absolutePath, chainFile.absolutePath))
+        } catch (e: Throwable) {
+            SystemLogger.warning(
+                "updateSubcomponentAsUid(keyId=$keyId, uid=$uid) failed: ${e.javaClass.simpleName}: ${e.message}"
+            )
+            -1
+        } finally {
+            try { leafFile.delete() } catch (_: Throwable) {}
+            try { chainFile.delete() } catch (_: Throwable) {}
         }
     }
 

--- a/app/src/main/java/org/matrix/teesim/KeystoreDb.kt
+++ b/app/src/main/java/org/matrix/teesim/KeystoreDb.kt
@@ -1,5 +1,6 @@
 package org.matrix.teesim
 
+import android.content.ContentValues
 import android.database.sqlite.SQLiteDatabase
 import android.os.Build
 import java.io.ByteArrayInputStream
@@ -60,6 +61,11 @@ object KeystoreDb {
 
     // The KeyMint attestation extension OID; a leaf carrying it has attestation content to re-root.
     private const val ATTEST_EXT_OID = "1.3.6.1.4.1.11129.2.1.17"
+
+    // keystore2's SubComponentType (database.rs): the blobentry.subcomponent_type of a key's leaf
+    // certificate and of the rest of its chain. KEY_BLOB is 0; these two are what re-rooting rewrites.
+    private const val SUBCOMPONENT_CERT = 1 // the leaf certificate
+    private const val SUBCOMPONENT_CERT_CHAIN = 2 // the rest of the chain
 
     // keystore2 stores key parameters in `keyparameter(tag, data)`. Tag::PURPOSE is the KeyMint tag
     // enum (TagType.ENUM_REP<<28 | 1) and KeyPurpose::ATTEST_KEY is 7, so a row (PURPOSE, 7) marks an
@@ -429,6 +435,85 @@ object KeystoreDb {
             } catch (_: Throwable) {}
         }
         return deleted
+    }
+
+    /** One pre-existing key's re-rooted certificates: its keyentry id, the leaf DER, and the DER
+     *  concatenation of the rest of the chain (empty when the leaf is the whole chain). */
+    data class CertUpdate(val id: Long, val leaf: ByteArray, val chain: ByteArray)
+
+    /**
+     * Fallback for [ReAttest]: write re-rooted certificates straight into keystore2's LIVE database when
+     * the owner-as-euid API refused the update. Mirrors [deleteFromDatabase] — same WAL open, busy wait,
+     * transaction, and per-id target-app re-check — but it REPLACES the key's stored certificates instead
+     * of removing the key. It reproduces keystore2's own set_blob for a certificate: delete any existing
+     * blobentry of that subcomponent type for the key (and any blobmetadata keyed off it), then insert the
+     * new one — [SUBCOMPONENT_CERT] for the leaf, [SUBCOMPONENT_CERT_CHAIN] for the rest. Unlike a key
+     * blob, keystore2 re-reads a key's certificates from the database on each getKeyEntry, so no keystore2
+     * restart is needed for the swap to take effect. The key blob is never touched. Returns the number of
+     * keys updated; 0 on failure (e.g. SELinux denies writing keystore2's DB).
+     */
+    fun updateSubcomponents(targets: Set<Int>, updates: List<CertUpdate>): Int {
+        if (!available() || updates.isEmpty() || targets.isEmpty()) return 0
+        val src = File(KEYSTORE2_DB)
+        if (!src.isFile) return 0
+
+        var db: SQLiteDatabase? = null
+        var updated = 0
+        try {
+            db =
+                SQLiteDatabase.openDatabase(
+                    src.absolutePath,
+                    null,
+                    SQLiteDatabase.OPEN_READWRITE or SQLiteDatabase.ENABLE_WRITE_AHEAD_LOGGING,
+                )
+            db.rawQuery("PRAGMA busy_timeout=4000", null).use { it.moveToNext() }
+            if (!tableExists(db, "blobentry")) return 0
+            val hasBlobMeta = tableExists(db, "blobmetadata")
+
+            db.beginTransactionNonExclusive()
+            try {
+                for (u in updates) {
+                    if (!isTargetKey(db, u.id, targets)) continue
+                    // Clear the key's existing leaf + chain blobs (and any blobmetadata keyed off them),
+                    // then insert the re-rooted pair — exactly what keystore2's set_blob does for a cert.
+                    if (hasBlobMeta) {
+                        db.execSQL(
+                            "DELETE FROM blobmetadata WHERE blobentryid IN " +
+                                "(SELECT id FROM blobentry WHERE keyentryid=? " +
+                                "AND subcomponent_type IN ($SUBCOMPONENT_CERT, $SUBCOMPONENT_CERT_CHAIN))",
+                            arrayOf(u.id),
+                        )
+                    }
+                    db.delete(
+                        "blobentry",
+                        "keyentryid=? AND subcomponent_type IN ($SUBCOMPONENT_CERT, $SUBCOMPONENT_CERT_CHAIN)",
+                        arrayOf(u.id.toString()),
+                    )
+                    db.insert("blobentry", null, ContentValues().apply {
+                        put("subcomponent_type", SUBCOMPONENT_CERT)
+                        put("keyentryid", u.id)
+                        put("blob", u.leaf)
+                    })
+                    db.insert("blobentry", null, ContentValues().apply {
+                        put("subcomponent_type", SUBCOMPONENT_CERT_CHAIN)
+                        put("keyentryid", u.id)
+                        put("blob", u.chain)
+                    })
+                    updated++
+                }
+                db.setTransactionSuccessful()
+            } finally {
+                db.endTransaction()
+            }
+            SystemLogger.info("KeystoreDb: direct database write re-rooted $updated of ${updates.size} key(s)")
+        } catch (e: Throwable) {
+            SystemLogger.warning("KeystoreDb.updateSubcomponents failed (SELinux may deny writing keystore2's DB)", e)
+        } finally {
+            try {
+                db?.close()
+            } catch (_: Throwable) {}
+        }
+        return updated
     }
 
     /**

--- a/app/src/main/java/org/matrix/teesim/KeystoreDb.kt
+++ b/app/src/main/java/org/matrix/teesim/KeystoreDb.kt
@@ -37,7 +37,7 @@ import org.json.JSONObject
  * only ever remove rows we re-verify as our own target-app keys). Root can read and write the
  * keystore-owned files.
  *
- * Schema (AOSP system/security/keystore2/src/database.rs, confirmed against a live API 37 device):
+ * Schema (AOSP system/security/keystore2/src/database.rs):
  * ```
  *   keyentry(id, key_type, domain, namespace, alias BLOB, state, km_uuid)
  *     domain    Domain::APP = 0  -> namespace is the app uid
@@ -69,7 +69,7 @@ object KeystoreDb {
 
     // keystore2 stores key parameters in `keyparameter(tag, data)`. Tag::PURPOSE is the KeyMint tag
     // enum (TagType.ENUM_REP<<28 | 1) and KeyPurpose::ATTEST_KEY is 7, so a row (PURPOSE, 7) marks an
-    // attestation key. Confirmed against the live DB on-device.
+    // attestation key.
     private const val PURPOSE_TAG = 536870913 // 0x20000001
     private const val ATTEST_KEY_PURPOSE = 7
 
@@ -445,12 +445,12 @@ object KeystoreDb {
      * Fallback for [ReAttest]: write re-rooted certificates straight into keystore2's LIVE database when
      * the owner-as-euid API refused the update. Mirrors [deleteFromDatabase] — same WAL open, busy wait,
      * transaction, and per-id target-app re-check — but it REPLACES the key's stored certificates instead
-     * of removing the key. It reproduces keystore2's own set_blob for a certificate: delete any existing
-     * blobentry of that subcomponent type for the key (and any blobmetadata keyed off it), then insert the
-     * new one — [SUBCOMPONENT_CERT] for the leaf, [SUBCOMPONENT_CERT_CHAIN] for the rest. Unlike a key
-     * blob, keystore2 re-reads a key's certificates from the database on each getKeyEntry, so no keystore2
-     * restart is needed for the swap to take effect. The key blob is never touched. Returns the number of
-     * keys updated; 0 on failure (e.g. SELinux denies writing keystore2's DB).
+     * of removing the key. It reproduces keystore2's own set_blob for a certificate (AOSP
+     * database.rs set_blob_internal): delete any existing blobentry of that subcomponent type for the key
+     * (and any blobmetadata keyed off it), then insert the new one — [SUBCOMPONENT_CERT] for the leaf,
+     * [SUBCOMPONENT_CERT_CHAIN] for the rest. The key blob is never touched. Unlike the delete fallback,
+     * this does not restart keystore2. Returns the number of keys updated; 0 on failure (e.g. SELinux
+     * denies writing keystore2's DB).
      */
     fun updateSubcomponents(targets: Set<Int>, updates: List<CertUpdate>): Int {
         if (!available() || updates.isEmpty() || targets.isEmpty()) return 0

--- a/app/src/main/java/org/matrix/teesim/Packages.kt
+++ b/app/src/main/java/org/matrix/teesim/Packages.kt
@@ -7,6 +7,7 @@ import android.content.pm.IPackageManager
 import android.content.pm.PackageManager
 import android.content.pm.ParceledListSlice
 import android.content.pm.ResolveInfo
+import android.content.pm.UserInfo
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.drawable.BitmapDrawable
@@ -18,6 +19,7 @@ import android.os.ServiceManager
 import android.util.LruCache
 import java.io.ByteArrayOutputStream
 import java.io.File
+import java.lang.reflect.InvocationTargetException
 
 /**
  * Package-name to uid resolution, across every Android user on the device. The public
@@ -104,9 +106,9 @@ object Packages {
 
     /**
      * The user list from IUserManager, or null when the service is unreachable or its aidl does not
-     * match. getUsers grew its excludePartial/excludePreCreated arguments in Android 11, so the
-     * three-argument form is tried first on R+ and the Android 10 one-argument form is the retry;
-     * a ROM that reshuffled the interface lands on NoSuchMethodError and we fall back to disk.
+     * match. getUsers is version-specific (see [getUsersForThisSdk]); a ROM that reshuffled or dropped
+     * the interface leaves us with no compatible overload and we fall back to disk. Such a mismatch is
+     * expected on OEM builds, so it is noted in a single line rather than a stack trace.
      */
     private fun usersFromService(): List<UserEntry>? {
         val binder =
@@ -131,21 +133,22 @@ object Packages {
             }
         val infos =
             try {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) um.getUsers(true, true, true)
-                else um.getUsers(true)
+                getUsersForThisSdk(um)
             } catch (e: Throwable) {
-                // NoSuchMethodError on an aidl mismatch, SecurityException if a ROM tightened the
-                // check beyond the platform's uid-0 waiver. Either way: try the other arity, then disk.
-                SystemLogger.warning("Packages: getUsers failed (${e.javaClass.simpleName}); retrying the legacy arity", e)
-                try {
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) um.getUsers(true)
-                    else um.getUsers(true, true, true)
-                } catch (e2: Throwable) {
-                    SystemLogger.warning("Packages: getUsers unavailable on this ROM", e2)
-                    return null
-                }
+                // NoSuchMethodError on an aidl mismatch, SecurityException if a ROM tightened the check
+                // beyond the platform's uid-0 waiver — both expected on OEM ROMs and both covered by the
+                // on-disk fallback, so log one line (no backtrace) and read /data/system/users.
+                val cause = (e as? InvocationTargetException)?.targetException ?: e
+                SystemLogger.info(
+                    "Packages: getUsers unavailable on this ROM (${cause.javaClass.simpleName}); reading /data/system/users"
+                )
+                return null
             }
-        if (infos == null || infos.isEmpty()) {
+        if (infos == null) {
+            SystemLogger.info("Packages: no compatible getUsers overload; reading /data/system/users")
+            return null
+        }
+        if (infos.isEmpty()) {
             SystemLogger.warning("Packages: getUsers returned nothing; falling back to /data/system/users")
             return null
         }
@@ -158,6 +161,35 @@ object Packages {
                 null
             }
         }
+    }
+
+    /**
+     * Invoke IUserManager.getUsers with the overload the device actually declares. AOSP's signature is
+     * SDK-specific — Android 10 has `getUsers(boolean excludeDying)`, Android 11+ has
+     * `getUsers(boolean excludePartial, boolean excludeDying, boolean excludePreCreated)` (verified on
+     * cs.android.com) — and OEM ROMs sometimes drop or reshuffle it. So instead of hard-coding one arity
+     * and catching a NoSuchMethodError, we reflect over the live interface, pick the all-boolean getUsers
+     * whose arity matches this SDK (any available one otherwise), and call it with every flag set (the
+     * broadest enumeration, matching what both AOSP arities mean by all-true). Returns null when the ROM
+     * declares no such overload, so the caller falls back to reading /data/system/users. Any exception the
+     * call itself throws propagates to the caller, which logs it in one line.
+     */
+    private fun getUsersForThisSdk(um: IUserManager): List<UserInfo>? {
+        val candidates =
+            um.javaClass.methods.filter { m ->
+                m.name == "getUsers" &&
+                    List::class.java.isAssignableFrom(m.returnType) &&
+                    m.parameterTypes.isNotEmpty() &&
+                    m.parameterTypes.all { it == java.lang.Boolean.TYPE }
+            }
+        if (candidates.isEmpty()) return null
+        val preferredArity = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) 3 else 1
+        val method =
+            candidates.firstOrNull { it.parameterTypes.size == preferredArity }
+                ?: candidates.minByOrNull { it.parameterTypes.size }!!
+        val allTrue = Array<Any>(method.parameterTypes.size) { true }
+        @Suppress("UNCHECKED_CAST")
+        return method.invoke(um, *allTrue) as? List<UserInfo>
     }
 
     // /data/system/users/<id>/ is one directory per user and <id>.xml its record; the daemon is root,

--- a/app/src/main/java/org/matrix/teesim/ReAttest.kt
+++ b/app/src/main/java/org/matrix/teesim/ReAttest.kt
@@ -9,9 +9,9 @@ import java.io.ByteArrayOutputStream
  * that carries such a leaf is re-signed under its profile's keybox — the same patch the router
  * applies to a freshly generated key — and written back. The write-back mirrors the delete path: it
  * asks keystore2 as the key's OWNER first ([Keystore2Service.updateSubcomponentAsUid], which seteuid's
- * so keystore2 accepts the update), and only a key keystore2 still refuses falls back to a direct
- * database write ([KeystoreDb.updateSubcomponents]). The key blob is never touched, so the real hardware
- * key keeps working; only the certificate the app reads changes.
+ * to the owner in a child), and a key keystore2 refuses falls back to a direct database write
+ * ([KeystoreDb.updateSubcomponents]). The key blob is never touched, so the real hardware key keeps
+ * working; only the certificate the app reads changes.
  *
  * Idempotent and record-less: it re-scans the live keystore each run and re-signs whatever it finds,
  * so a re-run, a keybox swap, or a newly installed app all converge on the next push.
@@ -25,7 +25,7 @@ object ReAttest {
      * delegated leaves to get a patched root of trust. Clearing it forces the app's next attestation to
      * re-create it, which now always mints in the TA (generation).
      *
-     * keystore2 only lets a key's OWNER delete it (KeyPerm::Delete, confirmed in service.rs), so the
+     * keystore2 only lets a key's OWNER delete it (KeyPerm::Delete, AOSP service.rs), so the
      * daemon can't remove another app's key through the API — [KeystoreDb.deleteTargetAttestKeys] falls
      * back to a direct database delete, which removes the row but does NOT evict keystore2's in-memory
      * cache, so the app would keep using the cached key. We therefore restart keystore2 after a purge so

--- a/app/src/main/java/org/matrix/teesim/ReAttest.kt
+++ b/app/src/main/java/org/matrix/teesim/ReAttest.kt
@@ -7,9 +7,11 @@ import java.io.ByteArrayOutputStream
  * covered (or under a previous keybox) still carries the real hardware attestation — an unlocked
  * root of trust rooted in the device's real attestation key. For each target app, every stored key
  * that carries such a leaf is re-signed under its profile's keybox — the same patch the router
- * applies to a freshly generated key — and written back with [Keystore2Service.updateSubcomponent].
- * The key blob is never touched, so the real hardware key keeps working; only the certificate the app
- * reads changes.
+ * applies to a freshly generated key — and written back. The write-back mirrors the delete path: it
+ * asks keystore2 as the key's OWNER first ([Keystore2Service.updateSubcomponentAsUid], which seteuid's
+ * so keystore2 accepts the update), and only a key keystore2 still refuses falls back to a direct
+ * database write ([KeystoreDb.updateSubcomponents]). The key blob is never touched, so the real hardware
+ * key keeps working; only the certificate the app reads changes.
  *
  * Idempotent and record-less: it re-scans the live keystore each run and re-signs whatever it finds,
  * so a re-run, a keybox swap, or a newly installed app all converge on the next push.
@@ -72,6 +74,7 @@ object ReAttest {
         if (keys.isEmpty()) return
 
         var done = 0
+        val dbFallback = ArrayList<KeystoreDb.CertUpdate>()
         for (key in keys) {
             val profileId = uidToProfile[key.uid] ?: continue
             val chain =
@@ -84,12 +87,25 @@ object ReAttest {
             // keystore2 stores the leaf (CERT) and the rest of the chain (CERT_CHAIN) separately.
             val leaf = chain[0]
             val rest = concatFrom(chain, 1)
-            if (Keystore2Service.updateSubcomponent(key.id, leaf, rest)) {
+            // Try the keystore2 API first, as the key's OWNER (the helper seteuid's): keystore2 gates the
+            // update on the caller's effective uid, so re-rooting another app's key means asking as that
+            // app. Whatever the API refuses falls back to a direct database write — the same
+            // API-first / DB-fallback shape the delete path uses.
+            if (Keystore2Service.updateSubcomponentAsUid(key.id, key.uid, leaf, rest) == 0) {
                 done++
                 SystemLogger.info(
                     "re-attest: key id=${key.id} uid=${key.uid} profile=$profileId re-rooted (${chain.size}-cert chain)"
                 )
+            } else {
+                dbFallback.add(KeystoreDb.CertUpdate(key.id, leaf, rest))
             }
+        }
+        if (dbFallback.isNotEmpty()) {
+            SystemLogger.warning(
+                "re-attest: keystore2 refused the owner update for ${dbFallback.size} key(s); " +
+                    "falling back to a direct database write"
+            )
+            done += KeystoreDb.updateSubcomponents(uidToProfile.keys, dbFallback)
         }
         SystemLogger.info("re-attest: re-rooted $done of ${keys.size} pre-existing target key(s) to the keybox")
     }


### PR DESCRIPTION
ReAttest re-signs each pre-existing target key under its profile's keybox and writes the patched chain back with IKeystoreService.updateSubcomponent, but the daemon called it in its own context. keystore2 authorizes the update by the caller's effective uid, and the key belongs to the app (gms, vending, ...), so every write was rejected -- service.rs:267, "Trying to access key without ownership / Permission Denied" -- and re-attest re-rooted 0 of 7 keys even though each resign itself succeeded. The delete path already handles this: only a key's owner may act on it, which is why deleteKeyByIdAsUid seteuid's in a throwaway child.

The write-back now takes the same shape. updateSubcomponentAsUid spawns a child that seteuid's to the owner and calls updateSubcomponent, and only a key keystore2 still refuses falls back to a direct database write (KeystoreDb.updateSubcomponents), which replaces the key's CERT (1) and CERT_CHAIN (2) blobentry rows the same way keystore2's own set_blob does -- delete the existing rows of that subcomponent type, then insert the new ones (see [database.rs](https://android.googlesource.com/platform/system/security/+/refs/heads/android15-release/keystore2/src/database.rs)). The key blob is never touched, so the real hardware key keeps signing.

Separately, quiet the getUsers fallback. The signature is version-specific -- getUsers(boolean) on Android 10, getUsers(boolean, boolean, boolean) since Android 11 and unchanged through the current [main](https://android.googlesource.com/platform/frameworks/base/+/refs/heads/main/core/java/android/os/IUserManager.aidl) -- and a device whose interface declares only the older 1-arg form made the fixed 3-arg call throw NoSuchMethodError(getUsers(ZZZ)) and log a full backtrace on every resolve before the legacy-arity retry succeeded. Packages now reflects the live interface, picks the all-boolean overload matching the SDK, and on any miss logs a single line before reading /data/system/users.

The two owner-scoped operations share their scaffolding: spawnOwnerOp builds and runs the child on the parent side, runAsOwner does the seteuid-then-call on the child side.
