### PR TITLE
Sign a new attest key under the caller's attest key instead of the keybox

### DIFF
--- a/keymint/keymint_router.cpp
+++ b/keymint/keymint_router.cpp
@@ -546,6 +546,17 @@ class TeesimKeyMintDevice : public BnKeyMintDevice {
     // attest-key creation already arrived with no injected key — exactly why StrongBox worked and TE did
     // not.) Forward std::nullopt: the TA self-attests the new key under the keybox.
     if (IsAttestKeyRequest(keyParams)) {
+      // An attest key created via setAttestKeyAlias(A) arrives with A's blob injected: the app is
+      // building a key graph A -> B and expects B's leaf to be SIGNED BY A (so verifying B under A's
+      // public key succeeds). If A is ours we must honor that — sign B's leaf with A in the TA — or the
+      // graph breaks and B's leaf verifies under neither A nor the keybox, a signature no real KeyMint
+      // could produce and a reliable "leaf re-rooted" tell. Only self-attest under the keybox when there
+      // is no injected key, or a FOREIGN one (an RKP key keystore2 injected for a bare challenge) we
+      // cannot re-root anyway.
+      if (attestationKey && IsOurs(attestationKey->keyBlob)) {
+        LOGI("generateKey: attest-key creation attested by our attest key; signing its leaf with it (preserving the A->B chain)");
+        return Simulate(t.ta.get(), keyParams, attestationKey, out);
+      }
       LOGI("generateKey: attest-key creation -> forced generation in the TA (ignoring any injected attest key)");
       return Simulate(t.ta.get(), keyParams, std::nullopt, out);
     }

--- a/keymint/keymint_router.cpp
+++ b/keymint/keymint_router.cpp
@@ -537,14 +537,14 @@ class TeesimKeyMintDevice : public BnKeyMintDevice {
       }
       return Status(-100);
     }
-    // Creating an ATTESTATION KEY (ATTEST_KEY purpose) always mints it in the TA (ours) and IGNORES any
-    // attest key keystore2 injected to attest it. This MUST come before the attestationKey branch below:
-    // on TrustedEnvironment, attesting a new attest key that carries a challenge makes keystore2 inject
-    // an RKP-provisioned (real hardware) key — which would otherwise be seen here as a "foreign attest
-    // key" and forwarded, leaving us a foreign attest key we can never re-root. We must hold this key's
-    // private key so the leaves it later signs get a patched root of trust. (StrongBox has no RKP, so its
-    // attest-key creation already arrived with no injected key — exactly why StrongBox worked and TE did
-    // not.) Forward std::nullopt: the TA self-attests the new key under the keybox.
+    // Creating an ATTESTATION KEY (ATTEST_KEY purpose) always mints it in the TA (ours). Unless the
+    // caller named one of our keys as its attest key (the "ours" case just below), we ignore any
+    // injected attest key and self-attest the new key under the keybox. This MUST come before the
+    // attestationKey branch below: on TrustedEnvironment, attesting a new attest key that carries a
+    // challenge makes keystore2 inject an RKP-provisioned (real hardware) key — which that branch would
+    // forward, leaving us a foreign attest key we can never re-root. We must hold this key's private key
+    // so the leaves it later signs get a patched root of trust. (StrongBox has no RKP, so its attest-key
+    // creation already arrived with no injected key — exactly why StrongBox worked and TE did not.)
     if (IsAttestKeyRequest(keyParams)) {
       // An attest key created via setAttestKeyAlias(A) arrives with A's blob injected: the app is
       // building a key graph A -> B and expects B's leaf to be SIGNED BY A (so verifying B under A's
@@ -557,7 +557,7 @@ class TeesimKeyMintDevice : public BnKeyMintDevice {
         LOGI("generateKey: attest-key creation attested by our attest key; signing its leaf with it (preserving the A->B chain)");
         return Simulate(t.ta.get(), keyParams, attestationKey, out);
       }
-      LOGI("generateKey: attest-key creation -> forced generation in the TA (ignoring any injected attest key)");
+      LOGI("generateKey: attest-key creation -> forced generation in the TA (no usable injected attest key)");
       return Simulate(t.ta.get(), keyParams, std::nullopt, out);
     }
     // A leaf that carries an attest key: keystore2 appends that attest key's OWN stored certificate chain


### PR DESCRIPTION
`generateKey` mints every `ATTEST_KEY`-purpose key in the TA and, until now, always self-attested it under the keybox, discarding any attestation key keystore2 injected with the request. That is right for a bare attestation key -- keystore2 injects an RKP-provisioned hardware key we cannot re-root, so rooting the new key at the keybox is the only option -- but wrong once the caller has built a key graph with [`setAttestKeyAlias`](<https://developer.android.com/reference/android/security/keystore/KeyGenParameterSpec.Builder#setAttestKeyAlias(java.lang.String)>). There the caller names an attest key A and expects the new key B's leaf to be signed by A, so that verifying B against A's public key succeeds. When A is one of ours, self-attesting B under the keybox breaks the graph: B's leaf carries A's subject as its issuer but a keybox signature, and the chain the caller assembled verifies under neither A nor the keybox.

The attest-key branch now checks whether the injected attestation key is ours and, if so, signs B's leaf with it, keeping the A -> B relationship intact; it falls back to keybox self-attestation only when no key was injected or the injected one is a foreign RKP key we cannot re-root. The ordinary business-key path already did this for leaves that are not themselves attest keys -- this extends the same rule to the attest-key case.
