### PR TITLE
Align the attested version to the device's Keymaster HAL on legacy devices

### DIFF
--- a/app/src/main/java/org/matrix/teesim/Harvester.kt
+++ b/app/src/main/java/org/matrix/teesim/Harvester.kt
@@ -367,21 +367,20 @@ object Harvester {
 
     /**
      * Reconcile the attestation/keymaster version we present with the keystore HAL the device declares in
-     * its VINTF manifest ([Vintf.attestationVersionConstraint]) — the number an integrity checker, and
-     * Android's own attestation contract, cross-checks the attested version against, and one we cannot
-     * change: it is baked into the image. Two HAL families impose two kinds of constraint:
+     * VINTF ([Vintf.attestationVersionConstraint]). Two constraint kinds, following
+     * VtsAidlKeyMintTargetTest::check_attestation_version and ../Duck-Detector-Refactoring
+     * VintfKeyMintVersionProbe:
      *
-     *  - An AIDL KeyMint HAL @N is a CEILING (N*100): a VTS-compliant device already satisfies
-     *    `attestationVersion / 100 <= N`, so this is a no-op there; it only bites an OEM image that ships
-     *    an older HAL (e.g. `IKeyMintDevice/default@3` on Android 16) while its keys — or our OS-derived
-     *    fabrication — claim a newer KeyMint, and we clamp DOWN.
-     *  - A legacy HIDL Keymaster HAL is an EXACT target (@3.0 -> 2, @4.0 -> 3, @4.1 -> 4): a checker maps
-     *    the HAL version to the attestation version and expects equality, so we move to it in BOTH
-     *    directions — the captured or fabricated value may sit either side of the declared HAL.
+     *  - An AIDL KeyMint HAL @N is a CEILING (N*100): `attestationVersion / 100 <= N`, so we clamp DOWN
+     *    only when the current value exceeds it (e.g. an image shipping `IKeyMintDevice/default@3` while
+     *    the keys or our fabrication claim a newer KeyMint).
+     *  - A legacy HIDL Keymaster HAL is an EXACT target (@3.0 -> 2, @4.0 -> 3, @4.1 -> 4; AOSP
+     *    system/keymaster): we set it in BOTH directions, since the captured or fabricated value may sit
+     *    either side of the declared HAL.
      *
-     * TEE is recorded as computed overrides so the WebUI, the config push and the TA all agree; StrongBox
-     * is reconciled in its own field, which Resolver reads directly. A resulting version below 400 also
-     * makes the TA drop MODULE_HASH, a v4-only tag, keeping the record self-consistent.
+     * TEE is recorded as computed overrides so the WebUI, the config push and the TA agree; StrongBox is
+     * reconciled in its own field, which Resolver reads directly. keymasterVersionFor derives the matching
+     * keymasterVersion, and a resulting version below 400 makes the TA drop MODULE_HASH (a v4-only tag).
      */
     private fun clampAttestationToVintf(r: Record): Record {
         var out = r

--- a/app/src/main/java/org/matrix/teesim/Harvester.kt
+++ b/app/src/main/java/org/matrix/teesim/Harvester.kt
@@ -376,17 +376,28 @@ object Harvester {
      * WebUI, the config push and the TA all agree; StrongBox is clamped in its own field, which Resolver
      * reads directly. A version below 400 also makes the TA drop MODULE_HASH, a v4-only tag, keeping the
      * record self-consistent.
+     *
+     * A device that ships no KeyMint HAL but the legacy Keymaster HIDL HAL (`IKeymasterDevice@4.1`, …) is
+     * instead ALIGNED to the attestation version that HAL corresponds to (see
+     * [Vintf.keymasterHalAttestationVersion]): unlike the KeyMint ceiling this moves in both directions,
+     * because the captured or fabricated value may sit either side of the declared Keymaster HAL, and a
+     * checker cross-checks the two for an exact match rather than an upper bound.
      */
     private fun clampAttestationToVintf(r: Record): Record {
         var out = r
 
-        Vintf.keyMintHalVersion("default")?.let { hal ->
-            val ceiling = hal * 100
+        // TEE / default instance. A KeyMint HAL is a ceiling we only ever clamp DOWN to (a higher
+        // attestation would contradict the manifest); a legacy Keymaster HIDL HAL is a target we ALIGN
+        // to in both directions (the captured/fabricated value may sit either side of the declared HAL,
+        // and a checker maps IKeymasterDevice@N -> attestationVersion, expecting an exact match).
+        val keyMint = Vintf.keyMintHalVersion("default")
+        if (keyMint != null) {
+            val ceiling = keyMint * 100
             val current = out.effectiveInt("attestationVersion", out.attestationVersion)
             if (current > ceiling) {
                 SystemLogger.info(
                     "Harvest: clamping attestationVersion $current -> $ceiling to match the device's " +
-                        "VINTF-declared KeyMint HAL (IKeyMintDevice/default@$hal); a higher value would " +
+                        "VINTF-declared KeyMint HAL (IKeyMintDevice/default@$keyMint); a higher value would " +
                         "contradict the vendor manifest"
                 )
                 out =
@@ -394,20 +405,46 @@ object Harvester {
                         .withOverride("attestationVersion", ceiling.toString())
                         .withOverride("keymasterVersion", keymasterVersionFor(ceiling).toString())
             }
-        }
+        } else
+            Vintf.keymasterHalAttestationVersion("default")?.let { target ->
+                val current = out.effectiveInt("attestationVersion", out.attestationVersion)
+                if (current != target) {
+                    SystemLogger.info(
+                        "Harvest: aligning attestationVersion $current -> $target to match the device's " +
+                            "VINTF-declared Keymaster HAL (IKeymasterDevice/default); a checker maps the HAL " +
+                            "version to the attestation version and expects them to agree"
+                    )
+                    out =
+                        out
+                            .withOverride("attestationVersion", target.toString())
+                            .withOverride("keymasterVersion", keymasterVersionFor(target).toString())
+                }
+            }
 
         // StrongBox declares its own instance version; fall back to the default instance's when the manifest
-        // does not list a separate strongbox HAL (many devices share one KeyMint version across levels).
-        (Vintf.keyMintHalVersion("strongbox") ?: Vintf.keyMintHalVersion("default"))?.let { hal ->
-            val ceiling = hal * 100
+        // does not list a separate strongbox HAL (many devices share one HAL version across levels).
+        val sbKeyMint = Vintf.keyMintHalVersion("strongbox") ?: Vintf.keyMintHalVersion("default")
+        if (sbKeyMint != null) {
+            val ceiling = sbKeyMint * 100
             if (out.strongBoxAttestationVersion > ceiling) {
                 SystemLogger.info(
                     "Harvest: clamping strongBoxAttestationVersion ${out.strongBoxAttestationVersion} -> " +
-                        "$ceiling to match the device's VINTF-declared KeyMint StrongBox HAL (@$hal)"
+                        "$ceiling to match the device's VINTF-declared KeyMint StrongBox HAL (@$sbKeyMint)"
                 )
                 out = out.copy(strongBoxAttestationVersion = ceiling)
             }
-        }
+        } else
+            (Vintf.keymasterHalAttestationVersion("strongbox")
+                    ?: Vintf.keymasterHalAttestationVersion("default"))
+                ?.let { target ->
+                    if (out.strongBoxAttestationVersion != target) {
+                        SystemLogger.info(
+                            "Harvest: aligning strongBoxAttestationVersion ${out.strongBoxAttestationVersion} " +
+                                "-> $target to match the device's VINTF-declared Keymaster StrongBox HAL"
+                        )
+                        out = out.copy(strongBoxAttestationVersion = target)
+                    }
+                }
 
         return out
     }

--- a/app/src/main/java/org/matrix/teesim/Harvester.kt
+++ b/app/src/main/java/org/matrix/teesim/Harvester.kt
@@ -366,85 +366,54 @@ object Harvester {
     }
 
     /**
-     * Cap the attestation/keymaster version we present so it never exceeds the KeyMint AIDL version the
-     * device declares in its VINTF manifest (see [Vintf.keyMintHalVersion]). That number is the ceiling an
-     * integrity checker — and Android's own attestation contract — cross-checks the attested version
-     * against, and one we cannot raise: it is baked into the vendor image. A VTS-compliant device already
-     * satisfies `attestationVersion / 100 <= vintfVersion`, so the clamp is a no-op there; it only bites an
-     * OEM image that ships an older HAL (e.g. `IKeyMintDevice/default@3` on Android 16) while its keys — or
-     * our OS-derived fabrication — claim a newer KeyMint. TEE is recorded as computed overrides so the
-     * WebUI, the config push and the TA all agree; StrongBox is clamped in its own field, which Resolver
-     * reads directly. A version below 400 also makes the TA drop MODULE_HASH, a v4-only tag, keeping the
-     * record self-consistent.
+     * Reconcile the attestation/keymaster version we present with the keystore HAL the device declares in
+     * its VINTF manifest ([Vintf.attestationVersionConstraint]) — the number an integrity checker, and
+     * Android's own attestation contract, cross-checks the attested version against, and one we cannot
+     * change: it is baked into the image. Two HAL families impose two kinds of constraint:
      *
-     * A device that ships no KeyMint HAL but the legacy Keymaster HIDL HAL (`IKeymasterDevice@4.1`, …) is
-     * instead ALIGNED to the attestation version that HAL corresponds to (see
-     * [Vintf.keymasterHalAttestationVersion]): unlike the KeyMint ceiling this moves in both directions,
-     * because the captured or fabricated value may sit either side of the declared Keymaster HAL, and a
-     * checker cross-checks the two for an exact match rather than an upper bound.
+     *  - An AIDL KeyMint HAL @N is a CEILING (N*100): a VTS-compliant device already satisfies
+     *    `attestationVersion / 100 <= N`, so this is a no-op there; it only bites an OEM image that ships
+     *    an older HAL (e.g. `IKeyMintDevice/default@3` on Android 16) while its keys — or our OS-derived
+     *    fabrication — claim a newer KeyMint, and we clamp DOWN.
+     *  - A legacy HIDL Keymaster HAL is an EXACT target (@3.0 -> 2, @4.0 -> 3, @4.1 -> 4): a checker maps
+     *    the HAL version to the attestation version and expects equality, so we move to it in BOTH
+     *    directions — the captured or fabricated value may sit either side of the declared HAL.
+     *
+     * TEE is recorded as computed overrides so the WebUI, the config push and the TA all agree; StrongBox
+     * is reconciled in its own field, which Resolver reads directly. A resulting version below 400 also
+     * makes the TA drop MODULE_HASH, a v4-only tag, keeping the record self-consistent.
      */
     private fun clampAttestationToVintf(r: Record): Record {
         var out = r
 
-        // TEE / default instance. A KeyMint HAL is a ceiling we only ever clamp DOWN to (a higher
-        // attestation would contradict the manifest); a legacy Keymaster HIDL HAL is a target we ALIGN
-        // to in both directions (the captured/fabricated value may sit either side of the declared HAL,
-        // and a checker maps IKeymasterDevice@N -> attestationVersion, expecting an exact match).
-        val keyMint = Vintf.keyMintHalVersion("default")
-        if (keyMint != null) {
-            val ceiling = keyMint * 100
+        Vintf.attestationVersionConstraint("default")?.let { c ->
             val current = out.effectiveInt("attestationVersion", out.attestationVersion)
-            if (current > ceiling) {
+            if (if (c.exact) current != c.version else current > c.version) {
                 SystemLogger.info(
-                    "Harvest: clamping attestationVersion $current -> $ceiling to match the device's " +
-                        "VINTF-declared KeyMint HAL (IKeyMintDevice/default@$keyMint); a higher value would " +
-                        "contradict the vendor manifest"
+                    "Harvest: constraining attestationVersion $current -> ${c.version} to the device's " +
+                        "VINTF-declared keystore HAL (${if (c.exact) "Keymaster HIDL, exact match" else "KeyMint AIDL, ceiling"})"
                 )
                 out =
                     out
-                        .withOverride("attestationVersion", ceiling.toString())
-                        .withOverride("keymasterVersion", keymasterVersionFor(ceiling).toString())
+                        .withOverride("attestationVersion", c.version.toString())
+                        .withOverride("keymasterVersion", keymasterVersionFor(c.version).toString())
             }
-        } else
-            Vintf.keymasterHalAttestationVersion("default")?.let { target ->
-                val current = out.effectiveInt("attestationVersion", out.attestationVersion)
-                if (current != target) {
-                    SystemLogger.info(
-                        "Harvest: aligning attestationVersion $current -> $target to match the device's " +
-                            "VINTF-declared Keymaster HAL (IKeymasterDevice/default); a checker maps the HAL " +
-                            "version to the attestation version and expects them to agree"
-                    )
-                    out =
-                        out
-                            .withOverride("attestationVersion", target.toString())
-                            .withOverride("keymasterVersion", keymasterVersionFor(target).toString())
-                }
-            }
+        }
 
-        // StrongBox declares its own instance version; fall back to the default instance's when the manifest
-        // does not list a separate strongbox HAL (many devices share one HAL version across levels).
-        val sbKeyMint = Vintf.keyMintHalVersion("strongbox") ?: Vintf.keyMintHalVersion("default")
-        if (sbKeyMint != null) {
-            val ceiling = sbKeyMint * 100
-            if (out.strongBoxAttestationVersion > ceiling) {
-                SystemLogger.info(
-                    "Harvest: clamping strongBoxAttestationVersion ${out.strongBoxAttestationVersion} -> " +
-                        "$ceiling to match the device's VINTF-declared KeyMint StrongBox HAL (@$sbKeyMint)"
-                )
-                out = out.copy(strongBoxAttestationVersion = ceiling)
-            }
-        } else
-            (Vintf.keymasterHalAttestationVersion("strongbox")
-                    ?: Vintf.keymasterHalAttestationVersion("default"))
-                ?.let { target ->
-                    if (out.strongBoxAttestationVersion != target) {
-                        SystemLogger.info(
-                            "Harvest: aligning strongBoxAttestationVersion ${out.strongBoxAttestationVersion} " +
-                                "-> $target to match the device's VINTF-declared Keymaster StrongBox HAL"
-                        )
-                        out = out.copy(strongBoxAttestationVersion = target)
-                    }
+        // StrongBox declares its own instance constraint; fall back to the default instance's when the
+        // manifest lists no separate strongbox HAL (many devices share one HAL version across levels).
+        (Vintf.attestationVersionConstraint("strongbox")
+                ?: Vintf.attestationVersionConstraint("default"))
+            ?.let { c ->
+                val current = out.strongBoxAttestationVersion
+                if (if (c.exact) current != c.version else current > c.version) {
+                    SystemLogger.info(
+                        "Harvest: constraining strongBoxAttestationVersion $current -> ${c.version} to the " +
+                            "device's VINTF-declared StrongBox keystore HAL"
+                    )
+                    out = out.copy(strongBoxAttestationVersion = c.version)
                 }
+            }
 
         return out
     }

--- a/app/src/main/java/org/matrix/teesim/Vintf.kt
+++ b/app/src/main/java/org/matrix/teesim/Vintf.kt
@@ -7,19 +7,16 @@ import org.xmlpull.v1.XmlPullParser
 /**
  * Reads the keystore HAL version the device declares in its VINTF manifest, so the harvest can present
  * an attestation version consistent with it ([attestationVersionConstraint]). Two HAL families appear:
- * the modern AIDL KeyMint HAL (`android.hardware.security.keymint.IKeyMintDevice/default@N`), whose `@N`
- * is a ceiling `attestationVersion / 100` must not exceed (Android's own contract,
- * VtsAidlKeyMintTargetTest::check_attestation_version), and the legacy HIDL Keymaster HAL
- * (`android.hardware.keymaster/IKeymasterDevice/default@4.1`), whose version maps 1:1 to an exact
- * attestation version an integrity checker expects. Neither can be changed — both are baked into the
- * image — so they bound what we may present.
+ * the AIDL KeyMint HAL (`android.hardware.security.keymint.IKeyMintDevice/default@N`), where
+ * `attestationVersion / 100` must not exceed `N` (VtsAidlKeyMintTargetTest::check_attestation_version),
+ * and the legacy HIDL Keymaster HAL (`android.hardware.keymaster/IKeymasterDevice/default@X.Y`), whose
+ * version maps to an attestation version (AOSP system/keymaster version_to_attestation_version).
  *
- * Values are parsed straight from the on-disk manifest fragments, the same files the platform assembles
- * the declaration from, across the device (vendor/odm) AND framework (system/system_ext/product)
- * manifests — a GSI or custom ROM may declare a keystore2 compat HAL framework-side. The module runs as
- * root, so all paths are readable. Both declaration styles VINTF allows are handled: `<version>` +
- * `<interface>`, and `<fqname>`. Results (including "not declared") are cached for the process — VINTF
- * cannot change without a reboot.
+ * Values are parsed from the on-disk manifest fragments. The scanned locations and the parsing (device
+ * vendor/odm AND framework system/system_ext/product manifests; the `<version>` + `<interface>` form,
+ * the `<fqname>` form, and HIDL version ranges) follow the reference detector's manifest reader
+ * (../Duck-Detector-Refactoring VintfKeyMintVersionProbe). The module runs as root, so all paths are
+ * readable. Results (including "not declared") are cached for the process.
  */
 object Vintf {
 
@@ -30,19 +27,15 @@ object Vintf {
     private const val KEYMINT_HAL = "android.hardware.security.keymint"
     private const val KEYMINT_IFACE = "IKeyMintDevice"
 
-    // The legacy Keymaster HIDL HAL. A pre-KeyMint device (Keymaster 3.0/4.0/4.1), or a 12+ device whose
-    // vendor still ships the Keymaster HAL behind keystore2's compat shim, declares this instead of the
-    // AIDL KeyMint HAL, with a dotted HIDL version like 4.1. An integrity checker maps that version to the
-    // attestation/keymaster versions a real device of that HAL reports (AOSP system/keymaster
-    // version_to_attestation_version / version_to_keymaster_version) and cross-checks the attested pair.
+    // The legacy Keymaster HIDL HAL, declared with a dotted HIDL version (e.g. 4.1). AOSP system/keymaster
+    // version_to_attestation_version / version_to_keymaster_version map that version to the attestation and
+    // keymaster versions.
     private const val KEYMASTER_HAL = "android.hardware.keymaster"
     private const val KEYMASTER_IFACE = "IKeymasterDevice"
 
-    // VINTF manifest locations. The device manifest (vendor/odm) is where a keystore HAL normally lives,
-    // but a GSI or custom ROM can declare the keystore2 compat HAL in a framework-side manifest
-    // (system/system_ext/product) instead — so all are scanned, matching what an integrity checker reads
-    // from the assembled VINTF. Each entry is scanned as a directory of *.xml fragments or as a flat file;
-    // the highest matching version across every file wins, so the real HAL is found wherever the OEM put it.
+    // VINTF manifest locations to scan: the device (vendor/odm) and framework (system/system_ext/product)
+    // manifests, matching ../Duck-Detector-Refactoring VintfKeyMintVersionProbe. Each entry is scanned as a
+    // directory of *.xml fragments or as a flat file; the highest matching version across every file wins.
     private val MANIFEST_PATHS =
         listOf(
             "/vendor/etc/vintf/manifest.xml",
@@ -74,10 +67,11 @@ object Vintf {
 
     /**
      * The attestation-version constraint the device's declared keystore HAL imposes for [instance]: an
-     * AIDL KeyMint HAL @N is a ceiling of N*100 that a higher attestation would contradict; a legacy HIDL
-     * Keymaster HAL is an EXACT target (@3.0 -> 2, @4.0 -> 3, @4.1 -> 4) an integrity checker cross-checks
-     * for equality. Prefers KeyMint when both are somehow present. Null when neither is declared. This is
-     * the single source [Harvester.clampAttestationToVintf] reconciles the presented version against.
+     * AIDL KeyMint HAL @N gives a ceiling of N*100 (exact=false); a legacy HIDL Keymaster HAL gives an
+     * exact target (@3.0 -> 2, @4.0 -> 3, @4.1 -> 4; AOSP system/keymaster). Prefers KeyMint when both are
+     * declared. Null when neither is declared. [Harvester.clampAttestationToVintf] reconciles the presented
+     * version against it. The ceiling-vs-exact treatment follows ../Duck-Detector-Refactoring
+     * VintfKeyMintVersionProbe (KeyMint compared as an upper bound, HIDL Keymaster as equality).
      */
     @Synchronized
     fun attestationVersionConstraint(instance: String = "default"): AttestationConstraint? {
@@ -118,12 +112,10 @@ object Vintf {
     }
 
     /**
-     * The `attestationVersion` a real device of the legacy Keymaster HIDL HAL declared for [instance]
-     * reports — 1 for `@2.0`, 2 for `@3.0`, 3 for `@4.0`, 4 for `@4.1` (AOSP system/keymaster
+     * The attestation version for the legacy Keymaster HIDL HAL version declared for [instance] — 1 for
+     * `@2.0`, 2 for `@3.0`, 3 for `@4.0`, 4 for `@4.1` (AOSP system/keymaster
      * `version_to_attestation_version`) — or null when no manifest declares a Keymaster HAL for that
-     * instance (a KeyMint device, or one whose manifest we could not read). Cached per instance, keyed
-     * apart from [keyMintHalVersion]'s cache entries. This is the value the harvest aligns the presented
-     * attestation to on a device that ships no KeyMint HAL.
+     * instance. Cached per instance, keyed apart from [keyMintHalVersion]'s cache entries.
      */
     @Synchronized
     fun keymasterHalAttestationVersion(instance: String = "default"): Int? {

--- a/app/src/main/java/org/matrix/teesim/Vintf.kt
+++ b/app/src/main/java/org/matrix/teesim/Vintf.kt
@@ -5,17 +5,21 @@ import java.io.File
 import org.xmlpull.v1.XmlPullParser
 
 /**
- * Reads the KeyMint HAL AIDL interface version the device declares in its VINTF manifest — the `@N`
- * in `android.hardware.security.keymint.IKeyMintDevice/default@N`. An integrity checker (and
- * Android's own attestation contract, VtsAidlKeyMintTargetTest::check_attestation_version)
- * cross-checks the attested `attestationVersion` against this number: `attestationVersion / 100`
- * must not exceed it. It is baked into the vendor image and we cannot raise it, so it is the hard
- * ceiling for the version we may present.
+ * Reads the keystore HAL version the device declares in its VINTF manifest, so the harvest can present
+ * an attestation version consistent with it ([attestationVersionConstraint]). Two HAL families appear:
+ * the modern AIDL KeyMint HAL (`android.hardware.security.keymint.IKeyMintDevice/default@N`), whose `@N`
+ * is a ceiling `attestationVersion / 100` must not exceed (Android's own contract,
+ * VtsAidlKeyMintTargetTest::check_attestation_version), and the legacy HIDL Keymaster HAL
+ * (`android.hardware.keymaster/IKeymasterDevice/default@4.1`), whose version maps 1:1 to an exact
+ * attestation version an integrity checker expects. Neither can be changed — both are baked into the
+ * image — so they bound what we may present.
  *
- * The value is parsed straight from the on-disk manifest fragments, which is exactly what the
- * platform assembles the declaration from; the module runs as root, so the vendor/odm paths are
- * readable. A result (including "not declared") is cached for the process — VINTF cannot change
- * without a reboot.
+ * Values are parsed straight from the on-disk manifest fragments, the same files the platform assembles
+ * the declaration from, across the device (vendor/odm) AND framework (system/system_ext/product)
+ * manifests — a GSI or custom ROM may declare a keystore2 compat HAL framework-side. The module runs as
+ * root, so all paths are readable. Both declaration styles VINTF allows are handled: `<version>` +
+ * `<interface>`, and `<fqname>`. Results (including "not declared") are cached for the process — VINTF
+ * cannot change without a reboot.
  */
 object Vintf {
 
@@ -34,22 +38,60 @@ object Vintf {
     private const val KEYMASTER_HAL = "android.hardware.keymaster"
     private const val KEYMASTER_IFACE = "IKeymasterDevice"
 
-    // Standard AIDL VINTF manifest locations, vendor first (KeyMint is a vendor HAL). The
-    // directories hold
-    // per-HAL fragments; the flat files are the legacy single-manifest form. All are scanned and
-    // the highest
-    // matching version wins, so a fragment declaring the real HAL is found wherever the OEM placed
-    // it.
+    // VINTF manifest locations. The device manifest (vendor/odm) is where a keystore HAL normally lives,
+    // but a GSI or custom ROM can declare the keystore2 compat HAL in a framework-side manifest
+    // (system/system_ext/product) instead — so all are scanned, matching what an integrity checker reads
+    // from the assembled VINTF. Each entry is scanned as a directory of *.xml fragments or as a flat file;
+    // the highest matching version across every file wins, so the real HAL is found wherever the OEM put it.
     private val MANIFEST_PATHS =
         listOf(
             "/vendor/etc/vintf/manifest.xml",
             "/vendor/etc/vintf/manifest",
             "/odm/etc/vintf/manifest.xml",
             "/odm/etc/vintf/manifest",
+            "/system/etc/vintf/manifest.xml",
+            "/system/etc/vintf/manifest",
+            "/system_ext/etc/vintf/manifest.xml",
+            "/system_ext/etc/vintf/manifest",
+            "/product/etc/vintf/manifest.xml",
+            "/product/etc/vintf/manifest",
             "/vendor/manifest.xml",
         )
 
+    // A HIDL fqname, e.g. "@4.1::IKeymasterDevice/default" -> (version, interface, instance).
+    private val HIDL_FQNAME = Regex("^@([0-9]+(?:\\.[0-9]+)?)::([^/]+)/(.+)$")
+    // A HIDL version range, e.g. "4.0-1" -> major 4, minors 0..1.
+    private val HIDL_RANGE = Regex("^([0-9]+)\\.([0-9]+)-([0-9]+)$")
+
     private val cache = HashMap<String, Int?>()
+
+    /** A VINTF-derived bound on the attestation version we may present for a security level: an EXACT
+     *  target (legacy HIDL Keymaster, whose HAL version maps 1:1 to an attestation version) or a CEILING
+     *  we must not exceed (AIDL KeyMint @N -> N*100). */
+    data class AttestationConstraint(val version: Int, val exact: Boolean)
+
+    private val constraintCache = HashMap<String, AttestationConstraint?>()
+
+    /**
+     * The attestation-version constraint the device's declared keystore HAL imposes for [instance]: an
+     * AIDL KeyMint HAL @N is a ceiling of N*100 that a higher attestation would contradict; a legacy HIDL
+     * Keymaster HAL is an EXACT target (@3.0 -> 2, @4.0 -> 3, @4.1 -> 4) an integrity checker cross-checks
+     * for equality. Prefers KeyMint when both are somehow present. Null when neither is declared. This is
+     * the single source [Harvester.clampAttestationToVintf] reconciles the presented version against.
+     */
+    @Synchronized
+    fun attestationVersionConstraint(instance: String = "default"): AttestationConstraint? {
+        if (constraintCache.containsKey(instance)) return constraintCache[instance]
+        val c =
+            keyMintHalVersion(instance)?.let { AttestationConstraint(it * 100, exact = false) }
+                ?: keymasterHalAttestationVersion(instance)?.let { AttestationConstraint(it, exact = true) }
+        constraintCache[instance] = c
+        SystemLogger.info(
+            "Vintf: attestation-version constraint for '$instance' = " +
+                "${c?.version ?: "unknown"} (exact=${c?.exact ?: false})"
+        )
+        return c
+    }
 
     /**
      * The declared KeyMint AIDL version for [instance] (e.g. 3 for `IKeyMintDevice/default@3`), or
@@ -146,11 +188,30 @@ object Vintf {
             else -> null
         }
 
+    /** Expand a HIDL version token to concrete versions: "4.1" -> ["4.1"]; the range form "4.0-1"
+     *  (major.minorFirst-minorLast, as a manifest may abbreviate 4.0 and 4.1) -> ["4.0", "4.1"]. */
+    private fun expandHidlVersions(version: String): List<String> {
+        val m = HIDL_RANGE.matchEntire(version.trim()) ?: return listOf(version.trim())
+        val major = m.groupValues[1]
+        return (m.groupValues[2].toInt()..m.groupValues[3].toInt()).map { "$major.$it" }
+    }
+
+    /** The version from a Keymaster `<fqname>` like "@4.1::IKeymasterDevice/default" — but only when it
+     *  names [instance] on IKeymasterDevice; null otherwise. HIDL fqnames bind version and instance
+     *  together, so a strongbox fqname never contributes to the default instance. */
+    private fun keymasterFqnameVersion(fqname: String, instance: String): String? {
+        val m = HIDL_FQNAME.matchEntire(fqname.trim()) ?: return null
+        val (version, iface, inst) = m.destructured
+        return version.takeIf { iface == KEYMASTER_IFACE && inst == instance }
+    }
+
     /**
      * The highest Keymaster `IKeymasterDevice/[instance]` HIDL version declared in one manifest file, as
-     * its attestationVersion equivalent, or null. Mirrors [versionIn] but for a `format="hidl"` block:
-     * the `<version>` is a dotted HIDL version (mapped by [keymasterAttestationVersion]) and the instance
-     * is named the classic way — `<interface><name>IKeymasterDevice</name><instance>default</instance>`.
+     * its attestationVersion equivalent, or null. Handles both declaration styles VINTF allows in a
+     * `format="hidl"` block: the classic `<version>` + `<interface><name>IKeymasterDevice</name>
+     * <instance>default</instance>` form (versions apply to every instance the interface lists), and the
+     * `<fqname>@4.1::IKeymasterDevice/default</fqname>` form (version bound to one instance). HIDL version
+     * ranges ("4.0-1") are expanded before mapping.
      */
     private fun keymasterVersionIn(file: File, instance: String): Int? {
         var best: Int? = null
@@ -161,7 +222,8 @@ object Vintf {
             var inHal = false
             var isHidl = false
             var halName: String? = null
-            val attestVersions = ArrayList<Int>()
+            val versions = ArrayList<String>() // raw <version> tokens (may be ranges)
+            val fqnames = ArrayList<String>()
             var instanceMatched = false
             var ifaceName: String? = null
 
@@ -174,7 +236,8 @@ object Vintf {
                             inHal = true
                             isHidl = "hidl".equals(parser.getAttributeValue(null, "format"), true)
                             halName = null
-                            attestVersions.clear()
+                            versions.clear()
+                            fqnames.clear()
                             instanceMatched = false
                             ifaceName = null
                         }
@@ -185,16 +248,25 @@ object Vintf {
                                 if (depth <= 3) halName = halName ?: text else ifaceName = text
                             }
                         "version" ->
-                            if (inHal && depth <= 3)
-                                keymasterAttestationVersion(readText(parser))?.let { attestVersions.add(it) }
+                            if (inHal && depth <= 3) readText(parser).let { if (it.isNotEmpty()) versions.add(it) }
                         "instance" ->
                             if (inHal && KEYMASTER_IFACE == ifaceName && readText(parser) == instance) {
                                 instanceMatched = true
                             }
+                        "fqname" -> if (inHal) readText(parser).let { if (it.isNotEmpty()) fqnames.add(it) }
                     }
                 } else if (event == XmlPullParser.END_TAG && parser.name == "hal") {
-                    if (inHal && isHidl && halName == KEYMASTER_HAL && instanceMatched) {
-                        attestVersions.maxOrNull()?.let { v -> best = maxOf(best ?: v, v) }
+                    if (inHal && isHidl && halName == KEYMASTER_HAL) {
+                        // Versions bound to the requested instance: the <version>+<interface> form when the
+                        // interface exposed this instance, plus any <fqname> that names it directly.
+                        val bound = ArrayList<String>()
+                        if (instanceMatched) bound.addAll(versions)
+                        for (fq in fqnames) keymasterFqnameVersion(fq, instance)?.let(bound::add)
+                        bound
+                            .flatMap(::expandHidlVersions)
+                            .mapNotNull(::keymasterAttestationVersion)
+                            .maxOrNull()
+                            ?.let { v -> best = maxOf(best ?: v, v) }
                     }
                     inHal = false
                 }

--- a/app/src/main/java/org/matrix/teesim/Vintf.kt
+++ b/app/src/main/java/org/matrix/teesim/Vintf.kt
@@ -26,6 +26,14 @@ object Vintf {
     private const val KEYMINT_HAL = "android.hardware.security.keymint"
     private const val KEYMINT_IFACE = "IKeyMintDevice"
 
+    // The legacy Keymaster HIDL HAL. A pre-KeyMint device (Keymaster 3.0/4.0/4.1), or a 12+ device whose
+    // vendor still ships the Keymaster HAL behind keystore2's compat shim, declares this instead of the
+    // AIDL KeyMint HAL, with a dotted HIDL version like 4.1. An integrity checker maps that version to the
+    // attestation/keymaster versions a real device of that HAL reports (AOSP system/keymaster
+    // version_to_attestation_version / version_to_keymaster_version) and cross-checks the attested pair.
+    private const val KEYMASTER_HAL = "android.hardware.keymaster"
+    private const val KEYMASTER_IFACE = "IKeymasterDevice"
+
     // Standard AIDL VINTF manifest locations, vendor first (KeyMint is a vendor HAL). The
     // directories hold
     // per-HAL fragments; the flat files are the legacy single-manifest form. All are scanned and
@@ -67,21 +75,130 @@ object Vintf {
         return v
     }
 
+    /**
+     * The `attestationVersion` a real device of the legacy Keymaster HIDL HAL declared for [instance]
+     * reports — 1 for `@2.0`, 2 for `@3.0`, 3 for `@4.0`, 4 for `@4.1` (AOSP system/keymaster
+     * `version_to_attestation_version`) — or null when no manifest declares a Keymaster HAL for that
+     * instance (a KeyMint device, or one whose manifest we could not read). Cached per instance, keyed
+     * apart from [keyMintHalVersion]'s cache entries. This is the value the harvest aligns the presented
+     * attestation to on a device that ships no KeyMint HAL.
+     */
+    @Synchronized
+    fun keymasterHalAttestationVersion(instance: String = "default"): Int? {
+        val key = "km-hidl:$instance"
+        if (cache.containsKey(key)) return cache[key]
+        val v = runCatching { scanKeymaster(instance) }
+            .getOrElse {
+                SystemLogger.info(
+                    "Vintf: Keymaster manifest scan failed: ${it.javaClass.simpleName}: ${it.message}"
+                )
+                null
+            }
+        cache[key] = v
+        SystemLogger.info(
+            "Vintf: declared Keymaster HAL attestationVersion for instance '$instance' = ${v ?: "unknown"}"
+        )
+        return v
+    }
+
+    /** Every candidate VINTF manifest file: each flat manifest that exists, plus every .xml fragment in
+     *  a manifest directory. Shared by the KeyMint and Keymaster scans. */
+    private fun manifestFiles(): List<File> {
+        val out = ArrayList<File>()
+        for (path in MANIFEST_PATHS) {
+            val f = File(path)
+            when {
+                !f.exists() -> {}
+                f.isDirectory ->
+                    f.listFiles { file -> file.isFile && file.name.endsWith(".xml") }?.let(out::addAll)
+                else -> out.add(f)
+            }
+        }
+        return out
+    }
+
     /** The highest KeyMint version declared for [instance] across every candidate manifest file. */
     private fun scan(instance: String): Int? {
         var best: Int? = null
-        for (path in MANIFEST_PATHS) {
-            val f = File(path)
-            val files =
-                when {
-                    !f.exists() -> emptyList()
-                    f.isDirectory ->
-                        f.listFiles { file -> file.isFile && file.name.endsWith(".xml") }?.toList()
-                            ?: emptyList()
-                    else -> listOf(f)
+        for (file in manifestFiles()) {
+            versionIn(file, instance)?.let { v -> best = maxOf(best ?: v, v) }
+        }
+        return best
+    }
+
+    /** The highest Keymaster HIDL attestation version declared for [instance] across every manifest. */
+    private fun scanKeymaster(instance: String): Int? {
+        var best: Int? = null
+        for (file in manifestFiles()) {
+            keymasterVersionIn(file, instance)?.let { v -> best = maxOf(best ?: v, v) }
+        }
+        return best
+    }
+
+    /** The `IKeymasterDevice@N` HIDL version, as its attestationVersion equivalent: 2.0->1, 3.0->2,
+     *  4.0->3, 4.1->4 (AOSP system/keymaster). Null for an unknown/absent version string. */
+    private fun keymasterAttestationVersion(dotted: String): Int? =
+        when (dotted.trim()) {
+            "2.0" -> 1
+            "3.0" -> 2
+            "4.0" -> 3
+            "4.1" -> 4
+            else -> null
+        }
+
+    /**
+     * The highest Keymaster `IKeymasterDevice/[instance]` HIDL version declared in one manifest file, as
+     * its attestationVersion equivalent, or null. Mirrors [versionIn] but for a `format="hidl"` block:
+     * the `<version>` is a dotted HIDL version (mapped by [keymasterAttestationVersion]) and the instance
+     * is named the classic way — `<interface><name>IKeymasterDevice</name><instance>default</instance>`.
+     */
+    private fun keymasterVersionIn(file: File, instance: String): Int? {
+        var best: Int? = null
+        file.inputStream().use { input ->
+            val parser = Xml.newPullParser()
+            parser.setInput(input, null)
+
+            var inHal = false
+            var isHidl = false
+            var halName: String? = null
+            val attestVersions = ArrayList<Int>()
+            var instanceMatched = false
+            var ifaceName: String? = null
+
+            var event = parser.eventType
+            while (event != XmlPullParser.END_DOCUMENT) {
+                if (event == XmlPullParser.START_TAG) {
+                    val depth = parser.depth
+                    when (parser.name) {
+                        "hal" -> {
+                            inHal = true
+                            isHidl = "hidl".equals(parser.getAttributeValue(null, "format"), true)
+                            halName = null
+                            attestVersions.clear()
+                            instanceMatched = false
+                            ifaceName = null
+                        }
+                        "interface" -> if (inHal) ifaceName = null
+                        "name" ->
+                            if (inHal) {
+                                val text = readText(parser)
+                                if (depth <= 3) halName = halName ?: text else ifaceName = text
+                            }
+                        "version" ->
+                            if (inHal && depth <= 3)
+                                keymasterAttestationVersion(readText(parser))?.let { attestVersions.add(it) }
+                        "instance" ->
+                            if (inHal && KEYMASTER_IFACE == ifaceName && readText(parser) == instance) {
+                                instanceMatched = true
+                            }
+                    }
+                } else if (event == XmlPullParser.END_TAG && parser.name == "hal") {
+                    if (inHal && isHidl && halName == KEYMASTER_HAL && instanceMatched) {
+                        attestVersions.maxOrNull()?.let { v -> best = maxOf(best ?: v, v) }
+                    }
+                    inHal = false
                 }
-            for (file in files) {
-                versionIn(file, instance)?.let { v -> best = maxOf(best ?: v, v) }
+                event = parser.next()
             }
         }
         return best


### PR DESCRIPTION
#247 clamps the attested `attestationVersion` to the KeyMint HAL version the device declares in VINTF, but `Vintf` only ever reads the AIDL KeyMint HAL (`android.hardware.security.keymint.IKeyMintDevice`). A device that ships the legacy Keymaster HIDL HAL instead — `android.hardware.keymaster/IKeymasterDevice/default@4.1` — declares no KeyMint HAL, so `keyMintHalVersion` returns null, the clamp is a no-op, and the presented pair stays at whatever was captured or fabricated. On such a device that came out `keymasterVersion=4/attestationVersion=3` (Keymaster 4.0), one minor version below the declared 4.1, and a checker that maps `IKeymasterDevice@N` to the attestation version a real device of that HAL reports ([AOSP system/keymaster](https://android.googlesource.com/platform/system/keymaster/+/refs/heads/main/km_openssl/attestation_record.cpp) `version_to_attestation_version` / `version_to_keymaster_version`: 4.1 → attestation 4, keymaster 41) flags the mismatch.

`Vintf` now also parses the Keymaster HIDL HAL and returns its attestation-version equivalent (2.0 → 1, 3.0 → 2, 4.0 → 3, 4.1 → 4). When no KeyMint HAL is declared, the harvest aligns the presented `attestationVersion`/`keymasterVersion` — and the StrongBox instance's version — to the declared Keymaster HAL. Unlike the KeyMint ceiling, which only clamps down, this aligns in both directions: a captured or fabricated value may sit either side of the legacy HAL, and the checker wants an exact match rather than an upper bound. `keymasterVersionFor` already yields the matching `keymasterVersion` (attestation 4 → keymaster 41), so the pair stays self-consistent, and the resulting sub-400 version keeps MODULE_HASH off, as a Keymaster device expects.
