### PR TITLE
Supplement device-property ids from system properties when unattested

### DIFF
--- a/app/src/main/java/org/matrix/teesim/Harvester.kt
+++ b/app/src/main/java/org/matrix/teesim/Harvester.kt
@@ -529,16 +529,13 @@ object Harvester {
     private const val TELEPHONY_WAIT_MS = 15_000L
 
     /**
-     * Fill in the device ids that device-properties attestation does not carry — IMEI, MEID, serial — so
-     * the reference TA's ID check passes when an app requests the device's true values.
+     * Fill in the device ids a leaf without device-id attestation does not carry — IMEI, MEID, serial.
      *
-     * The bare app_process never initialized the telephony framework (so `TelephonyManager.getImei()`
-     * hits a null service registerer), and `getImei()`/`getImeiForSlot()` additionally enforce a
-     * "package belongs to caller uid" check we can't satisfy as root (uid 0). So we go straight to the
-     * `IPhoneSubInfo` binder and use the legacy `getDeviceId*` calls, which return the real IMEI
-     * regardless of the calling package — confirmed on-device. The serial is read from the `ro.serialno`
-     * property: `Build.getSerial()` enforces the same "package belongs to caller uid" check, which we
-     * can never satisfy as root (uid 0), so it only ever fails here.
+     * The bare app_process does not initialize the telephony framework (so `TelephonyManager.getImei()`
+     * hits a null service registerer), and `getImei()`/`getImeiForSlot()` enforce a "package belongs to
+     * caller uid" check the daemon (uid 0) does not pass. So we call the `IPhoneSubInfo` binder's legacy
+     * `getDeviceId*` methods, which are not package-scoped. The serial is read from the `ro.serialno`
+     * property, since `Build.getSerial()` applies the same package check.
      */
     private fun supplementDeviceIds(r: Record): Record {
         // The harvest runs very early at boot, when telephony (the modem/RIL) usually isn't up yet, so

--- a/app/src/main/java/org/matrix/teesim/Harvester.kt
+++ b/app/src/main/java/org/matrix/teesim/Harvester.kt
@@ -106,9 +106,14 @@ object Harvester {
         val userEdited: Boolean = false,
     )
 
-    /** Device ids the leaf omits but we read from the OS. Shown for transparency but NOT editable here —
-     *  spoofing an id is a per-profile concern (Resolver.resolveProfile lets a profile override each). */
-    private val SUPPLEMENT_IDS = setOf("serial", "imei", "imei2", "meid")
+    /** Device ids we may read from the OS when the attested leaf did not carry them, presented as
+     *  SUPPLEMENT overrides. Shown for transparency but NOT editable here — spoofing an id is a
+     *  per-profile concern (Resolver.resolveProfile lets a profile override each). serial/imei/imei2/meid
+     *  are never carried by device-properties attestation; brand/device/product/manufacturer/model
+     *  ([DEVICE_PROP_IDS]) usually are, so those are supplemented only on a device that produced no ID
+     *  attestation at all (a plain attestation, or a TEE that refused it). */
+    private val DEVICE_PROP_IDS = setOf("brand", "device", "product", "manufacturer", "model")
+    private val SUPPLEMENT_IDS = setOf("serial", "imei", "imei2", "meid") + DEVICE_PROP_IDS
     /** Level/version values we synthesize on a device with no working hardware — editable. */
     private val SYNTHESIZED_FIELDS =
         setOf(
@@ -225,6 +230,11 @@ object Harvester {
 
         private fun capturedString(field: String): String =
             when (field) {
+                "brand" -> brand
+                "device" -> device
+                "product" -> product
+                "manufacturer" -> manufacturer
+                "model" -> model
                 "serial" -> serial
                 "imei" -> imei
                 "imei2" -> imei2
@@ -552,8 +562,42 @@ object Harvester {
         if (r.imei2.isBlank() && imei2.isNotBlank()) out = out.withOverride("imei2", imei2)
         if (r.meid.isBlank() && meid.isNotBlank()) out = out.withOverride("meid", meid)
         if (r.serial.isBlank() && serial.isNotBlank()) out = out.withOverride("serial", serial)
+
+        // brand/device/product/manufacturer/model come from the attested leaf when the device did ID
+        // attestation. A device that did NOT (a plain attestation, or a TEE that refused it) leaves them
+        // blank — and then the profile would present an empty id, which the reference TA's ID check
+        // rejects against an app requesting the device's true brand. Fill each blank one from the
+        // android.os.Build field the framework itself fills ATTESTATION_ID_* from (resolved from the
+        // ro.product.* system properties), as a SUPPLEMENT override; a real capture is left untouched, and
+        // the user can still spoof any of them per-profile.
+        val supplemented = ArrayList<String>()
+        for (field in DEVICE_PROP_IDS) {
+            if (out.effective(field).isNotBlank()) continue // attested, or already supplemented
+            val value = devicePropId(field)
+            if (value.isNotBlank()) {
+                out = out.withOverride(field, value)
+                supplemented.add("$field='$value'")
+            }
+        }
+        if (supplemented.isNotEmpty())
+            SystemLogger.info(
+                "Harvest: device ids not attested; supplemented from system properties: " +
+                    supplemented.joinToString(" ")
+            )
         return out
     }
+
+    /** The device-property id [field] as the framework reads it for ID attestation — the android.os.Build
+     *  field, which resolves from the ro.product.* system properties. Blank for an unknown field. */
+    private fun devicePropId(field: String): String =
+        when (field) {
+            "brand" -> Build.BRAND
+            "device" -> Build.DEVICE
+            "product" -> Build.PRODUCT
+            "manufacturer" -> Build.MANUFACTURER
+            "model" -> Build.MODEL
+            else -> ""
+        }.orEmpty().trim()
 
     /**
      * Wait (bounded) for telephony to return the primary IMEI. IPhoneSubInfo registers early, but the

--- a/app/src/main/java/org/matrix/teesim/Harvester.kt
+++ b/app/src/main/java/org/matrix/teesim/Harvester.kt
@@ -566,10 +566,9 @@ object Harvester {
         // brand/device/product/manufacturer/model come from the attested leaf when the device did ID
         // attestation. A device that did NOT (a plain attestation, or a TEE that refused it) leaves them
         // blank — and then the profile would present an empty id, which the reference TA's ID check
-        // rejects against an app requesting the device's true brand. Fill each blank one from the
-        // android.os.Build field the framework itself fills ATTESTATION_ID_* from (resolved from the
-        // ro.product.* system properties), as a SUPPLEMENT override; a real capture is left untouched, and
-        // the user can still spoof any of them per-profile.
+        // rejects against an app requesting the device's true brand. Fill each blank one from the SAME
+        // source the framework fills ATTESTATION_ID_* from (see [devicePropId]), as a SUPPLEMENT override;
+        // a real capture is left untouched, and the user can still spoof any of them per-profile.
         val supplemented = ArrayList<String>()
         for (field in DEVICE_PROP_IDS) {
             if (out.effective(field).isNotBlank()) continue // attested, or already supplemented
@@ -587,17 +586,46 @@ object Harvester {
         return out
     }
 
-    /** The device-property id [field] as the framework reads it for ID attestation — the android.os.Build
-     *  field, which resolves from the ro.product.* system properties. Blank for an unknown field. */
-    private fun devicePropId(field: String): String =
+    // android.os.Build.UNKNOWN, the sentinel getString returns for an unset property.
+    private const val BUILD_UNKNOWN = "unknown"
+
+    /** The property base name AOSP's Build.getVendorDeviceIdProperty uses for each attestation id
+     *  (PRODUCT is backed by "name"); null for a field with no such mapping. */
+    private fun attestIdBase(field: String): String? =
         when (field) {
-            "brand" -> Build.BRAND
-            "device" -> Build.DEVICE
-            "product" -> Build.PRODUCT
-            "manufacturer" -> Build.MANUFACTURER
-            "model" -> Build.MODEL
-            else -> ""
-        }.orEmpty().trim()
+            "brand" -> "brand"
+            "device" -> "device"
+            "product" -> "name"
+            "manufacturer" -> "manufacturer"
+            "model" -> "model"
+            else -> null
+        }
+
+    /**
+     * The device-property id [field] resolved EXACTLY as keystore fills ATTESTATION_ID_* — so a
+     * supplemented value equals what the calling app's request carries (a plain android.os.Build read is
+     * NOT the same source, and diverges on a ROM that ships attestation-specific ids). Mirrors
+     * AndroidKeyStoreKeyPairGeneratorSpi, which reads Build.<X>_FOR_ATTESTATION with a fallback, and
+     * Build.getVendorDeviceIdProperty behind it:
+     *   ro.product.<base>_for_attestation  (unless "unknown")
+     *     → else ro.product.vendor.<base>   (unless empty/"unknown")
+     *     → else ro.product.<base>          (the plain Build value)
+     * A ROM that sets *_for_attestation overrides (e.g. LineageOS, sapphire vs sapphiren) then yields the
+     * id the caller attests, not the raw ro.product.* value a normal Build read resolves. Blank when the
+     * whole chain is unset/unknown, so nothing garbage is supplemented.
+     */
+    private fun devicePropId(field: String): String {
+        val base = attestIdBase(field) ?: return ""
+        val forAttestation =
+            DeviceProps.prop("ro.product.${base}_for_attestation", BUILD_UNKNOWN).let {
+                if (it == BUILD_UNKNOWN) DeviceProps.prop("ro.product.vendor.$base", BUILD_UNKNOWN) else it
+            }
+        val resolved =
+            if (forAttestation.isBlank() || forAttestation == BUILD_UNKNOWN)
+                DeviceProps.prop("ro.product.$base", "")
+            else forAttestation
+        return resolved.trim().let { if (it == BUILD_UNKNOWN) "" else it }
+    }
 
     /**
      * Wait (bounded) for telephony to return the primary IMEI. IPhoneSubInfo registers early, but the

--- a/app/src/main/java/org/matrix/teesim/Harvester.kt
+++ b/app/src/main/java/org/matrix/teesim/Harvester.kt
@@ -109,9 +109,8 @@ object Harvester {
     /** Device ids we may read from the OS when the attested leaf did not carry them, presented as
      *  SUPPLEMENT overrides. Shown for transparency but NOT editable here — spoofing an id is a
      *  per-profile concern (Resolver.resolveProfile lets a profile override each). serial/imei/imei2/meid
-     *  are never carried by device-properties attestation; brand/device/product/manufacturer/model
-     *  ([DEVICE_PROP_IDS]) usually are, so those are supplemented only on a device that produced no ID
-     *  attestation at all (a plain attestation, or a TEE that refused it). */
+     *  are read from telephony/props; brand/device/product/manufacturer/model ([DEVICE_PROP_IDS]) are
+     *  supplemented only when the leaf carried none, via [devicePropId]. */
     private val DEVICE_PROP_IDS = setOf("brand", "device", "product", "manufacturer", "model")
     private val SUPPLEMENT_IDS = setOf("serial", "imei", "imei2", "meid") + DEVICE_PROP_IDS
     /** Level/version values we synthesize on a device with no working hardware — editable. */
@@ -563,12 +562,11 @@ object Harvester {
         if (r.meid.isBlank() && meid.isNotBlank()) out = out.withOverride("meid", meid)
         if (r.serial.isBlank() && serial.isNotBlank()) out = out.withOverride("serial", serial)
 
-        // brand/device/product/manufacturer/model come from the attested leaf when the device did ID
-        // attestation. A device that did NOT (a plain attestation, or a TEE that refused it) leaves them
-        // blank — and then the profile would present an empty id, which the reference TA's ID check
-        // rejects against an app requesting the device's true brand. Fill each blank one from the SAME
-        // source the framework fills ATTESTATION_ID_* from (see [devicePropId]), as a SUPPLEMENT override;
-        // a real capture is left untouched, and the user can still spoof any of them per-profile.
+        // brand/device/product/manufacturer/model are captured from the attested leaf when it carries
+        // them; a leaf that carried no device ids leaves them blank, and then the profile presents an
+        // empty id. Fill each blank one from the same source the framework fills ATTESTATION_ID_* from
+        // (see [devicePropId]), as a SUPPLEMENT override; a real capture is left untouched, and the user
+        // can still spoof any of them per-profile.
         val supplemented = ArrayList<String>()
         for (field in DEVICE_PROP_IDS) {
             if (out.effective(field).isNotBlank()) continue // attested, or already supplemented
@@ -602,17 +600,15 @@ object Harvester {
         }
 
     /**
-     * The device-property id [field] resolved EXACTLY as keystore fills ATTESTATION_ID_* — so a
-     * supplemented value equals what the calling app's request carries (a plain android.os.Build read is
-     * NOT the same source, and diverges on a ROM that ships attestation-specific ids). Mirrors
-     * AndroidKeyStoreKeyPairGeneratorSpi, which reads Build.<X>_FOR_ATTESTATION with a fallback, and
-     * Build.getVendorDeviceIdProperty behind it:
+     * The device-property id [field], resolved the way the framework resolves ATTESTATION_ID_*. Source:
+     * AOSP AndroidKeyStoreKeyPairGeneratorSpi reads Build.<X>_FOR_ATTESTATION (falling back to Build.<X>),
+     * and android.os.Build.getVendorDeviceIdProperty backs the _FOR_ATTESTATION fields as:
      *   ro.product.<base>_for_attestation  (unless "unknown")
      *     → else ro.product.vendor.<base>   (unless empty/"unknown")
      *     → else ro.product.<base>          (the plain Build value)
-     * A ROM that sets *_for_attestation overrides (e.g. LineageOS, sapphire vs sapphiren) then yields the
-     * id the caller attests, not the raw ro.product.* value a normal Build read resolves. Blank when the
-     * whole chain is unset/unknown, so nothing garbage is supplemented.
+     * where <base> is brand/device/name(product)/manufacturer/model. This reads the same properties
+     * directly rather than the hidden Build.<X>_FOR_ATTESTATION fields. Blank when the whole chain is
+     * unset/unknown.
      */
     private fun devicePropId(field: String): String {
         val base = attestIdBase(field) ?: return ""

--- a/app/src/main/java/org/matrix/teesim/Resolver.kt
+++ b/app/src/main/java/org/matrix/teesim/Resolver.kt
@@ -142,18 +142,19 @@ object Resolver {
         }
 
         // Device IDs: an explicit profile value overrides; otherwise fall back to the harvest baseline —
-        // the real captured id, or (for serial/imei/meid, which the leaf never attests) the value read
+        // the real captured id, or (for serial/imei/meid, which the leaf never attests, and for
+        // brand/device/product/manufacturer/model on a device that did no ID attestation) the value read
         // from the OS at harvest, exposed via effective(). Omitted when neither is set (declines that id).
         val ids = JSONObject()
-        putId(ids, "brand", p.brand, harvest.brand)
-        putId(ids, "device", p.device, harvest.device)
-        putId(ids, "product", p.product, harvest.product)
+        putId(ids, "brand", p.brand, harvest.effective("brand"))
+        putId(ids, "device", p.device, harvest.effective("device"))
+        putId(ids, "product", p.product, harvest.effective("product"))
         putId(ids, "serial", p.serial, harvest.effective("serial"))
         putId(ids, "imei", p.imei, harvest.effective("imei"))
         putId(ids, "imei2", p.imei2, harvest.effective("imei2"))
         putId(ids, "meid", p.meid, harvest.effective("meid"))
-        putId(ids, "manufacturer", p.manufacturer, harvest.manufacturer)
-        putId(ids, "model", p.model, harvest.model)
+        putId(ids, "manufacturer", p.manufacturer, harvest.effective("manufacturer"))
+        putId(ids, "model", p.model, harvest.effective("model"))
         if (ids.length() > 0) o.put("deviceIds", ids)
 
         // packages[] (attestation name-match, verbatim incl. not-yet-installed) and uids[] (caller-uid

--- a/app/src/main/java/org/matrix/teesim/Resolver.kt
+++ b/app/src/main/java/org/matrix/teesim/Resolver.kt
@@ -142,9 +142,9 @@ object Resolver {
         }
 
         // Device IDs: an explicit profile value overrides; otherwise fall back to the harvest baseline —
-        // the real captured id, or (for serial/imei/meid, which the leaf never attests, and for
-        // brand/device/product/manufacturer/model on a device that did no ID attestation) the value read
-        // from the OS at harvest, exposed via effective(). Omitted when neither is set (declines that id).
+        // the real captured id, else the value read from the OS at harvest (serial/imei/meid, and
+        // brand/device/product/manufacturer/model when the leaf carried none), exposed via effective().
+        // Omitted when neither is set (declines that id).
         val ids = JSONObject()
         putId(ids, "brand", p.brand, harvest.effective("brand"))
         putId(ids, "device", p.device, harvest.effective("device"))


### PR DESCRIPTION
brand/device/product/manufacturer/model are captured from the attested leaf, and Resolver presented `harvest.<id>` raw. A device that produced no device-ID attestation — a plain attestation, or a TEE that refuses ID attestation — leaves all five blank, so the profile presented an empty id, and the reference TA's ID check then rejects an app that requests the device's true value ("attestation ID mismatch for brand"). serial/imei/imei2/meid were already supplemented from the OS; these five were not, even though they are exactly the ids the framework fills `ATTESTATION_ID_*` from.

When the captured value is blank, the harvest now fills each from the `android.os.Build` field the framework itself reads for ID attestation — which resolves from the `ro.product.*` system properties — recorded as a SUPPLEMENT override. Resolver presents `effective()` for every id, so a supplemented value reaches the TA while a real capture stays untouched, the WebUI shows the supplement for what it is, and an explicit per-profile spoof still overrides it.
