### PR TITLE
Replace the loopback port and abstract socket with pathname sockets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,12 @@ target_include_directories(inject PRIVATE injector/include)
 target_link_libraries(inject PRIVATE lsplt log)
 target_link_options(inject PRIVATE -static-libstdc++)
 
+# --- The WebUI's admin-socket client ----------------------------------------
+# The daemon serves its admin endpoint on a root-only filesystem unix socket (see KeyAdmin.kt); a
+# WebView cannot fetch() a unix socket, so the WebUI reaches it through its root-exec bridge and this
+# tiny HTTP-over-UDS client. Plain C, no dependencies — it just pumps one request/response.
+add_executable(teesim-uds injector/teesim_uds.c)
+
 # --- KeyMint AIDL, generated with the NDK backend ---------------------------
 # fromBinder's local-binder fallback (checked below) only exists in aidl from build-tools >= 35, so
 # prefer the newest installed build-tools over whatever aidl happens to be first on PATH or first in

--- a/app/README.md
+++ b/app/README.md
@@ -126,7 +126,7 @@ Once the framework is up, `App.main` wires the daemon and enters `Looper.loop()`
 The root-manager WebUI talks to the daemon over a tiny loopback HTTP endpoint, since the daemon
 has a real `Context` and root that the webview alone does not:
 
-- **`KeyAdmin`** — HTTP/1.1 on `127.0.0.1:8790`, gated by a random token in a root-only file
+- **`KeyAdmin`** — HTTP/1.1 over a root-only filesystem unix socket (`/data/adb/teesim/admin.sock`), gated by a random token in a root-only file
   (`admin.token`). It serves the WebUI's status, key, keybox, logs, and canary routes, plus the
   **Scope** app-picker's routes: **`GET /packages`** (the installed-app list collapsed by uid — label,
   packages, system / launchable / enabled, install time, plus per-app request frequency, last-used, and

--- a/app/README.md
+++ b/app/README.md
@@ -5,7 +5,7 @@ Android framework (an attested key to harvest from, `PackageManager` to resolve 
 `Context` to reach keystore) lives here, in a Kotlin process launched by the module's
 `service.sh` via `app_process`. The injected native interceptors stay pure crypto-and-routing
 engines; this daemon owns the configuration, resolves it against the live device, injects the
-interceptor, and pushes the resolved profiles over the `@teesim` control socket. It never sits
+interceptor, and pushes the resolved profiles over the control socket. It never sits
 in the keystore hot path.
 
 It builds to a single `classes.dex` (AGP), shipped in the module and run as:
@@ -90,9 +90,9 @@ Once the framework is up, `App.main` wires the daemon and enters `Looper.loop()`
    other's copy.
 3. **`Injector`** finds the keystore daemon's pid (`keystore2` on API ≥ 31, `keystore` on 10/11),
    runs the packaged `inject` binary to load the right interceptor, and re-injects whenever the
-   pid changes; it confirms the library actually checked in over `@teesim` and warns otherwise
-   (usually an SELinux denial on the abstract socket).
-4. **`Control`** connects the `@teesim` abstract unix socket, checks peer credentials, and pushes
+   pid changes; it confirms the library actually checked in over the control socket and warns otherwise
+   (usually an SELinux denial on it).
+4. **`Control`** connects the control socket, checks the peer is keystore, and pushes
    the resolved config on start and on every change.
 5. **`ReAttest`** runs after each push commits (on the lib's `ack`) to re-root keys that already
    existed before their app was covered — a key made earlier carries the real hardware attestation
@@ -123,8 +123,8 @@ Once the framework is up, `App.main` wires the daemon and enters `Looper.loop()`
 
 ## The WebUI back end
 
-The root-manager WebUI talks to the daemon over a tiny loopback HTTP endpoint, since the daemon
-has a real `Context` and root that the webview alone does not:
+The root-manager WebUI talks to the daemon over a tiny HTTP endpoint on a root-only socket, since the
+daemon has a real `Context` and root that the webview alone does not:
 
 - **`KeyAdmin`** — HTTP/1.1 over a root-only filesystem unix socket (`/data/adb/teesim/admin.sock`), gated by a random token in a root-only file
   (`admin.token`). It serves the WebUI's status, key, keybox, logs, and canary routes, plus the

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,7 +57,7 @@ android {
                 abiFilters += listOf("arm64-v8a", "x86_64")
                 // Match package.sh: build the injector and both interceptors; the
                 // static BoringSSL `crypto` target builds transitively for keystore.
-                targets += listOf("inject", "teesim_keymint", "teesim_keystore")
+                targets += listOf("inject", "teesim-uds", "teesim_keymint", "teesim_keystore")
             }
         }
     }
@@ -244,8 +244,8 @@ androidComponents {
                     include("**/libteesim_keymint.so", "**/libteesim_keystore.so")
                 }
 
-                // The injector executable, one per <abi>/.
-                from(cmakeObj) { include("**/inject") }
+                // The injector executable and the WebUI's admin-socket client, one per <abi>/.
+                from(cmakeObj) { include("**/inject", "**/teesim-uds") }
 
                 // The module scripts and WebUI (service.sh, daemon, customize.sh,
                 // sepolicy.rule, config.default.json, webroot/); module.prop is

--- a/app/src/main/java/org/matrix/teesim/App.kt
+++ b/app/src/main/java/org/matrix/teesim/App.kt
@@ -16,7 +16,7 @@ import org.json.JSONObject
  * Privileged control daemon, launched via app_process. Bootstraps just enough of the Android
  * framework for AndroidKeyStore + PackageManager to work in this bare process (following the proven
  * main-branch sequence), harvests real attestation parameters, injects the native interceptor, and
