### PR TITLE
fix: match attestation versions for HIDL Keymaster

### DIFF
--- a/app/src/main/java/org/matrix/teesim/Harvester.kt
+++ b/app/src/main/java/org/matrix/teesim/Harvester.kt
@@ -380,32 +380,36 @@ object Harvester {
     private fun clampAttestationToVintf(r: Record): Record {
         var out = r
 
-        Vintf.keyMintHalVersion("default")?.let { hal ->
-            val ceiling = hal * 100
+        Vintf.attestationVersionConstraint("default")?.let { constraint ->
+            val required = constraint.version
             val current = out.effectiveInt("attestationVersion", out.attestationVersion)
-            if (current > ceiling) {
+            if ((constraint.exact && current != required) || current > required) {
                 SystemLogger.info(
-                    "Harvest: clamping attestationVersion $current -> $ceiling to match the device's " +
-                        "VINTF-declared KeyMint HAL (IKeyMintDevice/default@$hal); a higher value would " +
-                        "contradict the vendor manifest"
+                    "Harvest: constraining attestationVersion $current -> $required to match the device's " +
+                        "VINTF-declared KeyMint/Keymaster HAL; the attestation record must agree with " +
+                        "the vendor manifest"
                 )
                 out =
                     out
-                        .withOverride("attestationVersion", ceiling.toString())
-                        .withOverride("keymasterVersion", keymasterVersionFor(ceiling).toString())
+                        .withOverride("attestationVersion", required.toString())
+                        .withOverride("keymasterVersion", keymasterVersionFor(required).toString())
             }
         }
 
         // StrongBox declares its own instance version; fall back to the default instance's when the manifest
         // does not list a separate strongbox HAL (many devices share one KeyMint version across levels).
-        (Vintf.keyMintHalVersion("strongbox") ?: Vintf.keyMintHalVersion("default"))?.let { hal ->
-            val ceiling = hal * 100
-            if (out.strongBoxAttestationVersion > ceiling) {
+        (Vintf.attestationVersionConstraint("strongbox")
+            ?: Vintf.attestationVersionConstraint("default"))?.let { constraint ->
+            val required = constraint.version
+            if (
+                (constraint.exact && out.strongBoxAttestationVersion != required) ||
+                    out.strongBoxAttestationVersion > required
+            ) {
                 SystemLogger.info(
                     "Harvest: clamping strongBoxAttestationVersion ${out.strongBoxAttestationVersion} -> " +
-                        "$ceiling to match the device's VINTF-declared KeyMint StrongBox HAL (@$hal)"
+                        "$required to match the device's VINTF-declared KeyMint/Keymaster StrongBox HAL"
                 )
-                out = out.copy(strongBoxAttestationVersion = ceiling)
+                out = out.copy(strongBoxAttestationVersion = required)
             }
         }
 

--- a/app/src/main/java/org/matrix/teesim/Vintf.kt
+++ b/app/src/main/java/org/matrix/teesim/Vintf.kt
@@ -25,6 +25,8 @@ object Vintf {
     // too.
     private const val KEYMINT_HAL = "android.hardware.security.keymint"
     private const val KEYMINT_IFACE = "IKeyMintDevice"
+    private const val KEYMASTER_HAL = "android.hardware.keymaster"
+    private const val KEYMASTER_IFACE = "IKeymasterDevice"
 
     // Standard AIDL VINTF manifest locations, vendor first (KeyMint is a vendor HAL). The
     // directories hold
@@ -42,6 +44,29 @@ object Vintf {
         )
 
     private val cache = HashMap<String, Int?>()
+    data class AttestationConstraint(val version: Int, val exact: Boolean)
+
+    private val attestationCache = HashMap<String, AttestationConstraint?>()
+
+    /**
+     * Highest attestation schema version consistent with the hardware-backed keystore HAL declared
+     * for [instance]. Modern AIDL KeyMint versions map directly to their attestation encoding (3 ->
+     * 300). Legacy HIDL Keymaster versions use the historical mapping from the Android attestation
+     * specification: 3.0 -> 2, 4.0 -> 3, and 4.1 -> 4.
+     */
+    @Synchronized
+    fun attestationVersionConstraint(instance: String = "default"): AttestationConstraint? {
+        if (attestationCache.containsKey(instance)) return attestationCache[instance]
+        val constraint =
+            keyMintHalVersion(instance)?.let { AttestationConstraint(it * 100, exact = false) }
+                ?: scanKeymaster(instance)?.let { AttestationConstraint(it, exact = true) }
+        attestationCache[instance] = constraint
+        SystemLogger.info(
+            "Vintf: attestation version constraint for instance '$instance' = " +
+                "${constraint?.version ?: "unknown"} (exact=${constraint?.exact ?: false})"
+        )
+        return constraint
+    }
 
     /**
      * The declared KeyMint AIDL version for [instance] (e.g. 3 for `IKeyMintDevice/default@3`), or
@@ -86,6 +111,108 @@ object Vintf {
         }
         return best
     }
+
+    /** Highest legacy HIDL Keymaster attestation version declared for [instance]. */
+    private fun scanKeymaster(instance: String): Int? {
+        var best: Int? = null
+        for (path in MANIFEST_PATHS) {
+            val f = File(path)
+            val files =
+                when {
+                    !f.exists() -> emptyList()
+                    f.isDirectory ->
+                        f.listFiles { file -> file.isFile && file.name.endsWith(".xml") }?.toList()
+                            ?: emptyList()
+                    else -> listOf(f)
+                }
+            for (file in files) {
+                keymasterVersionIn(file, instance)?.let { v -> best = maxOf(best ?: v, v) }
+            }
+        }
+        return best
+    }
+
+    /** Parse a legacy HIDL Keymaster declaration and return its attestation schema version. */
+    private fun keymasterVersionIn(file: File, instance: String): Int? {
+        var best: Int? = null
+        file.inputStream().use { input ->
+            val parser = Xml.newPullParser()
+            parser.setInput(input, null)
+
+            var inHal = false
+            var isHidl = false
+            var halName: String? = null
+            val versions = ArrayList<String>()
+            var instanceMatched = false
+            var ifaceName: String? = null
+
+            var event = parser.eventType
+            while (event != XmlPullParser.END_DOCUMENT) {
+                if (event == XmlPullParser.START_TAG) {
+                    val depth = parser.depth
+                    when (parser.name) {
+                        "hal" -> {
+                            inHal = true
+                            isHidl = "hidl".equals(parser.getAttributeValue(null, "format"), true)
+                            halName = null
+                            versions.clear()
+                            instanceMatched = false
+                            ifaceName = null
+                        }
+                        "interface" -> if (inHal) ifaceName = null
+                        "name" ->
+                            if (inHal) {
+                                val text = readText(parser)
+                                if (depth <= 3) halName = halName ?: text else ifaceName = text
+                            }
+                        "version" -> if (inHal && depth <= 3) versions.add(readText(parser))
+                        "instance" ->
+                            if (
+                                inHal &&
+                                    KEYMASTER_IFACE == ifaceName &&
+                                    readText(parser) == instance
+                            ) {
+                                instanceMatched = true
+                            }
+                        "fqname" ->
+                            if (inHal) {
+                                // Format: "@3.0::IKeymasterDevice/default".
+                                val fq = readText(parser)
+                                val ifaceAndInstance = fq.substringAfter("::", fq)
+                                if (
+                                    ifaceAndInstance.substringBefore('/') == KEYMASTER_IFACE &&
+                                        ifaceAndInstance.substringAfterLast('/') == instance
+                                ) {
+                                    instanceMatched = true
+                                    fq.substringAfter('@', "")
+                                        .substringBefore("::")
+                                        .takeIf { it.isNotEmpty() }
+                                        ?.let { versions.add(it) }
+                                }
+                            }
+                    }
+                } else if (event == XmlPullParser.END_TAG && parser.name == "hal") {
+                    if (inHal && isHidl && halName == KEYMASTER_HAL && instanceMatched) {
+                        versions.mapNotNull(::keymasterAttestationVersion).maxOrNull()?.let { v ->
+                            best = maxOf(best ?: v, v)
+                        }
+                    }
+                    inHal = false
+                }
+                event = parser.next()
+            }
+        }
+        return best
+    }
+
+    private fun keymasterAttestationVersion(version: String): Int? =
+        when (version.trim()) {
+            "2.0" -> 1
+            "3.0" -> 2
+            "4.0" -> 3
+            "4.1" -> 4
+            else -> null
+        }
 
     /**
      * The highest KeyMint `IKeyMintDevice/[instance]` AIDL version declared in one manifest file,


### PR DESCRIPTION
## Problem

  The VINTF attestation-version constraint added in #247 handles modern AIDL
  KeyMint declarations, but not devices that expose a legacy HIDL Keymaster HAL.

  On a Samsung SM-N960F using Custom ROM based on SM-S926B running Android 15, VINTF declares:


  android.hardware.keymaster@3.0::IKeymasterDevice/default

  TEESimulator produced:

  attestationVersion = 1
  keymasterVersion = 1

  This caused an integrity checker to report a VINTF mismatch because Keymaster
  3.0 should produce:

  attestationVersion = 2
  keymasterVersion = 3

## Changes

  - Parse legacy HIDL Keymaster declarations from VINTF manifests.
  - Map Keymaster HAL versions to their corresponding attestation schema versions:
      - Keymaster 2.0 → attestation version 1
      - Keymaster 3.0 → attestation version 2
      - Keymaster 4.0 → attestation version 3
      - Keymaster 4.1 → attestation version 4

  - Require an exact version match for legacy HIDL Keymaster.
  - Preserve the existing ceiling behavior for modern AIDL KeyMint.
  - Apply the same constraint logic to StrongBox.


## Detection

<img width="1080" height="547" alt="Detect VINTF" src="https://github.com/user-attachments/assets/3abd9c63-4296-48e8-8b13-753624cbd2d2" />


## Testing

  Tested on:

  Device: SM-N960F using Custom ROM based on SM-S926B

  Android: 15
  HAL: android.hardware.keymaster@3.0::IKeymasterDevice/default

  Before:

  attestationVersion = 1
  keymasterVersion = 1
  VINTF mismatch reported

  After:

  attestationVersion = 2
  keymasterVersion = 3
  VINTF mismatch resolved

  The complete release build passed successfully:

  ./gradlew zipRelease

  Both arm64-v8a and x86_64 targets compiled successfully.
