### PR TITLE
Read logd in-process and recover the admin socket from a dead fd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,22 @@ target_link_options(inject PRIVATE -static-libstdc++)
 # tiny HTTP-over-UDS client. Plain C, no dependencies — it just pumps one request/response.
 add_executable(teesim-uds injector/teesim_uds.c)
 
+# --- The daemon's in-process log reader -------------------------------------
+# Loaded (System.load) into the app_process daemon by LogTail. Reads logd directly through liblog's
+# reader API instead of spawning a `logcat` child (which carried the whole device log stream through a
+# pipe and let a flood amplify — see #265): it filters in C to the lines we keep, serves them to the
+# WebUI from a bounded ring, and mirrors them to rotating files under /data/adb/teesim/log. The liblog
+# reader symbols are absent from the NDK stub, so they stay undefined here (-Wl,-z,undefs) and resolve
+# at runtime against the device's real liblog.so.
+add_library(teesim_logcat SHARED logcat/logcat.cpp)
+target_include_directories(teesim_logcat PRIVATE logcat)
+target_link_libraries(teesim_logcat PRIVATE log)
+target_link_options(teesim_logcat PRIVATE
+    -static-libstdc++
+    -Wl,-z,undefs
+    -Wl,--version-script=${CMAKE_SOURCE_DIR}/logcat/exports.map
+    -Wl,--gc-sections)
+
 # --- KeyMint AIDL, generated with the NDK backend ---------------------------
 # fromBinder's local-binder fallback (checked below) only exists in aidl from build-tools >= 35, so
 # prefer the newest installed build-tools over whatever aidl happens to be first on PATH or first in

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,9 +55,10 @@ android {
             cmake {
                 // The interceptors are 64-bit only (keystore2 is 64-bit everywhere).
                 abiFilters += listOf("arm64-v8a", "x86_64")
-                // Match package.sh: build the injector and both interceptors; the
-                // static BoringSSL `crypto` target builds transitively for keystore.
-                targets += listOf("inject", "teesim-uds", "teesim_keymint", "teesim_keystore")
+                // Match package.sh: build the injector, the UDS client, the daemon's log reader,
+                // and both interceptors; the static BoringSSL `crypto` target builds transitively
+                // for keystore.
+                targets += listOf("inject", "teesim-uds", "teesim_logcat", "teesim_keymint", "teesim_keystore")
             }
         }
     }
@@ -238,10 +239,14 @@ androidComponents {
                     }
                 }
 
-                // The stripped interceptor libraries, keeping their <abi>/ layout; the
-                // runtime stubs (libcrypto/libbinder/libutils) stay out of the zip.
+                // The stripped interceptor libraries and the daemon's log reader, keeping their
+                // <abi>/ layout; the runtime stubs (libcrypto/libbinder/libutils) stay out of the zip.
                 from(strippedLibs) {
-                    include("**/libteesim_keymint.so", "**/libteesim_keystore.so")
+                    include(
+                        "**/libteesim_keymint.so",
+                        "**/libteesim_keystore.so",
+                        "**/libteesim_logcat.so",
+                    )
                 }
 
                 // The injector executable and the WebUI's admin-socket client, one per <abi>/.

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -3,6 +3,16 @@
     public static void main(java.lang.String[]);
 }
 
+# Native (JNI) methods are resolved by their Java_<class>_<method> symbol names. The daemon
+# System.load()s libteesim_logcat.so and calls LogTail's native methods, whose exported names are
+# hard-coded in logcat/exports.map -- so R8 must not rename the declaring class or those methods, or
+# ART looks up Java_<obfuscated> and the daemon dies with UnsatisfiedLinkError on the log-reader
+# thread (the PR #266 release-only crash loop). This is the stock android rule, absent here because
+# the release build lists only this custom file (no getDefaultProguardFile).
+-keepclasseswithmembernames,includedescriptorclasses class * {
+    native <methods>;
+}
+
 # BouncyCastle providers are loaded by name/reflection; keep them intact.
 -keep class org.bouncycastle.jcajce.provider.** { *; }
 -keep class org.bouncycastle.jce.provider.** { *; }

--- a/app/src/main/java/org/matrix/teesim/App.kt
+++ b/app/src/main/java/org/matrix/teesim/App.kt
@@ -108,6 +108,9 @@ object App {
             )
         }
         SystemLogger.info("TEESimulator control daemon starting")
+        // Start the in-process log reader first, so even the boot-time bootstrap below is captured for
+        // the WebUI's Logs panel (the reader is a native thread; it does not depend on the framework).
+        startLogReader(resolveModuleDir(args))
         try {
             waitForSystemReady()
             appContext = prepareEnvironment()
@@ -425,6 +428,17 @@ object App {
                 SystemLogger.info("boot prop: forced $prop to the attested value (was '${live.ifEmpty { "unset" }}')")
             }
         }
+    }
+
+    /**
+     * Load and start [LogTail]'s native log reader from the module's per-ABI library directory. The ABI
+     * is chosen exactly as the [Injector] chooses the interceptor's — the daemon's own primary ABI, with
+     * a device-property fallback — since both artifacts ship side by side under `<abi>/`.
+     */
+    private fun startLogReader(moduleDir: File) {
+        val abi =
+            Build.SUPPORTED_ABIS?.firstOrNull() ?: DeviceProps.prop("ro.product.cpu.abi", "arm64-v8a")
+        LogTail.start(File(moduleDir, "$abi/libteesim_logcat.so"))
     }
 
     /** Where the inject binary + native libs live: args[0], else the dex dir, else default. */