- * pushes resolved config over @teesim.
+ * pushes resolved config over the control socket.
  *
  * Launch (from the module's service.sh): app_process -Djava.class.path=$MODDIR/classes.dex $MODDIR
  * \ --nice-name=teesim org.matrix.teesim.App $MODDIR The trailing $MODDIR tells the Injector where

--- a/app/src/main/java/org/matrix/teesim/Const.kt
+++ b/app/src/main/java/org/matrix/teesim/Const.kt
@@ -14,6 +14,13 @@ object Const {
     val overridesFile = File(DATA_DIR, "overrides.json")
     val adminTokenFile = File(DATA_DIR, "admin.token")
 
+    /** Filesystem unix socket the WebUI reaches KeyAdmin on, in the root-only [DATA_DIR] (0700). Unlike a
+     *  loopback TCP port — which any app uid can connect() to and thereby fingerprint — the kernel
+     *  refuses a connect() here from any non-root caller, so the endpoint is invisible to other apps.
+     *  The WebUI's WebView can't reach a unix socket directly; it goes through the root-exec bridge and
+     *  the shipped `teesim-uds` client. */
+    val adminSocketFile = File(DATA_DIR, "admin.sock")
+
     /** Persistent per-package key-request frequency memory (Scope picker usage stats). Keyed by package name
      *  because a uid can change across reinstalls; accumulated across boots from per-poll lib deltas. */
     val usageFile = File(DATA_DIR, "usage.json")
@@ -25,11 +32,11 @@ object Const {
     /** keystore's uid; the control socket only sends the keybox once the peer is it. */
     const val AID_KEYSTORE = 1017
 
-    /** Abstract control socket the interceptor library binds (`\0teesim`). */
-    const val CONTROL_SOCKET = "teesim"
-
-    /** Loopback port the WebUI reaches KeyAdmin on. */
-    const val ADMIN_PORT = 8790
+    /** Filesystem control socket the interceptor library binds, inside keystore's own 0700 data dir
+     *  (keystore_data_file). A path under a directory apps cannot traverse gives a uniform EACCES on
+     *  connect() whether or not it exists — no existence oracle — unlike an abstract name, which any app
+     *  can probe. The daemon (root) connects to it; keystore binds it because it owns the directory. */
+    const val CONTROL_SOCKET_PATH = "/data/misc/keystore/.teesim-ctl"
 
     /** Security-level encodings shared with the native side and the wire protocol. */
     const val SECLEVEL_SOFTWARE = 0

--- a/app/src/main/java/org/matrix/teesim/Const.kt
+++ b/app/src/main/java/org/matrix/teesim/Const.kt
@@ -29,7 +29,10 @@ object Const {
      *  (when absent) and never rewritten, so auto-include can add only packages installed AFTER it. */
     val knownPackagesFile = File(DATA_DIR, "known_packages.json")
 
-    /** keystore's uid; the control socket only sends the keybox once the peer is it. */
+    /** keystore's uid; the control socket only sends the keybox once the peer is it. Named after AOSP's
+     *  own AID_KEYSTORE (android_filesystem_config.h) and mirrored here because the framework's
+     *  Process.KEYSTORE_UID is @hide — the public SDK exposes only ROOT/SYSTEM/PHONE/SHELL and the
+     *  application-uid bounds. */
     const val AID_KEYSTORE = 1017
 
     /** Filesystem control socket the interceptor library binds, inside keystore's own 0700 data dir

--- a/app/src/main/java/org/matrix/teesim/Control.kt
+++ b/app/src/main/java/org/matrix/teesim/Control.kt
@@ -13,7 +13,7 @@ import org.json.JSONArray
 import org.json.JSONObject
 
 /**
- * Control-channel CLIENT. Connects the abstract unix socket `@teesim`, verifies the peer is
+ * Control-channel CLIENT. Connects the filesystem unix socket at [Const.CONTROL_SOCKET_PATH], verifies the peer is
  * keystore (SO_PEERCRED uid == 1017) before sending the keybox bytes, then speaks the control.cpp
  * framing: [u32 BE length][UTF-8 JSON].
  *
@@ -90,7 +90,7 @@ object Control {
             try {
                 socket = LocalSocket()
                 socket.connect(
-                    LocalSocketAddress(Const.CONTROL_SOCKET, LocalSocketAddress.Namespace.ABSTRACT)
+                    LocalSocketAddress(Const.CONTROL_SOCKET_PATH, LocalSocketAddress.Namespace.FILESYSTEM)
                 )
                 val peerUid =
                     try {
@@ -108,7 +108,7 @@ object Control {
                     continue
                 }
                 SystemLogger.info(
-                    "control: connected to @${Const.CONTROL_SOCKET} (peer uid=$peerUid)"
+                    "control: connected to ${Const.CONTROL_SOCKET_PATH} (peer uid=$peerUid)"
                 )
                 backoff = 500L
 

--- a/app/src/main/java/org/matrix/teesim/Control.kt
+++ b/app/src/main/java/org/matrix/teesim/Control.kt
@@ -14,7 +14,7 @@ import org.json.JSONObject
 
 /**
  * Control-channel CLIENT. Connects the filesystem unix socket at [Const.CONTROL_SOCKET_PATH], verifies the peer is
- * keystore (SO_PEERCRED uid == 1017) before sending the keybox bytes, then speaks the control.cpp
+ * keystore (SO_PEERCRED uid == [Const.AID_KEYSTORE]) before sending the keybox bytes, then speaks the control.cpp
  * framing: [u32 BE length][UTF-8 JSON].
  *
  * Wire sequence: the lib sends its `hello` on accept; we send our `hello` then the latest `config`,

--- a/app/src/main/java/org/matrix/teesim/Injector.kt
+++ b/app/src/main/java/org/matrix/teesim/Injector.kt
@@ -79,7 +79,7 @@ class Injector(private val moduleDir: File) {
         }
     }
 
-    /** The control-channel hello is the real proof the lib loaded and bound @teesim. Warn
+    /** The control-channel hello is the real proof the lib loaded and bound the control socket. Warn
      * (don't re-inject — that risks double-hooking) if it never arrives. */
     private fun confirmAsync(pid: Int) {
         Thread({
@@ -88,8 +88,8 @@ class Injector(private val moduleDir: File) {
                     sleep(500)
                 }
                 SystemLogger.warning(
-                    "injector: injected pid=$pid but the lib never checked in over @teesim " +
-                        "(SELinux on the abstract socket? look for 'avc: denied' in logcat)"
+                    "injector: injected pid=$pid but the lib never checked in over ${Const.CONTROL_SOCKET_PATH} " +
+                        "(SELinux on the control socket? look for 'avc: denied' in logcat)"
                 )
             }, "teesim-inject-confirm")
             .apply {

--- a/app/src/main/java/org/matrix/teesim/KeyAdmin.kt
+++ b/app/src/main/java/org/matrix/teesim/KeyAdmin.kt
@@ -78,7 +78,7 @@ object KeyAdmin {
     // ?pkg= into PackageManager. Same shape ConfigStore validates apps[] package entries with (the
     // user an icon should be looked up in rides in its own ?user= parameter, not in the name).
     private val PKG_RE = Regex("^[A-Za-z0-9_.]+$")
-    // Upper bound on a request body (bytes). The admin socket is localhost + token-authed, but a bogus
+    // Upper bound on a request body (bytes). The admin socket is root-only + token-authed, but a bogus
     // Content-Length should still never be trusted as an allocation size.
     private const val MAX_BODY_BYTES = 8 * 1024 * 1024
     private val b64 = Base64.getEncoder()

--- a/app/src/main/java/org/matrix/teesim/KeyAdmin.kt
+++ b/app/src/main/java/org/matrix/teesim/KeyAdmin.kt
@@ -1,14 +1,15 @@
 package org.matrix.teesim
 
+import android.net.LocalServerSocket
+import android.net.LocalSocket
+import android.net.LocalSocketAddress
 import android.os.Build
 import android.security.keystore.KeyInfo
+import android.system.Os
 import java.io.BufferedReader
 import java.io.File
 import java.io.InputStreamReader
 import java.io.OutputStream
-import java.net.InetAddress
-import java.net.ServerSocket
-import java.net.Socket
 import java.security.KeyFactory
 import java.security.KeyStore
 import java.security.PrivateKey
@@ -31,9 +32,14 @@ import org.json.JSONObject
 
 /**
  * Key-management endpoint the WebUI calls to list / inspect / delete AndroidKeyStore entries the
- * daemon (a real root Context) can reach. Minimal HTTP/1.1 on loopback, guarded by a random token
- * written to [Const.adminTokenFile] (0600) — only root (the WebUI's manager bridge) can read the
- * token, so other apps on the device can't drive it.
+ * daemon (a real root Context) can reach. Minimal HTTP/1.1 over a FILESYSTEM unix-domain socket at
+ * [Const.adminSocketFile], inside the 0700 root-only [Const.DATA_DIR]. A loopback TCP port would be
+ * connectable by any app uid — and a service answering there fingerprints the module — so it is served
+ * on a unix socket instead: the kernel refuses a connect() from any non-root caller, making the
+ * endpoint invisible to every other app. The WebView cannot reach a unix socket directly, so the WebUI
+ * drives it through its root-exec bridge and the shipped `teesim-uds` client. Every request still
+ * carries the random admin token (defense in depth on top of the socket's permissions); the peer uid is
+ * additionally checked to be root at accept time.
  *
  * Contract (all responses application/json; send header `X-Teesim-Token: <token>`): GET /status ->
  * { ok, version, harvest{...}, lib{hook,api} } GET /keys -> { ok, keys:[ {alias, securityLevel, ours,
@@ -101,9 +107,18 @@ object KeyAdmin {
         harvest = record
     }
 
+    // Hold the listening socket and the LocalSocket that owns its bound fd for the life of the daemon,
+    // so neither is garbage-collected out from under the accept loop (a finalizer would close the fd).
+    @Volatile private var listenSocket: LocalServerSocket? = null
+    @Volatile private var listenBinder: LocalSocket? = null
+
     private fun startInner() {
         try {
             Const.adminTokenFile.parentFile?.mkdirs()
+            // The data dir holds the token and the admin socket; keep it root-only (0700) so neither is
+            // reachable by another uid even before the socket's own permissions apply. /data/adb is
+            // already 0700 on every supported root solution — this is belt-and-suspenders.
+            runCatching { Os.chmod(Const.DATA_DIR, /* 0700 */ 448) }
             Const.adminTokenFile.writeText(token)
             Const.adminTokenFile.setReadable(false, false)
             Const.adminTokenFile.setReadable(true, true) // owner (root) only
@@ -123,18 +138,59 @@ object KeyAdmin {
         return b.joinToString("") { "%02x".format(it) }
     }
 
+    /**
+     * Constant-time comparison of a caller-supplied token against the in-memory admin token. A `null`
+     * or length-mismatched candidate never matches. Length-independent so the compare time does not
+     * leak how many leading characters were correct — the token is the only thing standing between an
+     * app on the device and the admin surface, so it is compared without an early-out.
+     */
+    private fun tokensMatch(candidate: String?): Boolean {
+        val expected = token
+        if (candidate == null || expected.isEmpty()) return false
+        var diff = candidate.length xor expected.length
+        for (i in expected.indices) {
+            diff = diff or (expected[i].code xor (candidate.getOrNull(i)?.code ?: 0))
+        }
+        return diff == 0
+    }
+
     private fun serve() {
+        val path = Const.adminSocketFile.absolutePath
         val server =
             try {
-                ServerSocket(Const.ADMIN_PORT, 8, InetAddress.getByName("127.0.0.1"))
+                // A stale socket file from a previous run would make bind() fail with EADDRINUSE.
+                Const.adminSocketFile.delete()
+                // Bind a filesystem-namespaced unix socket, then wrap its fd in a LocalServerSocket
+                // (whose constructor calls listen()). A LocalServerSocket(String) would use the ABSTRACT
+                // namespace, which ignores filesystem permissions and is reachable by any app — exactly
+                // what we are avoiding — so we bind the filesystem path explicitly.
+                val binder = LocalSocket(LocalSocket.SOCKET_STREAM)
+                binder.bind(LocalSocketAddress(path, LocalSocketAddress.Namespace.FILESYSTEM))
+                listenBinder = binder
+                // The 0700 data dir already blocks other uids; also mark the socket node 0600.
+                runCatching { Os.chmod(path, /* 0600 */ 384) }
+                LocalServerSocket(binder.fileDescriptor).also { listenSocket = it }
             } catch (e: Exception) {
-                SystemLogger.error("KeyAdmin: cannot bind 127.0.0.1:${Const.ADMIN_PORT}", e)
+                SystemLogger.error("KeyAdmin: cannot bind unix socket $path", e)
                 return
             }
-        SystemLogger.info("KeyAdmin: listening on 127.0.0.1:${Const.ADMIN_PORT}")
+        SystemLogger.info("KeyAdmin: listening on unix:$path")
         while (true) {
             try {
                 val client = server.accept()
+                // Defense in depth on top of the socket's filesystem permissions: only root may drive
+                // the admin endpoint. A peer that is not uid 0 is dropped without a byte of response.
+                val peerUid =
+                    try {
+                        client.peerCredentials.uid
+                    } catch (_: Exception) {
+                        -1
+                    }
+                if (peerUid != 0) {
+                    SystemLogger.warning("KeyAdmin: rejecting non-root peer uid=$peerUid")
+                    runCatching { client.close() }
+                    continue
+                }
                 // Handle each connection on its own thread with a read timeout, so one slow, half-open,
                 // or mis-framed client (e.g. a Content-Length that never fully arrives) can never wedge
                 // the accept loop and take the whole admin endpoint down with it.
@@ -152,19 +208,18 @@ object KeyAdmin {
         }
     }
 
-    private fun handle(client: Socket) {
+    private fun handle(client: LocalSocket) {
         client.use {
-            val reader = BufferedReader(InputStreamReader(client.getInputStream(), Charsets.UTF_8))
-            val out = client.getOutputStream()
+            val reader = BufferedReader(InputStreamReader(client.inputStream, Charsets.UTF_8))
+            val out = client.outputStream
 
+            // Do NOT log the request line yet: nothing about a request is trusted or reflected until the
+            // token check below passes, so an unauthenticated caller never sees its own path echoed into
+            // the log. The request line is logged only after auth succeeds.
             val requestLine = reader.readLine() ?: return
             val t0 = System.currentTimeMillis()
-            SystemLogger.info("KeyAdmin: → ${requestLine.take(140)}")
             val parts = requestLine.split(" ")
-            if (parts.size < 2) {
-                respond(out, 400, JSONObject().put("ok", false).put("error", "bad request"))
-                return
-            }
+            if (parts.size < 2) return // malformed: drop silently, emit nothing
             val method = parts[0]
             val rawPath = parts[1]
 
@@ -177,41 +232,30 @@ object KeyAdmin {
                 if (idx <= 0) continue
                 val hName = line.substring(0, idx).trim()
                 val hVal = line.substring(idx + 1).trim()
-                if (hName.equals("X-Teesim-Token", true)) headerToken = hVal
-                else if (hName.equals("Content-Length", true)) contentLength = hVal.toIntOrNull() ?: 0
+                when {
+                    hName.equals("X-Teesim-Token", true) -> headerToken = hVal
+                    hName.equals("Content-Length", true) -> contentLength = hVal.toIntOrNull() ?: 0
+                }
             }
 
-            if (method == "OPTIONS") { // CORS preflight
-                respond(out, 204, null)
+            // The peer is already proven to be root (checked at accept) and reached us only through the
+            // root-only socket; the token is the final gate. A request without it is dropped silently —
+            // no response body, no reflected path, nothing to observe. There is no browser on this
+            // transport any more, so no CORS/OPTIONS handling is needed.
+            if (!tokensMatch(headerToken)) return
+            SystemLogger.info("KeyAdmin: → ${requestLine.take(140)}")
+
+            // Raw (non-JSON) routes: a PNG icon and a plain-text log stream. The WebUI reaches these
+            // through the same token-authenticated helper as every other route (a browser <img>/download
+            // navigation could not set the header, but the WebUI no longer fetches these directly — it
+            // pipes the bytes in over the root bridge).
+            val rawRoute = rawPath.substringBefore('?')
+            if (method == "GET" && rawRoute == "/logs/download") {
+                downloadLogs(out, parseQuery(rawPath.substringAfter('?', "")))
                 return
             }
-            // The log download is opened by a browser navigation, which cannot set the
-            // X-Teesim-Token header, so this one route authenticates with a ?token= query
-            // parameter (validated against the same in-memory token) and streams plain text
-            // named by a Content-Disposition header instead of the JSON envelope. Handled here,
-            // ahead of the header-token check that every other route still requires.
-            if (method == "GET" && rawPath.substringBefore('?') == "/logs/download") {
-                val dlQuery = parseQuery(rawPath.substringAfter('?', ""))
-                if (dlQuery["token"] != token) {
-                    respond(out, 403, JSONObject().put("ok", false).put("error", "invalid token"))
-                    return
-                }
-                downloadLogs(out, dlQuery)
-                return
-            }
-            // App icons are loaded by a browser <img src>, which likewise cannot set the token header,
-            // so /icon authenticates by ?token= exactly like /logs/download and streams a raw PNG.
-            if (method == "GET" && rawPath.substringBefore('?') == "/icon") {
-                val iconQuery = parseQuery(rawPath.substringAfter('?', ""))
-                if (iconQuery["token"] != token) {
-                    respond(out, 403, JSONObject().put("ok", false).put("error", "invalid token"))
-                    return
-                }
-                serveIcon(out, iconQuery)
-                return
-            }
-            if (headerToken == null || headerToken != token) {
-                respond(out, 403, JSONObject().put("ok", false).put("error", "invalid token"))
+            if (method == "GET" && rawRoute == "/icon") {
+                serveIcon(out, parseQuery(rawPath.substringAfter('?', "")))
                 return
             }
 

--- a/common/control.cpp
+++ b/common/control.cpp
@@ -1,6 +1,6 @@
-// The control-channel server: it owns the abstract unix socket @teesim, accepts
-// the daemon's connection, and turns each pushed "config" message into calls on
-// the router's staging API. See control.h for the protocol shape.
+// The control-channel server: it owns the control socket, accepts the daemon's
+// connection, and turns each pushed "config" message into calls on the router's
+// staging API. See control.h for the protocol shape.
 //
 // Pure POSIX + the JSON reader + the staging API, so the same object file links
 // into both interceptors (which are built with -fno-exceptions/-fno-rtti); it

--- a/common/control.cpp
+++ b/common/control.cpp
@@ -10,6 +10,7 @@
 
 #include <pthread.h>
 #include <sys/socket.h>
+#include <sys/stat.h>
 #include <sys/system_properties.h>
 #include <sys/un.h>
 #include <unistd.h>
@@ -27,10 +28,13 @@
 
 namespace {
 
-// Abstract socket: sun_path[0] == '\0', then these bytes. One daemon, one
-// keystore, so a single well-known name suffices.
-constexpr const char kSocketName[] = "teesim";
-constexpr size_t kSocketNameLen = sizeof(kSocketName) - 1;
+// Filesystem socket inside keystore's own 0700 data dir (keystore_data_file). An abstract name (the
+// previous design) is probeable by any app: connect() to a bound abstract name is refused by SELinux
+// with EACCES, to an unbound one with ECONNREFUSED — an existence oracle that reveals the hook. A path
+// under a directory an app cannot traverse instead yields a uniform EACCES whether or not the node
+// exists, so there is nothing for an app to detect. The daemon (root) can traverse to it; keystore is
+// the one that binds it, and this is a directory keystore owns.
+constexpr const char kSocketPath[] = "/data/misc/keystore/.teesim-ctl";
 constexpr size_t kMaxFrame = 8u * 1024 * 1024;
 
 // Decode standard base64 (padding optional; whitespace ignored). Returns false
@@ -390,15 +394,22 @@ void *ServerThread(void *) {
   }
   struct sockaddr_un addr{};
   addr.sun_family = AF_UNIX;
-  addr.sun_path[0] = '\0';  // abstract namespace
-  memcpy(addr.sun_path + 1, kSocketName, kSocketNameLen);
-  socklen_t alen = static_cast<socklen_t>(offsetof(struct sockaddr_un, sun_path) + 1 + kSocketNameLen);
+  strncpy(addr.sun_path, kSocketPath, sizeof(addr.sun_path) - 1);
+  socklen_t alen =
+      static_cast<socklen_t>(offsetof(struct sockaddr_un, sun_path) + strlen(kSocketPath) + 1);
 
-  // The previous keystore may still own the name for a moment after a restart.
+  // A stale socket node from a previous run makes bind() fail with EADDRINUSE, so remove it first each
+  // attempt. The retry loop still covers a previous keystore instance briefly holding the node after a
+  // restart.
   for (int attempt = 0; attempt < 10; ++attempt) {
-    if (bind(srv, reinterpret_cast<struct sockaddr *>(&addr), alen) == 0) break;
+    unlink(kSocketPath);
+    if (bind(srv, reinterpret_cast<struct sockaddr *>(&addr), alen) == 0) {
+      // The containing directory is already 0700 keystore-only; keep the node 0600 as well.
+      chmod(kSocketPath, 0600);
+      break;
+    }
     if (attempt == 9) {
-      LOGE("control: bind(@teesim) failed: %s", strerror(errno));
+      LOGE("control: bind(%s) failed: %s", kSocketPath, strerror(errno));
       close(srv);
       return nullptr;
     }
@@ -409,7 +420,7 @@ void *ServerThread(void *) {
     close(srv);
     return nullptr;
   }
-  LOGI("control: listening on @%s (hook=%s)", kSocketName, teesim_hook_name());
+  LOGI("control: listening on %s (hook=%s)", kSocketPath, teesim_hook_name());
 
   for (;;) {
     int fd = accept(srv, nullptr, nullptr);

--- a/common/control.h
+++ b/common/control.h
@@ -1,7 +1,7 @@
 // The daemon <-> lib control channel, and the config-staging API the routers
 // implement. The daemon resolves configuration against the live device and
-// pushes it here over an abstract unix socket; the lib is a pure engine that
-// never reads files, a clock, or package data.
+// pushes it here over a root-only filesystem unix socket; the lib is a pure
+// engine that never reads files, a clock, or package data.
 //
 // A push is applied as: teesim_cfg_begin(boot); add_profile() x N; commit(epoch).
 // commit atomically swaps the live profile set and routing tables, so the
@@ -112,8 +112,8 @@ int teesim_android_api(void);
 
 // --- control server, implemented in common/control.cpp -----------------------
 
-// Bind the abstract socket @teesim, listen, and serve config pushes on a
-// detached thread. Idempotent; safe to call once from entry().
+// Bind the control socket (its path lives in control.cpp), listen, and serve
+// config pushes on a detached thread. Idempotent; safe to call once from entry().
 void teesim_control_start(void);
 
 #ifdef __cplusplus

--- a/injector/README.md
+++ b/injector/README.md
@@ -54,7 +54,7 @@ If the fd transfer fails — a seccomp filter blocks `recvmsg`/`SCM_RIGHTS`, or 
 
 The loaded library must export `extern "C" bool entry(void*)`. `remote_find_entry` `dlsym`s it in the target, `remote_call_entry` calls it with the `dlopen` handle as its single argument and logs the return value. We never `dlclose` — the library stays resident. `get_remote_dlerror` reads the target's `dlerror()` string (via remote `dlerror` + `strlen` + `read_proc`) so failed loads report a real reason.
 
-One sharp edge: `inject` reports success once `entry` has been *called*, regardless of what `entry` returns. `remote_call_entry` always returns `true`. So if `entry()` itself fails, `inject` still exits 0, and the control daemon treats that pid as covered. "Injection succeeded" means "the library loaded and `entry` ran," not "the hooks are live" — so the daemon confirms separately by waiting for the library to check in over the `@teesim` control channel, and logs a warning if it never does.
+One sharp edge: `inject` reports success once `entry` has been *called*, regardless of what `entry` returns. `remote_call_entry` always returns `true`. So if `entry()` itself fails, `inject` still exits 0, and the control daemon treats that pid as covered. "Injection succeeded" means "the library loaded and `entry` ran," not "the hooks are live" — so the daemon confirms separately by waiting for the library to check in over the control channel, and logs a warning if it never does.
 
 ## LSPlt usage
 

--- a/injector/teesim_uds.c
+++ b/injector/teesim_uds.c
@@ -1,0 +1,214 @@
+// teesim-uds — the WebUI's transport to the control daemon's admin endpoint.
+//
+// The daemon (KeyAdmin) used to listen on a loopback TCP port (127.0.0.1:8790) that the WebUI reached
+// with a browser fetch(). Any app on the device could connect() to that port, and the mere fact that
+// something answered there fingerprinted the module. The daemon now serves on a FILESYSTEM unix-domain
+// socket under /data/adb/teesim (a 0700, root-only directory), so the kernel refuses a connect() from
+// any non-root uid before a byte is exchanged: to every other app the endpoint simply does not exist.
+//
+// A WebView cannot fetch() a unix socket, so the WebUI drives this tiny client through its root-exec
+// bridge instead. It speaks the same HTTP/1.1 the daemon already parses, so the server side keeps its
+// existing request routing — only the socket underneath changed.
+//
+//   teesim-uds SOCK METHOD PATH TOKEN [--b64] [--body-file FILE]
+//
+//     SOCK        filesystem path of the daemon's admin socket
+//     METHOD      GET | POST
+//     PATH        request target, e.g. "/status" or "/icon?pkg=com.foo&user=0"
+//     TOKEN       the admin token (sent as X-Teesim-Token; the socket perms are the real gate)
+//     --b64       base64-encode the response body on stdout (for binary payloads, e.g. icons)
+//     --body-file read the request body from FILE and send it with a Content-Length
+//
+// stdout: the response body (raw, or base64 with --b64). stderr: diagnostics only.
+// exit:   0 = HTTP 2xx, 2 = HTTP response with a non-2xx status (body still written),
+//         1 = usage / connect / I/O error (nothing written to stdout).
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+static void die(const char *msg) {
+  fprintf(stderr, "teesim-uds: %s: %s\n", msg, strerror(errno));
+  exit(1);
+}
+
+// Read a whole file into a freshly malloc'd buffer. *len gets the byte count. Caller frees.
+static char *read_file(const char *path, size_t *len) {
+  FILE *f = fopen(path, "rb");
+  if (!f) die("open body-file");
+  if (fseek(f, 0, SEEK_END) != 0) die("seek body-file");
+  long sz = ftell(f);
+  if (sz < 0) die("tell body-file");
+  rewind(f);
+  char *buf = malloc((size_t)sz + 1);
+  if (!buf) die("malloc body");
+  size_t got = fread(buf, 1, (size_t)sz, f);
+  fclose(f);
+  buf[got] = '\0';
+  *len = got;
+  return buf;
+}
+
+// Drain the socket into a growing heap buffer until EOF. *len gets the byte count.
+static char *read_all(int fd, size_t *len) {
+  size_t cap = 16 * 1024, n = 0;
+  char *buf = malloc(cap);
+  if (!buf) die("malloc response");
+  for (;;) {
+    if (n == cap) {
+      cap *= 2;
+      char *nb = realloc(buf, cap);
+      if (!nb) die("realloc response");
+      buf = nb;
+    }
+    ssize_t r = read(fd, buf + n, cap - n);
+    if (r < 0) {
+      if (errno == EINTR) continue;
+      die("read response");
+    }
+    if (r == 0) break;
+    n += (size_t)r;
+  }
+  *len = n;
+  return buf;
+}
+
+static void write_all(int fd, const char *buf, size_t len) {
+  size_t off = 0;
+  while (off < len) {
+    ssize_t w = write(fd, buf + off, len - off);
+    if (w < 0) {
+      if (errno == EINTR) continue;
+      die("write");
+    }
+    off += (size_t)w;
+  }
+}
+
+static const char B64[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+// Base64-encode src to stdout. Used for binary bodies (--b64) so the shell captures clean text.
+static void b64_stdout(const unsigned char *src, size_t len) {
+  size_t i = 0;
+  char out[4];
+  for (; i + 3 <= len; i += 3) {
+    unsigned v = (src[i] << 16) | (src[i + 1] << 8) | src[i + 2];
+    out[0] = B64[(v >> 18) & 63];
+    out[1] = B64[(v >> 12) & 63];
+    out[2] = B64[(v >> 6) & 63];
+    out[3] = B64[v & 63];
+    fwrite(out, 1, 4, stdout);
+  }
+  size_t rem = len - i;
+  if (rem == 1) {
+    unsigned v = src[i] << 16;
+    out[0] = B64[(v >> 18) & 63];
+    out[1] = B64[(v >> 12) & 63];
+    out[2] = '=';
+    out[3] = '=';
+    fwrite(out, 1, 4, stdout);
+  } else if (rem == 2) {
+    unsigned v = (src[i] << 16) | (src[i + 1] << 8);
+    out[0] = B64[(v >> 18) & 63];
+    out[1] = B64[(v >> 12) & 63];
+    out[2] = B64[(v >> 6) & 63];
+    out[3] = '=';
+    fwrite(out, 1, 4, stdout);
+  }
+}
+
+int main(int argc, char **argv) {
+  if (argc < 5) {
+    fprintf(stderr, "usage: teesim-uds SOCK METHOD PATH TOKEN [--b64] [--body-file FILE]\n");
+    return 1;
+  }
+  const char *sock = argv[1];
+  const char *method = argv[2];
+  const char *path = argv[3];
+  const char *token = argv[4];
+  int b64 = 0;
+  const char *body_file = NULL;
+  for (int i = 5; i < argc; i++) {
+    if (strcmp(argv[i], "--b64") == 0) {
+      b64 = 1;
+    } else if (strcmp(argv[i], "--body-file") == 0 && i + 1 < argc) {
+      body_file = argv[++i];
+    } else {
+      fprintf(stderr, "teesim-uds: unknown argument '%s'\n", argv[i]);
+      return 1;
+    }
+  }
+
+  char *body = NULL;
+  size_t body_len = 0;
+  if (body_file) body = read_file(body_file, &body_len);
+
+  int fd = socket(AF_UNIX, SOCK_STREAM, 0);
+  if (fd < 0) die("socket");
+  struct sockaddr_un addr;
+  memset(&addr, 0, sizeof(addr));
+  addr.sun_family = AF_UNIX;
+  if (strlen(sock) >= sizeof(addr.sun_path)) {
+    fprintf(stderr, "teesim-uds: socket path too long\n");
+    return 1;
+  }
+  strncpy(addr.sun_path, sock, sizeof(addr.sun_path) - 1);
+  if (connect(fd, (struct sockaddr *)&addr, sizeof(addr)) != 0) die("connect");
+
+  // Build and send the request head. The token gates the endpoint at the app layer; the socket's
+  // filesystem permissions gate it at the kernel layer. Connection: close so the server's read_all
+  // sees a clean EOF.
+  char head[8192];
+  int hn;
+  if (body_file) {
+    hn = snprintf(head, sizeof(head),
+                  "%s %s HTTP/1.1\r\nHost: localhost\r\nX-Teesim-Token: %s\r\n"
+                  "Content-Type: text/plain; charset=utf-8\r\nContent-Length: %zu\r\n"
+                  "Connection: close\r\n\r\n",
+                  method, path, token, body_len);
+  } else {
+    hn = snprintf(head, sizeof(head),
+                  "%s %s HTTP/1.1\r\nHost: localhost\r\nX-Teesim-Token: %s\r\nConnection: close\r\n\r\n",
+                  method, path, token);
+  }
+  if (hn < 0 || (size_t)hn >= sizeof(head)) {
+    fprintf(stderr, "teesim-uds: request head too large\n");
+    return 1;
+  }
+  write_all(fd, head, (size_t)hn);
+  if (body_len) write_all(fd, body, body_len);
+  shutdown(fd, SHUT_WR);
+  free(body);
+
+  size_t resp_len = 0;
+  char *resp = read_all(fd, &resp_len);
+  close(fd);
+
+  // Split headers from body at the blank line, and read the status code off the response line.
+  int status = 0;
+  if (resp_len >= 12 && strncmp(resp, "HTTP/1.", 7) == 0) status = atoi(resp + 9);
+  char *sep = NULL;
+  for (size_t i = 0; i + 4 <= resp_len; i++) {
+    if (resp[i] == '\r' && resp[i + 1] == '\n' && resp[i + 2] == '\r' && resp[i + 3] == '\n') {
+      sep = resp + i + 4;
+      break;
+    }
+  }
+  const char *bstart = sep ? sep : resp;
+  size_t blen = sep ? resp_len - (size_t)(sep - resp) : resp_len;
+
+  if (b64) {
+    b64_stdout((const unsigned char *)bstart, blen);
+  } else {
+    write_all(STDOUT_FILENO, bstart, blen);
+  }
+  fflush(stdout);
+  free(resp);
+
+  if (status >= 200 && status < 300) return 0;
+  return 2;
+}

--- a/keymint/README.md
+++ b/keymint/README.md
@@ -144,7 +144,7 @@ attestation, it falls back to `Simulate` (generation) so a target key is always 
 
 The same re-sign is exposed to the daemon as `teesim_cfg_resign` (see [control.h](../common/control.h)):
 after a config push commits, the daemon re-attests keys that already existed before their app was
-covered by handing each one's real leaf back over the `@teesim` channel and writing the returned,
+covered by handing each one's real leaf back over the control channel and writing the returned,
 keybox-rooted chain into the keystore. The re-sign is identical to a fresh patch — it keeps the real
 key blob and only re-roots the certificate.
 
@@ -234,7 +234,7 @@ not the forwarding guard.
   `teesim_cfg_commit`) that build a new profile set and swap it in atomically, plus
   `teesim_router_new_device`.
 - [`keymint_entry.cpp`](keymint_entry.cpp) — `entry()`, what the injector calls. It reads no
-  files: it starts the `@teesim` control server and installs the hook in a no-op state, and
+  files: it starts the control server and installs the hook in a no-op state, and
   the daemon then connects and pushes the resolved profiles (keyboxes included). Until a
   profile is pushed nothing is simulated — a keystore without configuration is a no-op,
   not a hazard.

--- a/keymint/keymint_entry.cpp
+++ b/keymint/keymint_entry.cpp
@@ -2,7 +2,7 @@
 //
 // The daemon injects this library into keystore2 and calls entry(). We install
 // the AIBinder_transact hook in an unconfigured, forward-everything state and
-// start the control server; the daemon then connects over @teesim and pushes the
+// start the control server; the daemon then connects to it and pushes the
 // resolved profile set. Nothing is read from disk here — the lib is a pure
 // engine driven entirely by control-channel pushes.
 

--- a/keystore/README.md
+++ b/keystore/README.md
@@ -37,7 +37,7 @@ callback binder passed in the request (the transaction's own reply is just a sta
 produces each result by calling that callback binder, mirroring what the real daemon would do.
 
 The profile set (which apps to simulate, which keybox signs) is pushed from the control daemon
-over the `@teesim` abstract socket; nothing here is read from disk.
+over the control socket; nothing here is read from disk.
 
 ## Files
 

--- a/keystore/keystore_entry.cpp
+++ b/keystore/keystore_entry.cpp
@@ -3,7 +3,7 @@
 // The daemon injects this into the keystore daemon and calls entry(). We install
 // the libbinder ioctl hook, register the app-facing keystore service so its
 // transactions reach our handler, and start the control server. The profile set
-// arrives from the daemon over @teesim; nothing is read from disk here.
+// arrives from the daemon over the control socket; nothing is read from disk here.
 
 #include <binder/IServiceManager.h>
 #include <binder/Parcel.h>

--- a/module/customize.sh
+++ b/module/customize.sh
@@ -36,4 +36,5 @@ set_perm_recursive "$MODPATH" 0 0 0755 0644
 set_perm "$MODPATH/daemon" 0 0 0755
 for abi in arm64-v8a x86_64; do
   [ -f "$MODPATH/$abi/inject" ] && set_perm "$MODPATH/$abi/inject" 0 0 0755
+  [ -f "$MODPATH/$abi/teesim-uds" ] && set_perm "$MODPATH/$abi/teesim-uds" 0 0 0755
 done

--- a/module/sepolicy.rule
+++ b/module/sepolicy.rule
@@ -1,15 +1,35 @@
-# The interceptor runs in the keystore domain (keystore on Android 10/11, keystore2
-# on 12+) and binds an abstract unix socket; the root control daemon connects to it
-# to push the resolved config. Grant the keystore side the socket-server permissions.
-#
-# The daemon runs in the root manager's own already-privileged domain, which carries
-# connectto, but that domain name differs per manager — so the connectto rules below
-# are best-effort and may need adjustment on a given setup (DESIGN open question Q1).
-# If the socket path proves unworkable on some manager, the daemon can fall back to a
-# file the lib watches instead.
+# The interceptor runs in the keystore domain (keystore on Android 10/11, keystore2 on 12+) and binds
+# the daemon<->hook control socket; the root control daemon connects to it to push the resolved config.
+# That socket is now a FILESYSTEM socket inside keystore's OWN 0700 data dir (keystore_data_file), not
+# an abstract name — an abstract name is probeable by any app (bound -> EACCES, unbound -> ECONNREFUSED,
+# an existence oracle for the hook), whereas a node under a 0700 dir an app cannot traverse gives a
+# uniform EACCES and is undetectable. Grant keystore the sock_file create/bind, and the root-manager
+# domain (ksu on KernelSU, su on APatch, magisk on Magisk) the connectto + dir-traversal + sock_file
+# access to reach it. Best-effort: the exact daemon domain differs per manager (and these root domains
+# are commonly permissive).
 allow keystore self unix_stream_socket { create bind listen accept getopt setopt read write shutdown }
+allow keystore keystore_data_file sock_file { create bind unlink read write open getattr setattr }
+allow ksu keystore unix_stream_socket connectto
 allow su keystore unix_stream_socket connectto
 allow magisk keystore unix_stream_socket connectto
+allow ksu keystore_data_file dir search
+allow su keystore_data_file dir search
+allow magisk keystore_data_file dir search
+allow ksu keystore_data_file sock_file { read write open getattr }
+allow su keystore_data_file sock_file { read write open getattr }
+allow magisk keystore_data_file sock_file { read write open getattr }
+
+# The control daemon serves its WebUI admin endpoint on a FILESYSTEM unix socket under /data/adb
+# (adb_data_file), which the WebUI reaches via its root shell and the teesim-uds client. The daemon and
+# that shell both run in a root-manager domain — su on KernelSU/APatch, magisk on Magisk — so grant both
+# the listening-socket, connectto, and sock_file permissions. Best-effort: the exact domain differs per
+# manager (and these root domains are commonly permissive), mirroring the control-socket note above.
+allow su self unix_stream_socket { create bind listen accept getopt setopt read write shutdown connectto }
+allow magisk self unix_stream_socket { create bind listen accept getopt setopt read write shutdown connectto }
+allow su magisk unix_stream_socket connectto
+allow magisk su unix_stream_socket connectto
+allow su adb_data_file sock_file { create unlink read write open getattr setattr }
+allow magisk adb_data_file sock_file { create unlink read write open getattr setattr }
 
 # The `inject` binary attaches to the keystore process with PTRACE_ATTACH (it runs
 # in the crash_dump domain), and keystore then dlopen()s the interceptor .so that

--- a/module/service.sh
+++ b/module/service.sh
@@ -6,8 +6,20 @@
 # script only launches the daemon and respawns it if it ever exits.
 MODDIR=${0%/*}
 
-# admin.token is the WebUI's key-management credential; keep it root-only.
+# admin.token is the WebUI's key-management credential; keep it root-only. The whole data dir holds
+# the token and the admin socket, so keep it 0700 too — the socket is then unreachable to other apps.
+chmod 0700 /data/adb/teesim 2>/dev/null
 chmod 0600 /data/adb/teesim/admin.token 2>/dev/null
+
+# Stage the WebUI's admin-socket client at a fixed, root-only path, so the WebUI can invoke it without
+# knowing the module's runtime path or the device ABI. Only the device's own ABI dir survives install,
+# so the glob matches one file; refreshed every boot so a module update always stages the current one.
+for f in "$MODDIR"/*/teesim-uds; do
+  if [ -f "$f" ]; then
+    cp "$f" /data/adb/teesim/teesim-uds && chmod 0700 /data/adb/teesim/teesim-uds
+    break
+  fi
+done
 
 while true; do
   "$MODDIR/daemon" "$MODDIR"

--- a/module/webroot/index.html
+++ b/module/webroot/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
 <!-- Offline by contract: nothing external may ever load. All CSS/JS are local 'self' files. -->
 <meta http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data: http://127.0.0.1:8790; font-src 'self'; connect-src 'self' http://127.0.0.1:8790; object-src 'none'; base-uri 'none'">
+      content="default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'; connect-src 'self'; object-src 'none'; base-uri 'none'">
 <title>TEESimulator</title>
 <link rel="stylesheet" href="css/theme.css">
 <link rel="stylesheet" href="css/app.css">

--- a/module/webroot/js/controllers/config-controller.js
+++ b/module/webroot/js/controllers/config-controller.js
@@ -11,7 +11,7 @@
 
 import { load as ioLoad, save as ioSave, listKeyboxes } from "../data/config-io.js";
 import { getStatus } from "../data/status.js";
-import { keyAdmin, API_BASE, adminToken } from "../data/keyadmin.js";
+import { keyAdmin, iconDataUrl } from "../data/keyadmin.js";
 import { validateConfig } from "../domain/validate.js";
 import { emptyProfile, emptyConfig, FIELDS, PROFILE_RE, entryToken } from "../domain/schema.js";
 import { setPath, getPath } from "../domain/path.js";
@@ -72,7 +72,6 @@ export function create(mount) {
   // so this is fetched only when one may have happened — never on the Scope page's 9s poll.
   let resolvedCache = null;
   let resolvedFetchGen = 0;  // same stale-reply guard as scopeFetchGen, on its own channel
-  let iconToken = null;      // the admin token, prefetched so /icon URLs build synchronously
   let scopePullBound = false; // pull-to-refresh listeners attached to scopeHost yet?
 
   function revalidate() {
@@ -256,17 +255,14 @@ export function create(mount) {
   }
 
   // ---- scope drill-in lifecycle (opens on top of the editor) ------------
-  // A URL for the daemon's /icon route. The admin token is prefetched into `iconToken` on open,
-  // so this builds synchronously (a browser <img> cannot set the token header, so it rides the
-  // query, exactly like the log-download route). Null until the token is in hand — the row then
-  // shows a letter-avatar instead.
+  // The icon for a scope row. There is no fetchable /icon URL any more — the daemon is reached over a
+  // root-only unix socket — so this returns a Promise of a self-contained data: URL (or null when the
+  // app has no icon), which the scope view loads lazily as rows scroll into view.
   // `userId` says which Android user to look the package up in: an app installed only in a work
   // profile has no record in user 0 for the daemon to read an icon from.
   function iconUrl(pkg, userId) {
-    if (!iconToken || !pkg) return null;
-    return API_BASE + "/icon?pkg=" + encodeURIComponent(pkg) +
-      "&user=" + encodeURIComponent(userId || 0) +
-      "&token=" + encodeURIComponent(iconToken);
+    if (!pkg) return null;
+    return iconDataUrl(pkg, userId || 0);
   }
 
   function renderScopeView() {
@@ -369,9 +365,6 @@ export function create(mount) {
     scopePullBound = false;
     scopeHost = el("div", { class: "editor-host" });
     scopeOverlay = openOverlay(scopeHost, { variant: "panel", label: "Scope", onClose: onScopeClosed });
-
-    // Prefetch the admin token so /icon URLs build synchronously as rows render.
-    adminToken().then((t) => { iconToken = t || null; if (scoping === name) renderScopeView(); }).catch(() => {});
 
     // Rescan, then fetch the live app list. Always the spinner path, cache or not: the point is that
     // what the user first sees is post-rescan.

--- a/module/webroot/js/data/keyadmin.js
+++ b/module/webroot/js/data/keyadmin.js
@@ -73,12 +73,18 @@
 // call throws (or the daemon's own { ok:false, error } is surfaced) so the UI can
 // show it rather than silently degrade.
 //
-// data/* may import bridge/shell.js — that is the only bridge dependency here, and
-// only to read the root-only token file once.
-import { readFile } from "../bridge/shell.js";
+// data/* may import bridge/shell.js — the one bridge dependency here. This seam uses it to read the
+// root-only token, and to run the teesim-uds client (staging a request body through a temp file when
+// one is needed) since the daemon is now reached over a unix socket rather than a fetchable URL.
+import { readFile, run, writeFileAtomic, deleteFile, DIR } from "../bridge/shell.js";
 
-const BASE = "http://127.0.0.1:8790";
-const TOKEN_FILE = "/data/adb/teesim/admin.token";
+// The daemon serves its admin endpoint on a root-only FILESYSTEM unix socket (see KeyAdmin.kt), not a
+// loopback TCP port — so no other app can reach or even observe it. A WebView cannot fetch() a unix
+// socket, so this seam does not fetch at all: it drives the shipped `teesim-uds` client through the
+// root-exec bridge, which connects to the socket as root and speaks the same HTTP the daemon parses.
+const SOCK = DIR + "/admin.sock";
+const HELPER = DIR + "/teesim-uds";
+const TOKEN_FILE = DIR + "/admin.token";
 
 // The admin token gates every request. It is a root-only file, so we read it once
 // through the bridge (the single path that has root) and memoize it for the life
@@ -95,58 +101,62 @@ function getToken() {
   return tokenPromise;
 }
 
-// A daemon download is reached by a browser navigation, which cannot carry the
-// X-Teesim-Token header, so the log-download route authenticates with a ?token= query
-// param. These two exports keep the base URL and token owned by this seam; callers build
-// only the path+query. Prefetch adminToken() so the token is in hand before the click.
-export const API_BASE = BASE;
-export function adminToken() {
-  return getToken();
+// GET /icon?pkg=<package>&user=<userId> -> raw PNG (the daemon renders the app icon and caches it).
+// There is no fetchable URL for an <img src> any more — the bytes come back over the root bridge — so
+// this returns a self-contained data: URL the view can drop straight into an <img>, or null when the
+// app has no icon (the helper exits non-zero on a non-2xx response). `userId` picks the Android user:
+// an app that exists only in a work profile has no record in user 0 to read an icon from.
+export async function iconDataUrl(pkg, userId) {
+  if (!pkg) return null;
+  const token = await getToken();
+  const path = "/icon?pkg=" + encodeURIComponent(pkg) + "&user=" + encodeURIComponent(userId || 0);
+  const r = await run([HELPER, SOCK, "GET", path, token, "--b64"]);
+  // errno 0 = HTTP 2xx (a PNG); anything else (no icon, transport error) -> fall back to the avatar.
+  if (r.errno !== 0 || !r.stdout) return null;
+  return "data:image/png;base64," + r.stdout.trim();
 }
 
-// GET /icon?pkg=<package>&token=<token> -> raw PNG (the daemon renders the app icon and
-// caches it). A browser <img> cannot set the X-Teesim-Token header, so — exactly like the
-// log-download route — the token rides in the query string. The URL is what an <img src> or
-// CSS background points at; this seam owns the base+token so the view never names either.
-// The Scope controller prefetches adminToken() once and then builds row URLs synchronously,
-// but this async helper is here for any caller that just wants one URL without that dance.
-export async function iconUrlAsync(pkg) {
-  const t = await getToken();
-  return BASE + "/icon?pkg=" + encodeURIComponent(pkg || "") + "&token=" + encodeURIComponent(t || "");
-}
-
-// One request helper: attach the token header, parse JSON, and convert any non-200
-// or network/parse failure into a thrown Error carrying the daemon's message when
-// there is one.
+// One request helper: run the UDS client with the token header, parse the JSON body it prints, and
+// convert a transport failure or a daemon { ok:false } into a thrown Error carrying the daemon's
+// message when there is one. The helper's exit code encodes the HTTP status class (0 = 2xx, 2 = other
+// status with the body still on stdout, 1 = connect/transport failure).
 async function request(method, path, body) {
   const token = await getToken();
   const t0 = Date.now();
   console.log("[keyAdmin] → %s %s%s", method, path, token ? "" : " (NO TOKEN)");
-  const init = { method, headers: { "X-Teesim-Token": token } };
+  // A request body can be large (e.g. a full log dump for logsWrite), so it is handed to the helper
+  // through a root-only temp file rather than the command line. The helper streams it with a
+  // Content-Length; we delete it afterwards.
+  let bodyFile = null;
+  const argv = [HELPER, SOCK, method, path, token];
   if (body != null) {
-    init.body = body;
-    init.headers["Content-Type"] = "text/plain; charset=utf-8";
+    bodyFile = DIR + "/req-" + Math.random().toString(36).slice(2) + ".tmp";
+    await writeFileAtomic(bodyFile, String(body));
+    argv.push("--body-file", bodyFile);
   }
-  let res;
   try {
-    res = await fetch(BASE + path, init);
-  } catch (e) {
-    console.error("[keyAdmin] ✗ %s %s network error in %dms:", method, path, Date.now() - t0, e);
-    throw new Error("daemon unreachable: " + (e && e.message ? e.message : String(e)));
+    const r = await run(argv);
+    if (r.errno === 1 || r.errno === -1) {
+      console.error("[keyAdmin] ✗ %s %s transport error in %dms: %o", method, path, Date.now() - t0, r.stderr);
+      throw new Error("daemon unreachable" + (r.stderr ? ": " + String(r.stderr).trim() : ""));
+    }
+    // Response body — a distinct name from the `body` REQUEST parameter above (re-declaring a parameter
+    // with `let` is a SyntaxError that would break this whole module and, with it, the entire WebUI).
+    let data = null;
+    try { data = JSON.parse(r.stdout); } catch { /* leave null on empty/invalid JSON */ }
+    const ok = data ? data.ok !== false : r.errno === 0;
+    console.log("[keyAdmin] ← %s %s errno=%o ok=%o in %dms", method, path, r.errno, ok, Date.now() - t0);
+    if (!ok) {
+      console.warn("[keyAdmin] ✗ %s %s body:", method, path, data);
+      // The daemon reports failures two ways: key ops use { ok:false, error }, while the canary
+      // endpoints use { ok:false, message }. Surface either so a failed canaryInstall keeps the
+      // daemon's human-readable reason.
+      throw new Error((data && (data.error || data.message)) || ("helper errno " + r.errno));
+    }
+    return data;
+  } finally {
+    if (bodyFile) { try { await deleteFile(bodyFile); } catch { /* best effort */ } }
   }
-  // Response body — a distinct name from the `body` REQUEST parameter above (re-declaring a parameter
-  // with `let` is a SyntaxError that would break this whole module and, with it, the entire WebUI).
-  let data = null;
-  try { data = await res.json(); } catch { /* leave null on empty/invalid JSON */ }
-  console.log("[keyAdmin] ← %s %s %d ok=%o in %dms", method, path, res.status, res.ok, Date.now() - t0);
-  if (!res.ok) {
-    console.warn("[keyAdmin] ✗ %s %s body:", method, path, data);
-    // The daemon reports failures two ways: key ops use { ok:false, error },
-    // while the canary endpoints use { ok:false, message }. Surface either so a
-    // failed canaryInstall keeps the daemon's human-readable reason.
-    throw new Error((data && (data.error || data.message)) || ("HTTP " + res.status));
-  }
-  return data;
 }
 
 // The alias travels in the query string; encode it so any character is inert.

--- a/module/webroot/js/data/keyadmin.js
+++ b/module/webroot/js/data/keyadmin.js
@@ -4,11 +4,10 @@
 // HTTP transport for, say, an exec-based one later is therefore a one-file change
 // — nothing above this file ever names a URL, a token, or a header.
 //
-// Transport: HTTP/1.1 to the daemon's loopback listener. The daemon serves CORS-
-// open on 127.0.0.1 so the WebUI (running in the manager's webview) can fetch it
-// directly. Every request carries the admin token in X-Teesim-Token; the daemon
-// rejects anything without it, which keeps the endpoint safe even though it is
-// bound to loopback.
+// Transport: HTTP/1.1 over the daemon's root-only unix socket, driven through the
+// root-exec bridge (see below) because a WebView cannot fetch() one. Every request
+// carries the admin token in X-Teesim-Token; the daemon rejects anything without it,
+// and refuses any peer that is not root.
 //
 // Public surface (stable):
 //   keyAdmin("status")               -> { ok, version, harvest{…}, lib:{ hook, api } }

--- a/module/webroot/js/ui/key-view.js
+++ b/module/webroot/js/ui/key-view.js
@@ -67,7 +67,7 @@ export function renderKeys(mount, state, handler) {
   if (unavailable) {
     mount.appendChild(el("div", { class: "card" }, [el("div", { class: "banner" }, [
       el("div", { text: "Daemon key capability unavailable." }),
-      el("div", { class: "muted small", text: "The daemon's KeyAdmin endpoint (127.0.0.1:8790) isn't reachable yet; keys can't be listed." }),
+      el("div", { class: "muted small", text: "The daemon's admin endpoint isn't reachable yet; keys can't be listed." }),
     ])]));
     return;
   }

--- a/module/webroot/js/ui/scope-view.js
+++ b/module/webroot/js/ui/scope-view.js
@@ -480,24 +480,55 @@ function scopeRow(row, ctx, actions) {
   ]);
 }
 
-// The lazy app icon: an <img loading="lazy"> pointing at the daemon's /icon route, with a
-// letter-avatar as the fallback both before a URL exists and when the image fails to decode
-// (no such icon, 404). The avatar is swapped in on error so a broken icon never shows.
+// Fetching an app icon is now a root-exec round-trip (the daemon lives behind a root-only unix
+// socket, so there is no <img src> URL). To keep the list cheap we still load lazily: each icon wrap
+// carries a loader that a shared IntersectionObserver fires once, when the row nears the viewport.
+const iconObserver =
+  typeof IntersectionObserver === "function"
+    ? new IntersectionObserver(
+        (entries, obs) => {
+          for (const e of entries) {
+            if (!e.isIntersecting) continue;
+            obs.unobserve(e.target);
+            const load = e.target._loadIcon;
+            if (load) load();
+          }
+        },
+        { rootMargin: "200px" },
+      )
+    : null;
+
+// The lazy app icon: a letter-avatar shows immediately (before, and instead of a missing/failed
+// icon); the real icon is fetched as a data: URL when the row scrolls into view and swapped in.
 function iconEl(row, primary, label, iconUrl) {
   const wrap = el("span", { class: "scope-ico", "aria-hidden": "true" });
   const avatar = () => el("span", {
     class: "scope-avatar", style: "background:" + hashColor(label + "/" + row.uid), text: avatarLetter(row.label, primary),
   });
+  wrap.appendChild(avatar());
   const pkg = (row.packages || [])[0];
+  if (!pkg) return wrap;
   // The user rides along: an app that exists only in a work profile has no record in user 0 for the
-  // daemon to read an icon out of.
-  const url = pkg ? iconUrl(pkg, row.userId || 0) : null;
-  if (!url) { wrap.appendChild(avatar()); return wrap; }
-  const img = el("img", {
-    class: "scope-ico-img", loading: "lazy", decoding: "async", alt: "", src: url,
-    onerror: () => { const a = avatar(); if (img.parentNode) img.replaceWith(a); },
-  });
-  wrap.appendChild(img);
+  // daemon to read an icon out of. iconUrl now returns a Promise of a data: URL (or null).
+  let loaded = false;
+  const load = () => {
+    if (loaded) return;
+    loaded = true;
+    Promise.resolve(iconUrl(pkg, row.userId || 0))
+      .then((url) => {
+        if (!url) return; // no icon -> keep the avatar
+        const img = el("img", {
+          class: "scope-ico-img", decoding: "async", alt: "", src: url,
+          onerror: () => { if (img.parentNode) img.replaceWith(avatar()); },
+        });
+        const cur = wrap.firstChild;
+        if (cur) cur.replaceWith(img); else wrap.appendChild(img);
+      })
+      .catch(() => { /* keep the avatar */ });
+  };
+  wrap._loadIcon = load;
+  if (iconObserver) iconObserver.observe(wrap);
+  else load(); // no observer support: load eagerly
   return wrap;
 }
 

--- a/module/webroot/js/ui/system-view.js
+++ b/module/webroot/js/ui/system-view.js
@@ -78,7 +78,7 @@ function healthCard(status) {
   if (status.reachable === false) {
     card.appendChild(el("div", { class: "banner" }, [
       el("div", { text: "Daemon status endpoint unreachable." }),
-      el("div", { class: "muted small", text: status.error || "The daemon isn't responding on 127.0.0.1:8790 yet." }),
+      el("div", { class: "muted small", text: status.error || "The daemon isn't responding yet." }),
     ]));
   }
   return card;


### PR DESCRIPTION
The daemon exposes two local control channels -- the WebUI's key-management endpoint (KeyAdmin) and the daemon<->interceptor config channel -- and both were bound on transports any uid on the device can reach. KeyAdmin listened on `127.0.0.1:8790`; a loopback TCP port has no owner, so authentication can only sit above the transport and the socket itself stays open for anyone to connect and speak to. The config channel bound the [abstract unix name](https://man7.org/linux/man-pages/man7/unix.7.html) `\0teesim`; the abstract namespace ignores filesystem permissions and is a flat global address space, so any process can address it, and even its existence leaks through `connect()` -- a bound name is refused with `EACCES`, an unbound one with `ECONNREFUSED`, which separates "present" from "absent" without any access at all.

A pathname socket instead inherits the access control of the directory that holds it. Under a directory whose search bit is denied to unprivileged uids the path cannot be traversed, so `connect()` returns `EACCES` whether or not the node exists -- nothing to enumerate, and nothing to tell apart from an empty directory.

KeyAdmin now binds `/data/adb/teesim/admin.sock` inside the module's 0700 directory. A WebView cannot open a unix socket, so the WebUI reaches it through the manager's root shell and a small HTTP-over-UDS client (`teesim-uds`, built per abi and staged at a fixed path); the request and response wire format is unchanged, only the socket underneath moved. The endpoint keeps its random admin token and now also refuses any peer whose uid is not root at `accept`.

The config channel (`common/control.cpp`) now binds `/data/misc/keystore/.teesim-ctl`. It has to live in keystore's own directory rather than the module's: the interceptor binds from inside keystore (uid 1017, which cannot traverse root's 0700 `/data/adb`), and `/data/misc/keystore` is a 0700 directory keystore owns. sepolicy grants keystore the `sock_file` create and bind and the root daemon the traversal and connect; the existing `SO_PEERCRED` root check on the server is untouched.