--- a/app/src/main/java/org/matrix/teesim/Const.kt
+++ b/app/src/main/java/org/matrix/teesim/Const.kt
@@ -29,6 +29,10 @@ object Const {
      *  (when absent) and never rewritten, so auto-include can add only packages installed AFTER it. */
     val knownPackagesFile = File(DATA_DIR, "known_packages.json")
 
+    /** Where the in-process log reader ([LogTail]) writes its rotating log files (teesim.log + parts),
+     *  inside the root-only [DATA_DIR] so the captured stream is as private as the rest of the state. */
+    val logDir = File(DATA_DIR, "log")
+
     /** keystore's uid; the control socket only sends the keybox once the peer is it. Named after AOSP's
      *  own AID_KEYSTORE (android_filesystem_config.h) and mirrored here because the framework's
      *  Process.KEYSTORE_UID is @hide — the public SDK exposes only ROOT/SYSTEM/PHONE/SHELL and the

--- a/app/src/main/java/org/matrix/teesim/KeyAdmin.kt
+++ b/app/src/main/java/org/matrix/teesim/KeyAdmin.kt
@@ -81,6 +81,9 @@ object KeyAdmin {
     // Upper bound on a request body (bytes). The admin socket is root-only + token-authed, but a bogus
     // Content-Length should still never be trusted as an allocation size.
     private const val MAX_BODY_BYTES = 8 * 1024 * 1024
+    // Highest rotated log-part index LogTail keeps on disk (teesim.1.log .. teesim.<N>.log); mirrors
+    // kMaxParts in logcat.cpp so /logs/download reassembles the full set in chronological order.
+    private const val LOG_PART_MAX = 4
     private val b64 = Base64.getEncoder()
 
     @Volatile private var token: String = ""
@@ -125,7 +128,6 @@ object KeyAdmin {
         } catch (e: Exception) {
             SystemLogger.error("KeyAdmin: failed to write admin token", e)
         }
-        LogTail.start()
         Thread({ serve() }, "teesim-keyadmin").apply {
             isDaemon = true
             start()
@@ -154,30 +156,48 @@ object KeyAdmin {
         return diff == 0
     }
 
+    /**
+     * Bind a fresh filesystem-namespaced unix socket at [path] and wrap its fd in a LocalServerSocket
+     * (whose constructor calls listen()). A LocalServerSocket(String) would use the ABSTRACT namespace,
+     * which ignores filesystem permissions and is reachable by any app — exactly what we are avoiding —
+     * so we bind the filesystem path explicitly. Any prior binder/server is closed first, and the two
+     * @Volatile fields are refreshed so the accept loop and any GC finalizer both see the live fd.
+     * Returns the new server, or null if the bind failed. Called on first start AND on the recovery
+     * path in [serve] when the listen fd is torn out from under us (see #265).
+     */
+    private fun bindListener(path: String): LocalServerSocket? {
+        // Drop any prior listener explicitly so a rebind never leaks the old fd.
+        runCatching { listenSocket?.close() }
+        runCatching { listenBinder?.close() }
+        return try {
+            // A stale socket file (this run's dead node, or one left by a previous run) would make
+            // bind() fail with EADDRINUSE.
+            Const.adminSocketFile.delete()
+            val binder = LocalSocket(LocalSocket.SOCKET_STREAM)
+            binder.bind(LocalSocketAddress(path, LocalSocketAddress.Namespace.FILESYSTEM))
+            listenBinder = binder
+            // The 0700 data dir already blocks other uids; also mark the socket node 0600.
+            runCatching { Os.chmod(path, /* 0600 */ 384) }
+            LocalServerSocket(binder.fileDescriptor).also { listenSocket = it }
+        } catch (e: Exception) {
+            SystemLogger.error("KeyAdmin: cannot bind unix socket $path", e)
+            null
+        }
+    }
+
     private fun serve() {
         val path = Const.adminSocketFile.absolutePath
-        val server =
-            try {
-                // A stale socket file from a previous run would make bind() fail with EADDRINUSE.
-                Const.adminSocketFile.delete()
-                // Bind a filesystem-namespaced unix socket, then wrap its fd in a LocalServerSocket
-                // (whose constructor calls listen()). A LocalServerSocket(String) would use the ABSTRACT
-                // namespace, which ignores filesystem permissions and is reachable by any app — exactly
-                // what we are avoiding — so we bind the filesystem path explicitly.
-                val binder = LocalSocket(LocalSocket.SOCKET_STREAM)
-                binder.bind(LocalSocketAddress(path, LocalSocketAddress.Namespace.FILESYSTEM))
-                listenBinder = binder
-                // The 0700 data dir already blocks other uids; also mark the socket node 0600.
-                runCatching { Os.chmod(path, /* 0600 */ 384) }
-                LocalServerSocket(binder.fileDescriptor).also { listenSocket = it }
-            } catch (e: Exception) {
-                SystemLogger.error("KeyAdmin: cannot bind unix socket $path", e)
-                return
-            }
+        var server = bindListener(path) ?: return
         SystemLogger.info("KeyAdmin: listening on unix:$path")
+        // Consecutive accept() failures without an intervening success. A healthy endpoint stays at 0;
+        // a listen fd closed under us (EBADF — #265, MIUI power management reclaiming the fd on
+        // screen-off) fails instantly and forever, so we count the streak, back off so the thread never
+        // hot-spins at ~2.4 cores flooding the log, and rebind the socket to recover.
+        var consecutiveFailures = 0
         while (true) {
             try {
                 val client = server.accept()
+                consecutiveFailures = 0
                 // Defense in depth on top of the socket's filesystem permissions: only root may drive
                 // the admin endpoint. A peer that is not uid 0 is dropped without a byte of response.
                 val peerUid =
@@ -203,7 +223,31 @@ object KeyAdmin {
                     }
                 }, "teesim-keyadmin-conn").apply { isDaemon = true }.start()
             } catch (e: Exception) {
-                SystemLogger.warning("KeyAdmin: accept error", e)
+                consecutiveFailures++
+                // Log the first failure of a burst with its stack, then stay quiet: a dead fd throws
+                // thousands of times a second, and logging every one is itself the flood #265 reports.
+                if (consecutiveFailures == 1) {
+                    SystemLogger.warning("KeyAdmin: accept error; will back off and rebind", e)
+                }
+                // Back off (capped) so a persistently dead fd costs ~nothing instead of a whole core.
+                try {
+                    Thread.sleep(minOf(1000L, 50L * consecutiveFailures))
+                } catch (_: InterruptedException) {
+                    return
+                }
+                // The listen fd will not heal on its own — rebind a fresh socket so the WebUI becomes
+                // reachable again without a daemon restart (which would never come: the process stays
+                // alive under Looper.loop, so service.sh's respawn never fires).
+                if (consecutiveFailures >= 3) {
+                    val rebound = bindListener(path)
+                    if (rebound != null) {
+                        server = rebound
+                        consecutiveFailures = 0
+                        SystemLogger.info("KeyAdmin: rebound unix:$path after accept failures")
+                    } else {
+                        SystemLogger.warning("KeyAdmin: rebind failed; retrying")
+                    }
+                }
             }
         }
     }
@@ -628,19 +672,49 @@ object KeyAdmin {
     }
 
     /**
-     * Streams the same recent log buffer as [logs] but as a plain-text attachment, so a browser
-     * navigation names and saves the file from the Content-Disposition header (the WebView's
-     * download handler ignores an <a download> attribute). Honors the same optional `after`/`max`
-     * params as [logs]; with neither present it dumps the full recent buffer.
+     * Streams the daemon's persisted log as a plain-text attachment (the WebView's download handler
+     * ignores an <a download> attribute, so a Content-Disposition header names the saved file). Unlike
+     * the in-memory [logs] ring, this reads the rotating files [LogTail] writes under [Const.logDir],
+     * oldest part first, so a download taken AFTER a crash or restart still carries the history the ring
+     * has already dropped. The whole set is tail-capped so a pathological log can't blow the response
+     * up; an optional `max` (MiB, 1..64) overrides the default cap.
      */
     private fun downloadLogs(out: OutputStream, query: Map<String, String>) {
-        val after = query["after"]?.toLongOrNull() ?: 0L
-        val max = (query["max"]?.toIntOrNull() ?: 2000).coerceIn(1, 2000)
-        val (lines, _) = LogTail.snapshot(after, max)
-        // Each Line.text is already the full logcat line the Logs tab renders, so one line per
-        // entry joined by newlines reproduces exactly what the on-screen Save produced.
-        val body = lines.joinToString("\n") { it.text }
-        val payload = (if (body.isEmpty()) body else body + "\n").toByteArray(Charsets.UTF_8)
+        val capBytes = (query["max"]?.toIntOrNull() ?: 16).coerceIn(1, 64) * 1024 * 1024
+        // teesim.<N>.log (oldest) .. teesim.1.log, then teesim.log (newest) — chronological order.
+        val ordered =
+            (LOG_PART_MAX downTo 1).map { File(Const.logDir, "teesim.$it.log") } +
+                File(Const.logDir, "teesim.log")
+        val present = ordered.filter { it.isFile }
+        val total = present.sumOf { it.length() }
+        val payload =
+            try {
+                val buf =
+                    java.io.ByteArrayOutputStream(
+                        minOf(total, capBytes.toLong()).toInt().coerceAtLeast(0)
+                    )
+                // When the on-disk log exceeds the cap, keep the NEWEST bytes: skip whole older parts,
+                // then partially skip into the first part that fits.
+                var skip = (total - capBytes).coerceAtLeast(0)
+                for (f in present) {
+                    val len = f.length()
+                    if (skip >= len) {
+                        skip -= len
+                        continue
+                    }
+                    f.inputStream().use { ins ->
+                        if (skip > 0) {
+                            ins.skip(skip)
+                            skip = 0
+                        }
+                        ins.copyTo(buf)
+                    }
+                }
+                buf.toByteArray()
+            } catch (e: Exception) {
+                SystemLogger.warning("KeyAdmin: reading log files for download failed", e)
+                ByteArray(0)
+            }
         val name = safeDownloadName(query["name"])
         respondRaw(
             out,

--- a/app/src/main/java/org/matrix/teesim/LogTail.kt
+++ b/app/src/main/java/org/matrix/teesim/LogTail.kt
@@ -1,122 +1,107 @@
 package org.matrix.teesim
 
-import java.io.BufferedReader
-import java.io.InputStreamReader
+import java.io.File
 
 /**
- * Tails logcat into a bounded ring buffer so the WebUI can poll recent lines cheaply (no logcat
- * spawn per request). It keeps: every `TEESimulator` line (the daemon, the TA, and both native
- * interceptors all log under that tag), every `avc` line (SELinux denials — the usual injection
- * blocker), every `AndroidRuntime` line and every fatal-level line (Java/native crash reports, so a
- * crash that takes down the daemon or the hooked process is visible), and, once the interceptor is
- * injected, every line from the target keystore process, so the Logs panel shows what happens inside
- * the process we hook rather than only our own output. The WebUI filters this stream by tag, level,
- * and substring.
+ * The daemon's view onto the device log, for the WebUI's Logs panel. It no longer spawns a `logcat`
+ * child: an in-process native reader ([nativeRun], in libteesim_logcat.so) reads logd directly through
+ * liblog's reader API, filters in C to the lines we keep — every `TEESimulator` line (the daemon, the
+ * TA and both native interceptors log under that tag), `AndroidRuntime` and fatal-level lines
+ * (Java/native crash reports), and, once the interceptor is injected, every line from the target
+ * keystore process ([targetPid]) — and serves
+ * them two ways: a bounded ring the WebUI polls incrementally ([snapshot]), and rotating files under
+ * [Const.logDir] so a crash's context survives a restart.
  *
- * logcat cannot select by pid in its filterspec, so we capture broadly (`TEESimulator:V *:I`) and
- * keep only the matching lines here; [targetPid] is supplied by the [Injector].
+ * The old `logcat`-subprocess reader pulled the WHOLE device stream through a pipe and regex-filtered
+ * it in the JVM, so any flood (e.g. the KeyAdmin accept loop in #265) was carried at full volume into
+ * the daemon and amplified by the very reader meant to observe it. The native reader filters at the
+ * source and captures nothing under its own identity, so there is no feedback path to spin on.
  */
 object LogTail {
 
-    private const val CAP = 4000
+    // Field separator the native side packs each polled line with: "seq<SEP>level<SEP>tag<SEP>text".
+    // Neither a tag nor a log message contains U+0001, so the four-way split is unambiguous.
+    private const val SEP = '\u0001'
 
     data class Line(val seq: Long, val level: Char, val tag: String, val text: String)
 
-    /** The injected keystore/keystore2 pid, set by [Injector]; -1 when none is live. */
-    @Volatile var targetPid: Int = -1
+    @Volatile private var loaded = false
 
-    private val lock = Any()
-    private val buf = ArrayDeque<Line>(CAP)
-    private var seq = 0L
+    /** The injected keystore/keystore2 pid, set by [Injector]; -1 when none is live. Forwarded to the
+     *  native reader so its lines are kept even though they carry neither our tag nor a fatal level. */
+    @Volatile
+    var targetPid: Int = -1
+        set(value) {
+            field = value
+            if (loaded) runCatching { nativeSetTargetPid(value) }
+        }
 
-    @Volatile private var started = false
+    private external fun nativeRun(dir: String)
 
-    // threadtime: "MM-DD HH:MM:SS.mmm  PID  TID L TAG: message" — capture pid, level, tag.
-    private val HEADER =
-        Regex("^\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}\\.\\d{3}\\s+(\\d+)\\s+\\d+\\s+([VDIWEF])\\s+(.*?):\\s")
+    private external fun nativeSetTargetPid(pid: Int)
 
-    // Carried across a continuation line (no header) so a kept multi-line message — a
-    // stack trace — keeps all of its lines. Touched only from the single pump thread.
-    private var lastKept = false
-    private var lastLevel = 'I'
-    private var lastTag = ""
+    private external fun nativeMaxSeq(): Long
 
-    fun start() {
-        if (started) return
-        started = true
-        Thread({ pump() }, "teesim-logtail").apply {
+    private external fun nativePoll(after: Long, max: Int): Array<String>
+
+    /**
+     * Load libteesim_logcat.so from [nativeLib] and start the reader on its own daemon thread. Called
+     * once, from [App], with the module's per-ABI library path. If the library is missing or fails to
+     * load the Logs panel simply stays empty; the daemon is otherwise unaffected.
+     */
+    fun start(nativeLib: File) {
+        if (loaded) return
+        try {
+            System.load(nativeLib.absolutePath)
+            loaded = true
+        } catch (e: Throwable) {
+            SystemLogger.error("LogTail: cannot load ${nativeLib.absolutePath}; Logs panel disabled", e)
+            return
+        }
+        // The reader thread needs a place to write before it opens its files.
+        runCatching { Const.logDir.mkdirs() }
+        // Push the current target pid across in case the Injector set it before the library loaded.
+        runCatching { nativeSetTargetPid(targetPid) }
+        // The log reader is a debugging aid; it must NEVER take the daemon down. nativeRun can still
+        // throw at call time even after a successful load (e.g. an UnsatisfiedLinkError if a JNI name
+        // was renamed) — an uncaught throwable on this thread would kill the whole process, so it is
+        // contained here and merely disables the Logs panel.
+        Thread({
+            try {
+                nativeRun(Const.logDir.absolutePath)
+            } catch (e: Throwable) {
+                SystemLogger.error("LogTail: native log reader thread died; Logs panel disabled", e)
+            }
+        }, "teesim-logtail").apply {
             isDaemon = true
             start()
         }
+        SystemLogger.info("LogTail: native log reader started (dir=${Const.logDir.absolutePath})")
     }
 
-    private fun pump() {
-        while (true) {
-            try {
-                // TEESimulator at verbose; everything else at info+ so the target
-                // process's lines are emitted for add() to select.
-                val p =
-                    ProcessBuilder("logcat", "-v", "threadtime", "TEESimulator:V", "*:I")
-                        .redirectErrorStream(true)
-                        .start()
-                BufferedReader(InputStreamReader(p.inputStream, Charsets.UTF_8)).useLines { lines ->
-                    lines.forEach { add(it) }
-                }
-                p.waitFor()
-            } catch (e: Exception) {
-                SystemLogger.warning("LogTail: logcat pump failed; retrying", e)
-            }
-            // logcat exited (buffer reset, or it was killed) — pause briefly and reattach.
-            try {
-                Thread.sleep(1000)
-            } catch (_: InterruptedException) {
-                return
-            }
-        }
-    }
-
-    private fun add(raw: String) {
-        val m = HEADER.find(raw)
-        val keep: Boolean
-        val level: Char
-        val tag: String
-        if (m != null) {
-            val pid = m.groupValues[1].toIntOrNull() ?: -1
-            level = m.groupValues[2].firstOrNull() ?: 'I'
-            tag = m.groupValues[3].trim()
-            val pidNow = targetPid
-            // Also keep AndroidRuntime (Java crash reports) and every fatal-level line (native
-            // aborts / "FATAL EXCEPTION"), so a crash that takes down the daemon or keystore2 lands
-            // in the WebUI log without a separate logcat pull.
-            keep =
-                tag == "TEESimulator" ||
-                    tag == "avc" ||
-                    tag == "AndroidRuntime" ||
-                    level == 'F' ||
-                    (pidNow > 0 && pid == pidNow)
-            lastKept = keep
-            lastLevel = level
-            lastTag = tag
-        } else {
-            // Continuation line (stack trace, "beginning of main" separator): follow the
-            // previous entry so a kept multi-line message stays whole.
-            keep = lastKept
-            level = lastLevel
-            tag = lastTag
-        }
-        if (!keep) return
-        synchronized(lock) {
-            if (buf.size >= CAP) buf.removeFirst()
-            buf.addLast(Line(++seq, level, tag, raw))
-        }
-    }
-
-    /** Lines with seq greater than [after], up to [max], plus the cursor to poll with next. */
+    /** Lines with seq greater than [after], up to [max], plus the cursor to poll with next. Empty (and
+     *  the cursor unchanged) until the native reader is loaded. */
     fun snapshot(after: Long, max: Int): Pair<List<Line>, Long> {
-        synchronized(lock) {
-            val out = buf.asSequence().filter { it.seq > after }.take(max).toList()
-            val next = if (out.isNotEmpty()) out.last().seq else maxOf(after, seq)
-            return out to next
+        if (!loaded) return emptyList<Line>() to after
+        val packed =
+            try {
+                nativePoll(after, max)
+            } catch (e: Throwable) {
+                SystemLogger.warning("LogTail: nativePoll failed", e)
+                return emptyList<Line>() to after
+            }
+        val out = ArrayList<Line>(packed.size)
+        for (s in packed) {
+            // A four-way split keeps a multi-line message (a stack trace) whole in the last field.
+            val parts = s.split(SEP, limit = 4)
+            if (parts.size < 4) continue
+            val seq = parts[0].toLongOrNull() ?: continue
+            val level = parts[1].firstOrNull() ?: 'I'
+            out.add(Line(seq, level, parts[2], parts[3]))
         }
+        val next =
+            if (out.isNotEmpty()) out.last().seq
+            else maxOf(after, runCatching { nativeMaxSeq() }.getOrDefault(after))
+        return out to next
     }
 }

--- a/logcat/exports.map
+++ b/logcat/exports.map
@@ -1,0 +1,11 @@
+# Export only the JNI entry points; hide everything else (the bundled libc++ and the liblog
+# reader symbols we resolve at runtime).
+TEESIM_LOG {
+  global:
+    Java_org_matrix_teesim_LogTail_nativeRun;
+    Java_org_matrix_teesim_LogTail_nativeSetTargetPid;
+    Java_org_matrix_teesim_LogTail_nativePoll;
+    Java_org_matrix_teesim_LogTail_nativeMaxSeq;
+  local:
+    *;
+};

--- a/logcat/logcat.cpp
+++ b/logcat/logcat.cpp
@@ -1,0 +1,303 @@
+// In-process log reader for the control daemon.
+//
+// The daemon used to tail logs by spawning a `logcat` child and reading its stdout in Kotlin, with a
+// filterspec of `TEESimulator:V *:I`. That pulls the WHOLE device log stream through a pipe and
+// regex-filters it in the JVM, so any flood — e.g. the KeyAdmin accept loop in #265 — was carried at
+// full volume into the daemon and amplified by the reader that was meant to observe it.
+//
+// This replaces that with the platform's own log-reader API (liblog), the same one `logcat` uses,
+// running on one daemon thread: it reads logd directly, filters in C to only the lines we keep, and
+// serves them two ways — a bounded in-memory ring the WebUI polls incrementally (nativePoll), and a
+// set of rotating files on disk so a crash's context survives a restart and can be downloaded whole.
+//
+// It deliberately does NOT re-capture its own output: the reader emits nothing under the daemon's
+// "TEESimulator" tag (its own status lines go straight into the log file, never back through logd), so
+// there is no feedback path for it to spin on. The liblog reader symbols are absent from the NDK stub;
+// they are declared in logcat.h and resolved at runtime against the device's real liblog.so
+// (-Wl,-z,undefs), so nothing here is device-specific.
+
+#include "logcat.h"
+
+#include <fcntl.h>
+#include <jni.h>
+#include <limits.h>
+#include <sys/stat.h>
+#include <sys/system_properties.h>
+#include <sys/uio.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <cstdio>
+#include <cstring>
+#include <deque>
+#include <mutex>
+#include <string>
+#include <string_view>
+#include <thread>
+#include <vector>
+
+using namespace std::string_view_literals;
+using namespace std::chrono_literals;
+
+namespace {
+
+// Standard logcat priority characters, indexed by android_LogPriority.
+constexpr std::array<char, ANDROID_LOG_SILENT + 1> kLogChar = {
+    /*UNKNOWN*/ 'I', /*DEFAULT*/ 'I', /*VERBOSE*/ 'V', /*DEBUG*/ 'D', /*INFO*/ 'I',
+    /*WARN*/ 'W',    /*ERROR*/ 'E',   /*FATAL*/ 'F',    /*SILENT*/ 'I',
+};
+
+// Tags we always keep, whatever the pid: the daemon, the TA and both native interceptors all log under
+// "TEESimulator"; "AndroidRuntime" carries Java crash reports. A native abort (priority FATAL) and the
+// crash buffer are kept regardless of tag.
+constexpr auto kKeepTags = std::array{"AndroidRuntime"sv, "TEESimulator"sv};
+
+// One field separator the WebUI parse splits on. Neither a tag nor a log message contains it.
+constexpr char kSep = '\x01';
+
+// Ring capacity (lines) the WebUI polls; matches the client's own retention cap.
+constexpr size_t kRingCap = 4000;
+
+// On-disk rotation: teesim.log plus up to kMaxParts rolled parts, each capped at kMaxLogSize.
+constexpr size_t kMaxLogSize = 2 * 1024 * 1024;  // 2 MB per part
+constexpr int kMaxParts = 4;                     // teesim.log + .1..4  => ~10 MB of history
+constexpr long kLogBufferSize = 256 * 1024;      // ask logd for a larger buffer to cut dropped reads
+
+// The injected keystore/keystore2 pid (set from Kotlin by the Injector); -1 when none is live. Its
+// lines are kept so the Logs panel shows what happens inside the process we hook, not only our own.
+std::atomic<int> g_target_pid{-1};
+
+struct Entry {
+    uint64_t seq;
+    char level;
+    std::string tag;
+    std::string text;  // the full threadtime-formatted line the Logs panel renders
+};
+
+// The ring the WebUI polls. Guarded by its own mutex; the single reader thread appends, the KeyAdmin
+// handler threads read snapshots. seq is monotonic so a client cursor never needs resetting.
+std::mutex g_ring_mu;
+std::deque<Entry> g_ring;
+uint64_t g_seq = 0;
+
+void RingPush(char level, std::string_view tag, std::string_view text) {
+    std::lock_guard<std::mutex> lk(g_ring_mu);
+    if (g_ring.size() >= kRingCap) g_ring.pop_front();
+    g_ring.push_back(Entry{++g_seq, level, std::string(tag), std::string(text)});
+}
+
+class Logcat {
+public:
+    explicit Logcat(std::string dir) : dir_(std::move(dir)) {}
+    [[noreturn]] void Run();
+
+private:
+    void OpenCurrent();
+    void Rotate();
+    void WriteLine(std::string_view line);
+    void Emit(std::string_view line);  // status line straight to the file, never back through logd
+    void Process(struct log_msg* buf);
+    void OnCrash(int err);
+
+    std::string dir_;
+    int fd_ = -1;
+    size_t written_ = 0;
+    pid_t my_pid_ = getpid();
+};
+
+void Logcat::OpenCurrent() {
+    std::string path = dir_ + "/teesim.log";
+    // Append so a service.sh respawn keeps the previous run's tail; rotation still bounds the size.
+    fd_ = open(path.c_str(), O_WRONLY | O_CREAT | O_APPEND | O_CLOEXEC, 0600);
+    written_ = 0;
+    if (fd_ >= 0) {
+        struct stat st{};
+        if (fstat(fd_, &st) == 0) written_ = static_cast<size_t>(st.st_size);
+    }
+}
+
+void Logcat::Rotate() {
+    if (fd_ >= 0) {
+        close(fd_);
+        fd_ = -1;
+    }
+    char oldp[PATH_MAX], newp[PATH_MAX];
+    snprintf(oldp, sizeof(oldp), "%s/teesim.%d.log", dir_.c_str(), kMaxParts);
+    unlink(oldp);  // drop the oldest part (ok if absent)
+    for (int i = kMaxParts - 1; i >= 1; --i) {
+        snprintf(oldp, sizeof(oldp), "%s/teesim.%d.log", dir_.c_str(), i);
+        snprintf(newp, sizeof(newp), "%s/teesim.%d.log", dir_.c_str(), i + 1);
+        rename(oldp, newp);  // ok if the source is absent
+    }
+    snprintf(oldp, sizeof(oldp), "%s/teesim.log", dir_.c_str());
+    snprintf(newp, sizeof(newp), "%s/teesim.1.log", dir_.c_str());
+    rename(oldp, newp);
+    OpenCurrent();  // a fresh, empty teesim.log
+}
+
+void Logcat::WriteLine(std::string_view line) {
+    if (fd_ < 0) return;
+    bool add_nl = line.empty() || line.back() != '\n';
+    struct iovec iov[2] = {{const_cast<char*>(line.data()), line.size()},
+                           {const_cast<char*>("\n"), add_nl ? 1U : 0U}};
+    ssize_t n = writev(fd_, iov, 2);
+    if (n > 0) written_ += static_cast<size_t>(n);
+    if (written_ >= kMaxLogSize) Rotate();
+}
+
+void Logcat::Emit(std::string_view line) {
+    // The reader's own status (logd resets, rotation notes). Written to the file only — never through
+    // __android_log so the reader can never observe and re-capture itself.
+    WriteLine(line);
+}
+
+void Logcat::Process(struct log_msg* buf) {
+    AndroidLogEntry entry;
+    if (android_log_processLogBuffer(&buf->entry, &entry) < 0) return;
+
+    // tagLen counts the trailing NUL (drop it); messageLen is the exact message length (no NUL). Strip
+    // trailing newlines off the message so one liblog entry (a whole Java stack trace arrives as one)
+    // is one ring line, not many blanks.
+    std::string_view tag(entry.tag, entry.tagLen > 0 ? entry.tagLen - 1 : 0);
+    std::string_view msg(entry.message, entry.messageLen);
+    while (!msg.empty() && (msg.back() == '\n' || msg.back() == '\r')) msg.remove_suffix(1);
+
+    int tpid = g_target_pid.load(std::memory_order_relaxed);
+    bool keep = std::find(kKeepTags.begin(), kKeepTags.end(), tag) != kKeepTags.end() ||
+                entry.priority == ANDROID_LOG_FATAL || buf->id() == LOG_ID_CRASH ||
+                (tpid > 0 && entry.pid == tpid);
+    if (!keep) return;
+
+    char level = kLogChar[entry.priority <= ANDROID_LOG_SILENT ? entry.priority : ANDROID_LOG_INFO];
+
+    // threadtime layout: "MM-DD HH:MM:SS.mmm  PID  TID L TAG: message". Kept human-readable for the
+    // file and the download; the WebUI reads level/tag from the packed fields, not by re-parsing this.
+    struct tm tm_info;
+    time_t sec = entry.tv_sec;
+    localtime_r(&sec, &tm_info);
+    char head[64];
+    int hn = snprintf(head, sizeof(head), "%02d-%02d %02d:%02d:%02d.%03ld %5d %5d %c ",
+                      tm_info.tm_mon + 1, tm_info.tm_mday, tm_info.tm_hour, tm_info.tm_min,
+                      tm_info.tm_sec, entry.tv_nsec / 1000000, entry.pid, entry.tid, level);
+
+    std::string line;
+    line.reserve(hn + tag.size() + 2 + msg.size());
+    line.append(head, hn);
+    line.append(tag);
+    line.append(": ");
+    line.append(msg);
+
+    WriteLine(line);
+    RingPush(level, tag, line);
+}
+
+void Logcat::OnCrash(int err) {
+    static size_t crash_count = 0;
+    static size_t restart_wait = 8;
+    if (++crash_count >= restart_wait) {
+        Emit("\n--- logd unreadable too many times; requesting a restart ---");
+        __system_property_set("ctl.restart", "logd");
+        if (restart_wait < 1024) restart_wait <<= 1; else crash_count = 0;
+    } else {
+        std::string m = "\n--- logd read failed (";
+        m += strerror(err);
+        m += "); retrying in 1s ---";
+        Emit(m);
+    }
+    std::this_thread::sleep_for(1s);
+}
+
+void Logcat::Run() {
+    OpenCurrent();
+    unsigned int tail = 0;  // first attach: no history, just follow
+    while (true) {
+        auto* list = android_logger_list_alloc(0 /* blocking */, tail, 0);
+        if (!list) {
+            OnCrash(errno);
+            continue;
+        }
+        // On a reconnect after a logd reset, pull the last few lines back for context.
+        tail = 10;
+        for (log_id_t id : {LOG_ID_MAIN, LOG_ID_SYSTEM, LOG_ID_CRASH}) {
+            auto* logger = android_logger_open(list, id);
+            if (logger && android_logger_get_log_size(logger) < kLogBufferSize) {
+                android_logger_set_log_size(logger, kLogBufferSize);
+            }
+        }
+
+        struct log_msg msg;
+        while (android_logger_list_read(list, &msg) > 0) {
+            // Never re-read our own reader identity. (We emit nothing through logd, so this only guards
+            // against a future __android_log call from this pid slipping into the stream.)
+            if (msg.entry.pid == static_cast<uint32_t>(my_pid_)) {
+                AndroidLogEntry peek;
+                if (android_log_processLogBuffer(&msg.entry, &peek) >= 0) {
+                    std::string_view t(peek.tag, peek.tagLen > 0 ? peek.tagLen - 1 : 0);
+                    if (t == "TEESimLog"sv) continue;
+                }
+            }
+            Process(&msg);
+        }
+        android_logger_list_free(list);
+        OnCrash(errno);
+    }
+}
+
+}  // namespace
+
+extern "C" JNIEXPORT void JNICALL Java_org_matrix_teesim_LogTail_nativeRun(JNIEnv* env, jobject,
+                                                                           jstring dir) {
+    const char* d = env->GetStringUTFChars(dir, nullptr);
+    std::string dir_s = d ? d : "/data/adb/teesim/log";
+    if (d) env->ReleaseStringUTFChars(dir, d);
+    // Blocks for the life of the daemon; runs on the dedicated Kotlin thread that called it.
+    Logcat(dir_s).Run();
+}
+
+extern "C" JNIEXPORT void JNICALL Java_org_matrix_teesim_LogTail_nativeSetTargetPid(JNIEnv*, jobject,
+                                                                                    jint pid) {
+    g_target_pid.store(pid, std::memory_order_relaxed);
+}
+
+// Current maximum sequence number, so the WebUI's cursor can advance even when a poll returns nothing.
+extern "C" JNIEXPORT jlong JNICALL Java_org_matrix_teesim_LogTail_nativeMaxSeq(JNIEnv*, jobject) {
+    std::lock_guard<std::mutex> lk(g_ring_mu);
+    return static_cast<jlong>(g_seq);
+}
+
+// Ring lines with seq greater than `after`, up to `max`, each packed as
+// "seq \x01 level \x01 tag \x01 text" for the Kotlin side to split. Returns them oldest-first.
+extern "C" JNIEXPORT jobjectArray JNICALL Java_org_matrix_teesim_LogTail_nativePoll(JNIEnv* env,
+                                                                                    jobject,
+                                                                                    jlong after,
+                                                                                    jint max) {
+    std::vector<std::string> out;
+    {
+        std::lock_guard<std::mutex> lk(g_ring_mu);
+        for (const auto& e : g_ring) {
+            if (e.seq <= static_cast<uint64_t>(after)) continue;
+            std::string s;
+            s.reserve(e.tag.size() + e.text.size() + 24);
+            s += std::to_string(e.seq);
+            s += kSep;
+            s += e.level;
+            s += kSep;
+            s += e.tag;
+            s += kSep;
+            s += e.text;
+            out.push_back(std::move(s));
+            if (static_cast<jint>(out.size()) >= max) break;
+        }
+    }
+    jclass strClass = env->FindClass("java/lang/String");
+    jobjectArray arr = env->NewObjectArray(static_cast<jsize>(out.size()), strClass, nullptr);
+    for (jsize i = 0; i < static_cast<jsize>(out.size()); ++i) {
+        jstring js = env->NewStringUTF(out[i].c_str());
+        env->SetObjectArrayElement(arr, i, js);
+        env->DeleteLocalRef(js);
+    }
+    return arr;
+}

--- a/logcat/logcat.h
+++ b/logcat/logcat.h
@@ -1,0 +1,64 @@
+#pragma once
+
+// liblog's log-reader API. The NDK stub liblog.so does not export these (they are the platform
+// reader interface `logcat` itself uses), so we declare them here and leave them undefined at link
+// time (-Wl,-z,undefs); they resolve at runtime against the device's real liblog.so. This is the same
+// mechanism LSPosed's log reader uses, adapted here so the daemon reads logd DIRECTLY instead of
+// spawning a `logcat` child (see LogTail.kt / issue #265).
+
+#include <android/log.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+#define LOGGER_ENTRY_MAX_LEN (5 * 1024)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct AndroidLogEntry_t {
+    time_t tv_sec;
+    long tv_nsec;
+    android_LogPriority priority;
+    int32_t uid;
+    int32_t pid;
+    int32_t tid;
+    const char *tag;
+    size_t tagLen;
+    size_t messageLen;
+    const char *message;
+} AndroidLogEntry;
+
+struct logger_entry {
+    uint16_t len;      /* length of the payload */
+    uint16_t hdr_size; /* sizeof(struct logger_entry) */
+    int32_t pid;       /* generating process's pid */
+    uint32_t tid;      /* generating process's tid */
+    uint32_t sec;      /* seconds since Epoch */
+    uint32_t nsec;     /* nanoseconds */
+    uint32_t lid;      /* log id of the payload, bottom 4 bits currently */
+    uint32_t uid;      /* generating process's uid */
+};
+
+struct log_msg {
+    union alignas(4) {
+        unsigned char buf[LOGGER_ENTRY_MAX_LEN + 1];
+        struct logger_entry entry;
+    };
+#ifdef __cplusplus
+    log_id_t id() { return static_cast<log_id_t>(entry.lid); }
+#endif
+};
+struct logger;
+struct logger_list;
+
+long android_logger_get_log_size(struct logger *logger);
+int android_logger_set_log_size(struct logger *logger, unsigned long size);
+struct logger_list *android_logger_list_alloc(int mode, unsigned int tail, pid_t pid);
+void android_logger_list_free(struct logger_list *logger_list);
+int android_logger_list_read(struct logger_list *logger_list, struct log_msg *log_msg);
+struct logger *android_logger_open(struct logger_list *logger_list, log_id_t id);
+int android_log_processLogBuffer(struct logger_entry *buf, AndroidLogEntry *entry);
+#ifdef __cplusplus
+}
+#endif

--- a/module/sepolicy.rule
+++ b/module/sepolicy.rule
@@ -31,6 +31,15 @@ allow magisk su unix_stream_socket connectto
 allow su adb_data_file sock_file { create unlink read write open getattr setattr }
 allow magisk adb_data_file sock_file { create unlink read write open getattr setattr }
 
+# The daemon now reads logd DIRECTLY, in-process, through liblog's reader API (libteesim_logcat.so),
+# instead of spawning a `logcat` child. Reading the log stream means connecting to logd's reader
+# socket, so grant the daemon's root-manager domain (su on KernelSU/APatch, magisk on Magisk) that
+# access. Best-effort per manager, as above; these root domains are commonly permissive.
+allow su logd unix_stream_socket connectto
+allow magisk logd unix_stream_socket connectto
+allow su logdr_socket sock_file write
+allow magisk logdr_socket sock_file write
+
 # The `inject` binary attaches to the keystore process with PTRACE_ATTACH (it runs
 # in the crash_dump domain), and keystore then dlopen()s the interceptor .so that
 # lives under /data/adb (adb_data_file). Both are required for injection to work on


### PR DESCRIPTION
Two failures compounded once the KeyAdmin listen fd was closed under the daemon (#265) -- on the reporter's device, MIUI power management reclaiming it on screen-off. The accept loop caught the resulting EBADF and immediately retried on the same dead fd, with no backoff and a full stack trace each time: ~7000 throws a second, ~2.4 cores, and a logcat flood that pushed logd to drop other readers' entries. The socket node stayed on disk with no listener behind it, so the WebUI got ECONNREFUSED and never recovered -- the daemon stays alive under Looper.loop, so service.sh's respawn never fires.

serve() now binds through a bindListener() helper and, on accept failure, backs off (capped at 1s), logs only the first failure of a burst, and rebinds a fresh LocalServerSocket after three consecutive failures. A one-time external fd close now costs a short pause and a rebind instead of a permanent spin, and the WebUI comes back on its own.

The logging path made the flood worse: LogTail spawned a `logcat -v threadtime *:I` child, so logd copied every app's info-and-above line into a pipe that the JVM then regex-filtered -- the whole device stream carried at full volume and amplified by the reader meant to observe it. It is replaced by an in-process native reader (libteesim_logcat.so) built on liblog's reader API, the same one `logcat` uses. It reads logd directly, filters in C to the lines we keep (TEESimulator, AndroidRuntime, fatal-level, the crash buffer, and the injected keystore pid), and serves them two ways: a bounded ring the WebUI polls incrementally over the unchanged /logs cursor, and rotating files under /data/adb/teesim/log so a crash's context survives a restart. /logs/download now streams those files rather than the in-memory ring. The reader emits nothing through logd, so it can never observe and re-capture itself.

The liblog reader symbols are absent from the NDK stub; they are declared locally and left undefined at link (-Wl,-z,undefs), resolving at runtime against the device's real liblog. sepolicy grants the daemon's root-manager domain the logd connect and logdr_socket write it now needs directly.
